### PR TITLE
Удалить функции GetDeviceVariable* из TDeviceDataCollector

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/112
-Your prepared branch: issue-112-ea290c46
-Your prepared working directory: /tmp/gh-issue-solver-1759989712720
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Summary
Removed duplicate functions from TDeviceDataCollector class in uzvmcdrawing.pas:
- GetDeviceVariableString
- GetDeviceVariableBoolean  
- GetDeviceVariableInteger
- GetDeviceVariableDouble

## Problem
These functions duplicated functionality already available in ZCAD through direct use of `FindVariableInEnt` and type casting. The standard ZCAD pattern used throughout the codebase (uzvelcreatetempdb.pas, uzvmanagerconnect.pas, and other velec modules) is:

```pascal
pvd := FindVariableInEnt(device, 'varname');
if pvd <> nil then
  value := ptype(pvd^.data.Addr.Instance)^;
```

## Changes
- Replaced all usages of GetDeviceVariable* functions with the standard ZCAD pattern
- Removed the four duplicate functions from the class
- Updated CollectAllDevices and GetDeviceByName methods to use direct variable access

## Impact
- **Reduced code duplication** - No longer maintaining wrapper functions for standard ZCAD functionality
- **Improved consistency** - Code now follows the same pattern as the rest of the codebase
- **No functionality change** - All operations remain functionally identical

## Testing
The code changes will be validated by AppVeyor CI build to ensure compilation succeeds.

Fixes veb86/zcadvelecAI#112

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)