### PR TITLE
Fix compilation errors in uzccommand_spline.pas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-210-92569e72
-Your prepared working directory: /tmp/gh-issue-solver-1760649104547
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes Free Pascal compilation errors in `uzccommand_spline.pas:220-246` that were preventing the code from compiling.

## Problem

The code had the following compilation errors:
- **Line 220**: `Error: Type identifier expected`
- **Lines 235, 237, 238, 246**: `Error: Illegal qualifier`

The root cause was using `array of array of single` as a `var` parameter in the `SolveLinearSystem` procedure. Free Pascal does not support open arrays of open arrays as `var` parameters, which caused the type identifier error and subsequently made array indexing operations like `A[k][k]` fail with "Illegal qualifier" errors.

## Solution

1. **Defined proper dynamic array types** in the interface section:
   ```pascal
   TSingleArray = array of single;
   TMatrix = array of TSingleArray;
   ```

2. **Updated the procedure signature** (line 222):
   ```pascal
   procedure SolveLinearSystem(var A:TMatrix; const b:array of single; var x:array of single; n:integer);
   ```

3. **Updated variable declaration** in `ConvertOnCurvePointsToControlPointsArray` (line 286):
   ```pascal
   N: TMatrix;
   ```

## Testing

The fix addresses all reported compilation errors:
- ✅ Line 220: Type identifier now properly defined as `TMatrix`
- ✅ Lines 235, 237, 238, 246: Array indexing `A[k][k]`, `A[i][k]`, `A[k][j]` now works correctly with the proper type

## Files Changed

- `cad_source/zcad/commands/uzccommand_spline.pas`: Added type definitions and updated procedure signature

## References

Fixes #210

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)