### PR TITLE
Fix missing DWG_TYPE constants by importing uzeffdwg unit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/37
+Your prepared branch: issue-37-566f155d
+Your prepared working directory: /tmp/gh-issue-solver-1759395727533
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/37
-Your prepared branch: issue-37-566f155d
-Your prepared working directory: /tmp/gh-issue-solver-1759395727533
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
+++ b/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
@@ -30,7 +30,7 @@ uses
   uzestyleslayers,
   uzeentline,uzeentcircle,uzeentpolyline,uzeentlwpolyline,uzegeometry,uzeentity,uzegeometrytypes,//uzgldrawcontext,
   uzeffLibreDWG,
-  uzeffmanager;
+  uzeffmanager,uzeffdwg;
 implementation
 //type
   //PDwg_Entity_LINE=^Dwg_Entity_LINE;


### PR DESCRIPTION
## ✅ Fixed: Missing DWG_TYPE_LWPLINE Identifier

This PR fixes the compilation error in `uzefflibredwg2ents.pas`:
```
uzefflibredwg2ents.pas(210,41) Error: Identifier not found "DWG_TYPE_LWPLINE"
```

### 📋 Issue Reference
Fixes veb86/zcadvelecAI#37

### 🔍 Root Cause
The `DWG_TYPE_*` constants (including `DWG_TYPE_LWPLINE`, `DWG_TYPE_LINE`, `DWG_TYPE_CIRCLE`, `DWG_TYPE_POLYLINE_3D`, etc.) are defined in the `uzeffdwg` unit as part of the `DWG_OBJECT_TYPE` enumeration.

However, `uzefflibredwg2ents.pas` was not importing the `uzeffdwg` unit, making these constants unavailable during compilation.

### 🔧 Solution
Added `uzeffdwg` to the uses clause in `uzefflibredwg2ents.pas`:

```pascal
uses
  uzbLogIntf,
  SysUtils,
  dwg,dwgproc,
  uzeentgenericsubentry,{uzbtypes,}uzedrawingsimple,
  uzbstrproc,
  uzestyleslayers,
  uzeentline,uzeentcircle,uzeentpolyline,uzeentlwpolyline,uzegeometry,uzeentity,uzegeometrytypes,
  uzeffLibreDWG,
  uzeffmanager,uzeffdwg;  // ← Added uzeffdwg
```

### ✨ Changes Made
**File:** `cad_source/zengine/fileformats/uzefflibredwg2ents.pas`
- **Line 33:** Added `uzeffdwg` to the uses clause

### 🧪 Testing
- No circular dependency issues (verified that `uzeffdwg.pas` does not import `uzefflibredwg2ents.pas`)
- All DWG_TYPE constants used in the initialization section are now accessible:
  - `DWG_TYPE_LAYER`
  - `DWG_TYPE_LTYPE`
  - `DWG_TYPE_BLOCK_HEADER`
  - `DWG_TYPE_LINE`
  - `DWG_TYPE_CIRCLE`
  - `DWG_TYPE_POLYLINE_3D`
  - `DWG_TYPE_LWPLINE` ✅
  - `DWG_TYPE_BLOCK`

### 📝 Background
Previous PR #49 fixed the `PushBack` → `PushBackData` method calls and vertex access patterns for 3D and LW polylines. This PR completes the fix by resolving the missing constant import that was preventing compilation.

---

🤖 Generated with [Claude Code](https://claude.ai/code)