### PR TITLE
Fix DispatcherConnectionManager column editing by adding coEditable option

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/45
-Your prepared branch: issue-45-01e0bec8
-Your prepared working directory: /tmp/gh-issue-solver-1759389775379
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/45
+Your prepared branch: issue-45-01e0bec8
+Your prepared working directory: /tmp/gh-issue-solver-1759389775379
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas
+++ b/cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas
@@ -615,18 +615,21 @@ begin
       begin
         Text := 'devname';
         Width := 100;
+        Options := Options + [coAllowFocus, coEditable];
       end;
 
       with vstDev.Header.Columns.Add do
       begin
         Text := 'hdname';
         Width := 100;
+        Options := Options + [coAllowFocus, coEditable];
       end;
 
       with vstDev.Header.Columns.Add do
       begin
         Text := 'hdgroup';
         Width := 100;
+        Options := Options + [coAllowFocus, coEditable];
       end;
 
       // Кнопка "Ред."


### PR DESCRIPTION
## Summary
Fixed editing functionality in DispatcherConnectionManager's vstDev component for columns devname, hdname, and hdgroup by adding the missing column-level `coEditable` and `coAllowFocus` options.

Fixes #45

## Root Cause Analysis

Previous attempts (PR #42, #44, #46) correctly implemented:
- ✅ Tree-wide `toEditable` option
- ✅ Tree-wide `toEditOnDblClick` option
- ✅ `OnEditing` event handler to control which columns can be edited
- ✅ `OnNewText` event handler to save changes to the database

However, they all missed a **critical requirement in Lazarus VirtualStringTree**:

**Individual columns must have the `coEditable` option set in their column Options property for editing to actually work.**

Without these column-specific options, the VirtualStringTree's `CanEdit()` function returns `false`, preventing users from entering edit mode even when double-clicking on cells, despite all tree-wide settings and event handlers being correctly configured.

## Changes Made

Added column-specific options to the three editable columns in `InitializeVstDev` procedure:

```pascal
// Column 1: devname
with vstDev.Header.Columns.Add do
begin
  Text := 'devname';
  Width := 100;
  Options := Options + [coAllowFocus, coEditable];  // ← Added
end;

// Column 2: hdname  
with vstDev.Header.Columns.Add do
begin
  Text := 'hdname';
  Width := 100;
  Options := Options + [coAllowFocus, coEditable];  // ← Added
end;

// Column 3: hdgroup
with vstDev.Header.Columns.Add do
begin
  Text := 'hdgroup';
  Width := 100;
  Options := Options + [coAllowFocus, coEditable];  // ← Added
end;
```

## How Column Editing Works Now

The complete editing system requires **both tree-level and column-level settings**:

### Tree-Level Settings (already implemented in PR #42, #46):
- `toEditable` - enables editing capability for the tree
- `toEditOnDblClick` - specifies that double-click triggers edit mode

### Column-Level Settings (added in this PR):
- `coAllowFocus` - allows the column to receive focus
- `coEditable` - enables editing for this specific column

### Event Handlers (already implemented in PR #42, #44):
- `OnEditing` - controls which cells can be edited (returns `Allowed := (Column >= 1) and (Column <= 3)`)
- `OnNewText` - handles saving the edited value to both NodeData and SQLite database

## User Experience

Users can now edit cells in columns devname, hdname, and hdgroup by:
1. **Double-clicking** on the desired cell
2. Typing the new value
3. Pressing **Enter** or clicking elsewhere to save

Changes are automatically persisted to the SQLite database with proper transaction handling and error recovery.

## Technical Details

In Lazarus VirtualStringTree (laz.VirtualTrees), the column editing system requires a multi-layered configuration:

1. **Tree Options** - Enable editing at tree level (`toEditable`, `toEditOnDblClick`)
2. **Column Options** - Enable editing at column level (`coEditable`, `coAllowFocus`)
3. **OnEditing Event** - Runtime control of which specific cells can be edited
4. **OnNewText Event** - Handler for saving edited values

All four layers must be properly configured for editing to work. Previous PRs configured layers 1, 3, and 4, but missed layer 2 (column options), which is why editing still didn't work after those fixes.

## Files Modified
- `cad_source/zcad/velec/connectmanager/dispatcherconnectionmanager.pas` (+3 lines)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>