### PR TITLE
Fix crash when selecting polylines - remove invalid pointtype assignment

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/23
+Your prepared branch: issue-23-1f69db73
+Your prepared working directory: /tmp/gh-issue-solver-1759303121406
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/23
-Your prepared branch: issue-23-1f69db73
-Your prepared working directory: /tmp/gh-issue-solver-1759303121406
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/cad_source/zengine/core/entities/uzeentpolyline.pas
+++ b/cad_source/zengine/core/entities/uzeentpolyline.pas
@@ -267,7 +267,6 @@ begin
     pv:=VertexArrayInWCS.getDataMutable(i);
     pdesc.vertexnum:=i;
     pdesc.attr:=[CPA_Strech];
-    pdesc.pointtype:=i;
     pdesc.worldcoord:=pv^;
     PSelectedObjDesc(tdesc)^.pcontrolpoint^.PushBackData(pdesc);
   end;


### PR DESCRIPTION
## 🐛 Bug Fix

This pull request fixes issue #23 - program crash when selecting polylines.

### 📋 Issue Reference
Fixes #23

### 🔍 Root Cause Analysis

PR #14 added central grip handles for GDBObjPolyline segments. However, it introduced a conflict with the parent class GDBObjCurve in the `addcontrolpoints` method.

**The Problem:**
In `uzeentpolyline.pas` line 270, the code incorrectly set:
```pascal
pdesc.pointtype:=i;  // Wrong! Sets pointtype to vertex index (0,1,2,...)
```

**Why This Caused a Crash:**
- The `pointtype` field is of type `TSnapType`, which should contain snap type constants like `os_begin`, `os_end`, `os_midle`, etc.
- Setting it to an arbitrary integer (vertex index) caused undefined behavior
- The parent class `GDBObjCurve.addcontrolpoints` does NOT set `pointtype` for vertex grips
- This conflict between parent and child implementations caused the crash when selecting polylines

### 🔧 Solution

**Changed file:** `cad_source/zengine/core/entities/uzeentpolyline.pas`

**The fix:** Removed line 270 which incorrectly assigned `pdesc.pointtype:=i;`

This makes `GDBObjPolyline` consistent with its parent class `GDBObjCurve`, which does not set `pointtype` for vertex control points. The `pointtype` field should only be set to valid `TSnapType` constants (as done for center grips on line 284: `pdesc.pointtype:=os_midle;`).

### ✅ Verification

- Analyzed parent class `GDBObjCurve.addcontrolpoints` - confirmed it does not set `pointtype` for vertices
- Analyzed similar entity `GDBObjLine.addcontrolpoints` - confirmed `pointtype` should only be set to `os_*` constants
- The fix removes the conflicting line, eliminating the undefined behavior

### 📝 Technical Details

The `addcontrolpoints` method now correctly:
1. Adds vertex grips with `vertexnum`, `attr`, and `worldcoord` (like parent GDBObjCurve)
2. Adds center segment grips with proper `pointtype:=os_midle` (from PR #14)
3. No longer conflicts with parent class implementation

---
🤖 Generated with [Claude Code](https://claude.ai/code)