### PR TITLE
Fix syntax error in dwg.pp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/88
-Your prepared branch: issue-88-b99d93aa
-Your prepared working directory: /tmp/gh-issue-solver-1759732415649
+Issue to solve: https://github.com/veb86/zcadvelecAI/issues/90
+Your prepared branch: issue-90-a66f463f
+Your prepared working directory: /tmp/gh-issue-solver-1759734592847
 Your forked repository: konard/zcadvelecAI
 Original repository (upstream): veb86/zcadvelecAI
 

--- a/cad_source/components/fpdwg/dwg.pp
+++ b/cad_source/components/fpdwg/dwg.pp
@@ -9871,10 +9871,11 @@ in declaration at line 7399 *)
           name : Pchar;
           dxfname : Pchar;
           supertype : DWG_OBJECT_SUPERTYPE;
-           tio : record
-               entity : PDwg_Object_Entity;
-               &object : PDwg_Object_Object absolute entity;
-             end;
+            tio : record
+              case integer of
+                0: (entity : PDwg_Object_Entity);
+                1: (&object : PDwg_Object_Object);
+              end;
           handle : Dwg_Handle;
           parent : P_dwg_struct;
           klass : PDwg_Class;


### PR DESCRIPTION
## Summary

Fix syntax error in dwg.pp at line 9876. The issue was caused by H2Pas generating invalid Pascal syntax for a C union. Replaced the incorrect 'absolute' usage in a record field with a proper variant record to correctly represent the union of entity and object pointers.

### Changes
- Modified the `tio` record in `_dwg_object` to use a variant record instead of invalid 'absolute' syntax.
- This allows the `entity` and `&object` fields to share memory as intended in the original C union.

### Testing
- The change uses standard Free Pascal variant record syntax.
- No functional changes, only syntax correction to allow compilation.