### PR TITLE
Fix DWG version detection by updating DWG_VERSION_TYPE enum

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/78
+Your prepared branch: issue-78-47299dc6
+Your prepared working directory: /tmp/gh-issue-solver-1759674103516
+Your forked repository: konard/zcadvelecAI
+Original repository (upstream): veb86/zcadvelecAI
+
+Proceed.

--- a/cad_source/components/fpdwg/dwg.pp
+++ b/cad_source/components/fpdwg/dwg.pp
@@ -1230,11 +1230,9 @@ in declaration at line 16 *)
         R_2_6,R_9,R_9c1,R_10,R_11b1,R_11b2,R_11,
         R_12,R_13b1,R_13b2,R_13,R_13c3,R_14,
         R_2000b,R_2000,R_2000i,R_2002,R_2004a,
-        R_2004b,R_2004c,R_2004,R_2005,R_2006,R_2007b,
-        R_2007,R_2008,R_2009,R_2010b,R_2010,R_2011,
-        R_2012,R_2013b,R_2013,R_2014,R_2015,R_2016,
-        R_2017,R_2018b,R_2018,R_2019,R_2020,R_2021,
-        R_2022,R_AFTER);
+        R_2004b,R_2004c,R_2004,R_2007a,R_2007b,
+        R_2007,R_2010b,R_2010,R_2013b,R_2013,
+        R_2018b,R_2018,R_2022b,R_AFTER);
 (* Const before type ignored *)
 (* Const before declarator ignored *)
 (* Const before type ignored *)


### PR DESCRIPTION
## Summary

This PR fixes the incorrect DWG version detection issue where libredwg was reporting R_2006 instead of R_2007b when opening DWG files.

## Root Cause

The DWG_VERSION_TYPE enum in `cad_source/components/fpdwg/dwg.pp` did not match the enum in `cad_source/components/fpdwg/libredwg/dwg.h`. The Pascal translation had extra version entries (R_2005, R_2006, R_2008, etc.) that were commented out in the C header, causing a mismatch in enum ordinal values.

## Changes

- Updated DWG_VERSION_TYPE enum in `dwg.pp` to exactly match `dwg.h`
- Removed extra versions: R_2005, R_2006, R_2008, R_2009, R_2011, R_2012, R_2014-R_2017, R_2019-R_2021
- Added missing R_2007a
- Replaced R_2022 with R_2022b

## Testing

The fix ensures that Ord(R_2007b) in Pascal now matches the value used by the libredwg C library, so version detection will correctly report R_2007b instead of R_2006.

Fixes #78