### PR TITLE
Добавлена команда addZona в модуле command_zona

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-224-0f120ced
-Your prepared working directory: /tmp/gh-issue-solver-1760695615773
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## 📋 Описание / Description

Добавлена команда `addZona` для работы с зонами согласно issue #224.

## 🎯 Что сделано / What was done

1. **Создан новый модуль** `cad_source/zcad/velec/zona/command_zona.pas`
   - Реализована команда `addZona`
   - При запуске команды выводится сообщение: "запущена команда addZona"
   - Команда зарегистрирована через `CreateZCADCommand` в секции initialization

2. **Обновлен главный файл проекта** `cad_source/zcad.pas`
   - Добавлен импорт модуля `command_zona` в секцию `ELECTROTECH`
   - Модуль будет загружаться при сборке ZCADELECTROTECH

## 📝 Детали реализации / Implementation details

### Структура команды:
- **Имя команды**: `addZona`
- **Функция**: `addZona_com(const Context:TZCADCommandContext;operands:TCommandOperands):TCommandResult`
- **Контекст**: `CADWG` (команда работает в контексте чертежа)
- **Вывод**: Сообщение отправляется через `ZCMsgCallBackInterface.TextMessage` в историю команд

### Следует шаблону:
Реализация следует стандартному шаблону команд ZCAD, аналогично существующим командам в модулях `uzvcom.pas` и других velec модулях.

## 🔗 Связанные issue

Fixes #224

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)