### PR TITLE
Fix type incompatibility in vstDevNewText event handler

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/43
-Your prepared branch: issue-43-f79ca6fc
-Your prepared working directory: /tmp/gh-issue-solver-1759385384525
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/43
+Your prepared branch: issue-43-f79ca6fc
+Your prepared working directory: /tmp/gh-issue-solver-1759385384525
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas
+++ b/cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas
@@ -56,7 +56,7 @@ type
     procedure vstDevEditing(Sender: TBaseVirtualTree; Node: PVirtualNode;
       Column: TColumnIndex; var Allowed: Boolean);
     procedure vstDevNewText(Sender: TBaseVirtualTree; Node: PVirtualNode;
-      Column: TColumnIndex; NewText: String);
+      Column: TColumnIndex; const NewText: AnsiString);
   private
     //для работы разделителя
     FProportion: Double; // Пропорция ширины PanelSynchDraw / (ClientWidth - Splitter)
@@ -745,7 +745,7 @@ begin
 end;
 
 procedure TDispatcherConnectionFrame.vstDevNewText(Sender: TBaseVirtualTree;
-  Node: PVirtualNode; Column: TColumnIndex; NewText: String);
+  Node: PVirtualNode; Column: TColumnIndex; const NewText: AnsiString);
 var
   NodeData: PGridNodeData;
   UpdateQuery: TSQLQuery;


### PR DESCRIPTION
## Summary
Fixed compilation error in DispatcherConnectionManager caused by incompatible type signature in the `vstDevNewText` event handler.

## Changes
- Updated `vstDevNewText` method signature to use `const AnsiString` instead of `String` for the `NewText` parameter
- Modified both the declaration (line 59) and implementation (line 748) in `dispatcherconnectionmanager.pas`

## Technical Details
The error was:
```
dispatcherconnectionmanager.pas(491,23) Error: Incompatible types: got "procedure variable type of procedure(TBaseVirtualTree;PVirtualNode;TColumnIndex;AnsiString) of object;Register" expected "procedure variable type of procedure(TBaseVirtualTree;PVirtualNode;TColumnIndex;const AnsiString) of object;Register"
```

The VirtualTreeView's `OnNewText` event requires the text parameter to be declared as `const AnsiString`, but the handler was using `String` without the `const` modifier.

## Files Changed
- `cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas`

Fixes #43

🤖 Generated with [Claude Code](https://claude.ai/code)