### PR TITLE
Команда Stretch: исправление ошибок компиляции для поддержки предварительного выбора

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-10-cf8182c3
-Your prepared working directory: /tmp/gh-issue-solver-1760510936541
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.

--- a/cad_source/zcad/commands/uzccommand_stretch.pas
+++ b/cad_source/zcad/commands/uzccommand_stretch.pas
@@ -37,7 +37,8 @@ uses
   uzegeometrytypes,
   uzegeometry,
   uzccommand_selectframe,uzccommand_ondrawinged,
-  UGDBSelectedObjArray;
+  UGDBSelectedObjArray,
+  UGDBControlPointArray;
 
 implementation
 
@@ -52,6 +53,14 @@ type
 
 var
   StretchComMode:TStretchComMode;
+
+// Создание вершины 2D с целочисленными координатами
+// Creating a 2D vertex with integer coordinates
+function CreateVertex2DI(x, y: Integer): GDBvertex2DI;
+begin
+  Result.x := x;
+  Result.y := y;
+end;
 
 // Проверка наличия выбранных контрольных точек в массиве выделенных объектов
 // Checking for the presence of selected control points in the selected objects array


### PR DESCRIPTION
## 📋 Описание

Этот PR исправляет ошибки компиляции в команде Stretch, которые возникли при реализации функции предварительного выбора объектов.

## 🎯 Решаемая проблема

Fixes #10

После предыдущих попыток реализации функции предварительного выбора для команды Stretch возникли следующие ошибки компиляции:
- `uzccommand_stretch.pas(98,55) Error: Identifier not found "GDBControlPointArray"`
- `uzccommand_stretch.pas(140,7) Error: Identifier not found "CreateVertex2DI"`
- `uzccommand_stretch.pas(141,7) Error: Identifier not found "CreateVertex2DI"`

## 🔧 Внесённые изменения

### 1. Добавлен недостающий модуль в секцию uses
```pascal
uses
  // ... другие модули ...
  UGDBSelectedObjArray,
  UGDBControlPointArray;  // Добавлен для использования типа GDBControlPointArray
```

### 2. Реализована функция CreateVertex2DI
```pascal
// Создание вершины 2D с целочисленными координатами
// Creating a 2D vertex with integer coordinates
function CreateVertex2DI(x, y: Integer): GDBvertex2DI;
begin
  Result.x := x;
  Result.y := y;
end;
```

## 📝 Функциональность

Реализованная логика команды Stretch теперь поддерживает три сценария:

1. **Предварительно выбранные контрольные точки** - если вершины уже выбраны секущей рамкой, команда сразу переходит к режиму редактирования
2. **Предварительно выбранные объекты без контрольных точек** - создаёт контрольные точки для всех выбранных объектов и подсвечивает их красным цветом
3. **Нет предварительного выбора** - запускается стандартный процесс выбора с помощью секущей рамки

## ✅ Результат

- ✅ Устранены все ошибки компиляции
- ✅ Сохранены все русские комментарии в коде
- ✅ Функция предварительного выбора готова к тестированию

## 🧪 Тестирование

Требуется ручное тестирование:
1. Выделить вершины примитивов секущей рамкой
2. Запустить команду Stretch
3. Убедиться, что ручки управления вершин сразу загораются красным и редактирование начинается без повторного выделения

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)