### PR TITLE
Fix editing in DispatcherConnectionManager vstDev columns (devname, hdname, hdgroup)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/45
+Your prepared branch: issue-45-1f00babc
+Your prepared working directory: /tmp/gh-issue-solver-1759386189003
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/45
-Your prepared branch: issue-45-1f00babc
-Your prepared working directory: /tmp/gh-issue-solver-1759386189003
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas
+++ b/cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas
@@ -598,7 +598,7 @@ begin
       vstDev.TreeOptions.SelectionOptions :=
         vstDev.TreeOptions.SelectionOptions + [toFullRowSelect];
       vstDev.TreeOptions.MiscOptions :=
-        vstDev.TreeOptions.MiscOptions + [toEditable];
+        vstDev.TreeOptions.MiscOptions + [toEditable, toEditOnDblClick];
       vstDev.Header.Options :=
         vstDev.Header.Options + [hoVisible, hoColumnResize] - [hoAutoResize];
       vstDev.Header.AutoSizeIndex := -1;


### PR DESCRIPTION
## Summary
Fixed the editing functionality in DispatcherConnectionManager's vstDev component for columns devname, hdname, and hdgroup by adding the missing `toEditOnDblClick` option.

Fixes #45

## Root Cause
While the previous implementation (PR #42 and #44) correctly set up:
- ✅ `toEditable` option to allow editing in principle
- ✅ `OnEditing` event handler to control which columns can be edited
- ✅ `OnNewText` event handler to save changes to the database

It was **missing the trigger option** that actually allows users to enter edit mode. Without `toEditOnDblClick` or `toEditOnClick`, the VirtualStringTree component would not respond to user interactions to start editing, even though editing was technically enabled.

## Changes Made
Added `toEditOnDblClick` to `vstDev.TreeOptions.MiscOptions` in the `InitializeVstDev` procedure:

```pascal
vstDev.TreeOptions.MiscOptions :=
  vstDev.TreeOptions.MiscOptions + [toEditable, toEditOnDblClick];
```

## How It Works Now
Users can now edit cells in columns 1, 2, and 3 (devname, hdname, hdgroup) by:
1. **Double-clicking** on the desired cell
2. Typing the new value
3. Pressing **Enter** or clicking elsewhere to save

The changes are automatically saved to the SQLite database with proper transaction handling and error recovery.

## Technical Details
In Lazarus VirtualStringTree (laz.VirtualTrees), the editing system requires:
- `toEditable` - enables editing capability
- `toEditOnDblClick` or `toEditOnClick` - specifies **when** editing should be triggered
- `OnEditing` event - controls **which** cells can be edited
- `OnNewText` event - handles **saving** the new values

The previous implementation had 3 out of 4 required components, which is why editing appeared to be "not working."

## Files Modified
- `cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas` (1 line changed)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>