### PR TITLE
Исправить загрузку круга через LibreDWG

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/19
-Your prepared branch: issue-19-07a50860
-Your prepared working directory: /tmp/gh-issue-solver-1759299077187
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/19
+Your prepared branch: issue-19-07a50860
+Your prepared working directory: /tmp/gh-issue-solver-1759299077187
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
+++ b/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
@@ -90,10 +90,10 @@ begin
   pobj := AllocAndInitLine(ZContext.PDrawing^.pObjRoot);
   PGDBObjLine(pobj)^.CoordInOCS.lBegin.x:=PLine^.start.x;
   PGDBObjLine(pobj)^.CoordInOCS.lBegin.y:=PLine^.start.y;
-  PGDBObjLine(pobj)^.CoordInOCS.lBegin.z:=PLine^.start.x;
+  PGDBObjLine(pobj)^.CoordInOCS.lBegin.z:=PLine^.start.z;
   PGDBObjLine(pobj)^.CoordInOCS.lEnd.x:=PLine^.&end.x;
   PGDBObjLine(pobj)^.CoordInOCS.lEnd.y:=PLine^.&end.y;
-  PGDBObjLine(pobj)^.CoordInOCS.lEnd.z:=PLine^.&end.x;
+  PGDBObjLine(pobj)^.CoordInOCS.lEnd.z:=PLine^.&end.z;
   ZContext.PDrawing^.pObjRoot^.AddMi(@pobj);
   //PGDBObjEntity(pobj)^.BuildGeometry(drawing);
   //PGDBObjEntity(pobj)^.formatEntity(drawing,dc);
@@ -108,6 +108,9 @@ begin
   PGDBObjCircle(pobj)^.Local.p_insert.y:=PCircle^.center.y;
   PGDBObjCircle(pobj)^.Local.p_insert.z:=PCircle^.center.z;
   PGDBObjCircle(pobj)^.Radius:=PCircle^.radius;
+  PGDBObjCircle(pobj)^.Local.basis.oz.x:=PCircle^.extrusion.x;
+  PGDBObjCircle(pobj)^.Local.basis.oz.y:=PCircle^.extrusion.y;
+  PGDBObjCircle(pobj)^.Local.basis.oz.z:=PCircle^.extrusion.z;
   ZContext.PDrawing^.pObjRoot^.AddMi(@pobj);
 end;
 


### PR DESCRIPTION
## 🔧 Проблема

Код для загрузки примитива круг (CIRCLE) через LibreDWG был добавлен, но не работал корректно из-за отсутствия обработки вектора экструзии.

## ✅ Решение

### 1. Исправлена загрузка круга (CIRCLE)

**Проблема:** `AddCircleEntity` не учитывал поле `extrusion` из структуры DWG

**Решение:** Добавлена установка `Local.basis.oz` из `PCircle^.extrusion`:

\`\`\`pascal
PGDBObjCircle(pobj)^.Local.basis.oz.x:=PCircle^.extrusion.x;
PGDBObjCircle(pobj)^.Local.basis.oz.y:=PCircle^.extrusion.y;
PGDBObjCircle(pobj)^.Local.basis.oz.z:=PCircle^.extrusion.z;
\`\`\`

**Почему это важно:**
- Поле `extrusion` определяет нормальный вектор к плоскости примитива
- `Local.basis.oz` используется в `CalcObjMatrix` для построения полной системы координат
- Без установки `oz` функция `GetXfFromZ` не может корректно вычислить базис локальной системы координат
- Круги с ненулевой экструзией (не лежащие в плоскости XY) не отображались корректно

### 2. Исправлена загрузка линии (LINE)

**Проблема:** В `AddLineEntity` была ошибка копирования z-координат:

\`\`\`pascal
PGDBObjLine(pobj)^.CoordInOCS.lBegin.z:=PLine^.start.x;  // ❌ Неверно
PGDBObjLine(pobj)^.CoordInOCS.lEnd.z:=PLine^.&end.x;     // ❌ Неверно
\`\`\`

**Решение:** Исправлено на корректное использование z-координат:

\`\`\`pascal
PGDBObjLine(pobj)^.CoordInOCS.lBegin.z:=PLine^.start.z;  // ✅ Верно
PGDBObjLine(pobj)^.CoordInOCS.lEnd.z:=PLine^.&end.z;     // ✅ Верно
\`\`\`

## 📚 Технические детали

### Структура LibreDWG для круга

\`\`\`pascal
_dwg_entity_CIRCLE = record
  parent : P_dwg_object_entity;
  center : BITCODE_3BD;      // Центр круга
  radius : BITCODE_BD;       // Радиус
  thickness : BITCODE_BT;    // Толщина (не используется пока)
  extrusion : BITCODE_BE;    // Вектор экструзии (нормаль к плоскости)
end;
\`\`\`

### Как работает система координат

1. **Загрузка:** `Local.basis.oz` устанавливается из `extrusion`
2. **Форматирование:** При вызове `FormatEntity` → `CalcObjMatrix`
3. **Построение базиса:** `GetXfFromZ(Local.basis.oz)` вычисляет `ox` и `oy`
4. **Матрица объекта:** Создается полная матрица трансформации из базиса и позиции

### Аналогия с DXF

Это та же логика, что используется при загрузке из DXF:
- Код группы 210 в DXF соответствует `extrusion` в DWG
- `LoadFromDXFObjShared` в `GDBObjWithLocalCS` обрабатывает код 210

## 🎯 Результат

Теперь круги загружаются из DWG файлов корректно с учетом:
- ✅ Центра (center)
- ✅ Радиуса (radius)
- ✅ Вектора экструзии (extrusion/нормали к плоскости)

Дополнительно исправлена загрузка 3D координат линий.

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #19