### PR TITLE
Fix libredwg 3D and LW polyline loading errors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/37
-Your prepared branch: issue-37-2b7bfaf8
-Your prepared working directory: /tmp/gh-issue-solver-1759393521115
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Summary
Fixed compilation errors in libredwg polyline loading functionality that prevented 3D polylines and LW polylines from being properly loaded.

### Changes Made:
1. **Fixed method calls**: Changed `PushBack()` to `PushBackData()` for vertex arrays
   - `PGDBObjPolyline(pobj)^.VertexArrayInOCS.PushBackData(v)` (line 169)
   - `PGDBObjLWPolyline(pobj)^.Vertex2D_in_OCS_Array.PushBackData(v2d)` (line 193)

2. **Fixed constant name**: Changed `DWG_TYPE_LWPOLYLINE` to `DWG_TYPE_LWPLINE` (line 210)
   - This matches the actual constant definition in uzeffdwg.pas

### Errors Fixed:
- ❌ `uzefflibredwg2ents.pas(169,51) Error: Identifier idents no member "PushBack"`
- ❌ `uzefflibredwg2ents.pas(193,51) Error: Identifier idents no member "PushBack"`  
- ❌ `uzefflibredwg2ents.pas(210,41) Error: Identifier not found "DWG_TYPE_LWPOLYLINE"`

### Technical Details:
The `GZVector` container uses `PushBackData()` method to add elements, not `PushBack()`. The correct DWG type constant for lightweight polylines is `DWG_TYPE_LWPLINE` as defined in the dwg types enumeration.

## Test Plan
- [x] Code analysis completed
- [x] Changes follow existing codebase patterns
- [ ] Build verification (requires full build environment)

Fixes #37

🤖 Generated with [Claude Code](https://claude.ai/code)