### PR TITLE
Добавить поддержку загрузки через LibreDWG нового примитива: круг

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/8
-Your prepared branch: issue-8-0baa18f6
-Your prepared working directory: /tmp/gh-issue-solver-1759291327677
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/8
+Your prepared branch: issue-8-0baa18f6
+Your prepared working directory: /tmp/gh-issue-solver-1759291327677
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
+++ b/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
@@ -28,7 +28,7 @@ uses
   uzeentgenericsubentry,{uzbtypes,}uzedrawingsimple,
   uzbstrproc,
   uzestyleslayers,
-  uzeentline,uzeentity,//uzgldrawcontext,
+  uzeentline,uzeentcircle,uzeentity,//uzgldrawcontext,
   uzeffLibreDWG,
   uzeffmanager;
 implementation
@@ -99,12 +99,25 @@ begin
   //PGDBObjEntity(pobj)^.formatEntity(drawing,dc);
 end;
 
+procedure AddCircleEntity(var ZContext:TZDrawingContext;var DWGContext:TDWGCtx;var DWGObject:Dwg_Object;PCircle:PDwg_Entity_CIRCLE);
+var
+  pobj:PGDBObjEntity;
+begin
+  pobj := AllocAndInitCircle(ZContext.PDrawing^.pObjRoot);
+  PGDBObjCircle(pobj)^.Local.p_insert.x:=PCircle^.center.x;
+  PGDBObjCircle(pobj)^.Local.p_insert.y:=PCircle^.center.y;
+  PGDBObjCircle(pobj)^.Local.p_insert.z:=PCircle^.center.z;
+  PGDBObjCircle(pobj)^.Radius:=PCircle^.radius;
+  ZContext.PDrawing^.pObjRoot^.AddMi(@pobj);
+end;
+
 initialization
   ZCDWGParser.RegisterDWGObjectLoadProc(DWG_TYPE_LAYER,@AddLayer);
   ZCDWGParser.RegisterDWGObjectLoadProc(DWG_TYPE_LTYPE,@AddLineType);
   ZCDWGParser.RegisterDWGObjectLoadProc(DWG_TYPE_BLOCK_HEADER,@AddBlockHeader);
 
   ZCDWGParser.RegisterDWGEntityLoadProc(DWG_TYPE_LINE,@AddLineEntity);
+  ZCDWGParser.RegisterDWGEntityLoadProc(DWG_TYPE_CIRCLE,@AddCircleEntity);
   ZCDWGParser.RegisterDWGEntityLoadProc(DWG_TYPE_BLOCK,@AddBlock);
 finalization
 end.


### PR DESCRIPTION
## Описание

Этот PR добавляет поддержку загрузки примитива **круг** (CIRCLE) из DWG файлов через библиотеку LibreDWG.

## Ссылка на задачу

Fixes veb86/zcadvelecAI#8

## Реализация

Механизм загрузки круга реализован в том же стиле, что и для линии:

### Изменения в файле `uzefflibredwg2ents.pas`:

1. **Добавлен импорт модуля круга**:
   - Добавлен `uzeentcircle` в секцию `uses`

2. **Реализована процедура `AddCircleEntity`**:
   ```pascal
   procedure AddCircleEntity(var ZContext:TZDrawingContext;var DWGContext:TDWGCtx;var DWGObject:Dwg_Object;PCircle:PDwg_Entity_CIRCLE);
   ```
   - Выделяет и инициализирует объект круга с помощью `AllocAndInitCircle`
   - Устанавливает координаты центра круга из `PCircle^.center.x/y/z`
   - Устанавливает радиус из `PCircle^.radius`
   - Добавляет круг в корневой объект рисунка

3. **Зарегистрирован обработчик**:
   - В секции `initialization` добавлена регистрация:
   ```pascal
   ZCDWGParser.RegisterDWGEntityLoadProc(DWG_TYPE_CIRCLE,@AddCircleEntity);
   ```

## Структура LibreDWG CIRCLE

Использована структура `Dwg_Entity_CIRCLE` из библиотеки LibreDWG:
- `center` - 3D точка центра круга (x, y, z)
- `radius` - радиус круга (double)

## Тестирование

- Код написан в соответствии с существующим стилем и паттерном загрузки LINE
- Изменения минимальны и следуют существующей архитектуре
- GitHub Actions проверят компиляцию кода

---
🤖 Generated with [Claude Code](https://claude.ai/code)