### PR TITLE
Fix arc rotation and mirroring by using canonical local basis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/38
-Your prepared branch: issue-38-c2994705
-Your prepared working directory: /tmp/gh-issue-solver-1759357070650
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/38
+Your prepared branch: issue-38-c2994705
+Your prepared working directory: /tmp/gh-issue-solver-1759357070650
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/cad_source/zengine/core/entities/uzeentarc.pas
+++ b/cad_source/zengine/core/entities/uzeentarc.pas
@@ -166,9 +166,9 @@ begin
   sav:=VertexSub(sav,pins);
   eav:=VertexSub(eav,pins);
 
-  m:=objMatrix;
+  // Use canonical local basis for angle calculation
+  m:=CreateMatrixFromBasis(Local.basis.ox,Local.basis.oy,Local.basis.oz);
   MatrixInvert(m);
-  m.mtr[3]:=NulVector4D;
 
   local_sav:=VectorTransform3D(sav,m);
   local_eav:=VectorTransform3D(eav,m);
@@ -191,6 +191,11 @@ begin
 
   ox:=GetXfFromZ(Local.basis.oz);
   oy:=NormalizeVertex(VectorDot(Local.basis.oz,Local.basis.ox));
+
+  // Update Local.basis with canonical values
+  Local.basis.ox:=ox;
+  Local.basis.oy:=oy;
+
   m:=CreateMatrixFromBasis(ox,oy,Local.basis.oz);
 
   Local.P_insert:=VectorTransform3D(PGDBVertex(@objmatrix.mtr[3])^,m);


### PR DESCRIPTION
## 🎯 Issue
Fixes #38 - Arc rotation and mirroring were not working correctly

## 🔍 Root Cause Analysis

The problem was in how the arc's local coordinate system basis vectors were handled during transformation:

1. **In `GDBObjARC.ReCalcFromObjMatrix`**: 
   - Canonical basis vectors `ox` and `oy` were calculated from the Z-axis
   - These canonical values were **not** stored back into `Local.basis.ox` and `Local.basis.oy`
   - This created a mismatch between the intended canonical orientation and the actual stored basis

2. **In `GDBObjARC.transform`**:
   - Used the scaled `objMatrix` (which includes radius scaling) for angle recalculation
   - Should have used only the rotation component (local basis) without scaling

## 🛠️ Solution

### Change 1: Update `GDBObjARC.ReCalcFromObjMatrix` 
Store the canonical basis vectors in `Local.basis`:
```pascal
ox:=GetXfFromZ(Local.basis.oz);
oy:=NormalizeVertex(VectorDot(Local.basis.oz,Local.basis.ox));

// Update Local.basis with canonical values  
Local.basis.ox:=ox;
Local.basis.oy:=oy;
```

### Change 2: Use canonical basis in `GDBObjARC.transform`
Replace the scaled objMatrix with the canonical local basis matrix:
```pascal
// Use canonical local basis for angle calculation
m:=CreateMatrixFromBasis(Local.basis.ox,Local.basis.oy,Local.basis.oz);
MatrixInvert(m);
```

## ✅ Expected Results

With these changes, arc transformations should work correctly:

### Test Case 1: Rotation around origin by 25°
- **Initial**: center=(2,5,0), R=10, angles=8°→94°
- **Expected**: center=(-0.3005,5.3768,0), R=10, angles=33°→119°

### Test Case 2: Rotation around point (1,1,1) by 25°
- **Initial**: center=(2,5,0), R=10, angles=8°→94°  
- **Expected**: center=(-0.2158,5.0478,0), R=10, angles=33°→119°

### Test Case 3: Mirror across YZ plane
- **Initial**: center=(5,5,0), R=10, angles=30°→120°
- **Expected**: center=(-5,5,0), R=10, angles swapped and corrected for mirroring

## 📝 Technical Details

The fix ensures that:
- Arc angles are always measured relative to the **world X-axis** (canonical orientation)
- After transformation, the local basis is reset to canonical form based on the Z-axis
- The angle calculation uses the pure rotation matrix without radius scaling

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)