### PR TITLE
Fix compilation errors in uzccommand_spline.pas - SolveLinearSystem

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-210-1e2fb823
-Your prepared working directory: /tmp/gh-issue-solver-1760649672774
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR fixes all compilation errors in `uzccommand_spline.pas` related to the `SolveLinearSystem` procedure and the `ConvertOnCurvePointsToControlPointsArray` function.

## Problem

The code had a Pascal case-insensitivity issue where two variables:
- `n` (integer) - for counting number of points
- `N` (TMatrix) - for storing the basis function matrix

were treated as duplicate identifiers by the Free Pascal compiler, since Pascal is case-insensitive.

This caused a cascade of compilation errors:
- Line 286: `Error: Duplicate identifier "n"`
- Line 290: `Error: Incompatible types: got "Int64" expected "TMatrix"`
- Line 293: `Error: Operator is not overloaded: "{Dynamic} Array Of TSingleArray" < "ShortInt"`
- Line 299: `Error: Operator is not overloaded: "LongInt" >= "{Dynamic} Array Of TSingleArray"`
- Line 300: `Error: Incompatible types: got "TMatrix" expected "Int64"`

## Solution

Renamed the conflicting variables for clarity and correctness:
- `n` → `numPoints` (more descriptive name for the integer variable)
- `N` → `BasisMatrix` (more descriptive name for the matrix variable)

Updated all 45+ references throughout the `ConvertOnCurvePointsToControlPointsArray` function to use the new names consistently.

## Testing

The changes are purely variable renaming with no logic modifications. The mathematical implementation of the B-spline interpolation algorithm remains unchanged.

## Files Changed

- `cad_source/zcad/commands/uzccommand_spline.pas` - Fixed variable naming conflicts

Fixes #210

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)