### PR TITLE
Add layer support for LINE and CIRCLE primitives in LibreDWG loader

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/24
-Your prepared branch: issue-24-c49b9a8c
-Your prepared working directory: /tmp/gh-issue-solver-1759303700739
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Summary

Fixes #24 - Adds proper layer support for LINE and CIRCLE primitives when loading DWG files via LibreDWG.

## Problem

Previously, when loading DWG files through LibreDWG, LINE and CIRCLE entities were always loaded on `DefaultErrorLayer` instead of being assigned to their correct layers (e.g., layer "0" or any custom layer defined in the DWG file).

## Solution

Added layer assignment logic to both `AddLineEntity` and `AddCircleEntity` procedures in `uzefflibredwg2ents.pas`:

### Implementation Details

1. **Layer Retrieval**: Use LibreDWG's `dwg_get_entity_layer()` function to retrieve the layer object from the entity's parent structure
   ```pascal
   PDWGLayer:=dwg_get_entity_layer(PLine^.parent);
   ```

2. **Layer Name Extraction**: Extract the layer name using existing `BITCODE_T2Text()` function with proper encoding handling
   ```pascal
   BITCODE_T2Text(PDWGLayer^.name,DWGContext,layerName);
   if DWGContext.DWGVer>R_2006 then
     layerName:=Tria_Utf8ToAnsi(layerName);
   ```

3. **Layer Lookup**: Find the corresponding layer in the drawing's LayerTable
   ```pascal
   player:=ZContext.PDrawing^.LayerTable.getAddres(layerName);
   ```

4. **Layer Assignment**: Assign the found layer to the entity, with fallback to system layer if not found
   ```pascal
   if player<>nil then
     PGDBObjEntity(pobj)^.vp.Layer:=player
   else
     PGDBObjEntity(pobj)^.vp.Layer:=ZContext.PDrawing^.LayerTable.GetSystemLayer;
   ```

### Technical Background

- Both `Dwg_Entity_LINE` and `Dwg_Entity_CIRCLE` structures contain a `parent` field pointing to `Dwg_Object_Entity`
- The `Dwg_Object_Entity` structure contains layer handle information
- LibreDWG provides `dwg_get_entity_layer()` to resolve the layer from the entity hierarchy
- The implementation follows the same pattern used in `AddLayer` procedure for consistency

## Changes Made

**File Modified**: `cad_source/zengine/fileformats/uzefflibredwg2ents.pas`
- Updated `AddLineEntity` procedure (lines 86-117)
- Updated `AddCircleEntity` procedure (lines 119-148)
- Added necessary local variables for layer processing
- Added +34 lines of layer assignment logic

## Testing Notes

To verify the fix:
1. Load a DWG file containing LINE and CIRCLE entities on different layers
2. Verify that entities are loaded on their correct layers (not DefaultErrorLayer)
3. Check layer "0" specifically as mentioned in the issue

## References

- Issue: #24
- LibreDWG API: `dwg_get_entity_layer()` function
- Related code patterns: `AddLayer` procedure in the same file

🤖 Generated with [Claude Code](https://claude.ai/code)