### PR TITLE
Исправлена несовместимость типов в InteractivePolyLineNextVertexManipulator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: undefined
-Your prepared branch: issue-232-5edbc833
-Your prepared working directory: /tmp/gh-issue-solver-1760699881583
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Описание / Description

Этот PR исправляет ошибку несовместимости типов в манипуляторе `InteractivePolyLineNextVertexManipulator`, которая препятствовала компиляции команды `addSpace`.

This PR fixes a type incompatibility error in the `InteractivePolyLineNextVertexManipulator` manipulator that was preventing the `addSpace` command from compiling.

## Проблема / Problem

При попытке компиляции `uzvcommand_space.pas` возникала следующая ошибка:
```
uzvcommand_space.pas(108,50) Error: Incompatible type for arg no. 3: Got "<address of procedure(const PGDBObjPolyline;GVector3$2$crc8186BAAD_crc8619CEFD;Boolean);Register>", expected "<procedure variable type of procedure(const Pointer;GVector3$2$crc8186BAAD_crc8619CEFD;Boolean);Register>"
```

When attempting to compile `uzvcommand_space.pas`, the following error occurred:
```
uzvcommand_space.pas(108,50) Error: Incompatible type for arg no. 3: Got "<address of procedure(const PGDBObjPolyline;GVector3$2$crc8186BAAD_crc8619CEFD;Boolean);Register>", expected "<procedure variable type of procedure(const Pointer;GVector3$2$crc8186BAAD_crc8619CEFD;Boolean);Register>"
```

## Причина / Root Cause

В режиме компиляции `{$mode objfpc}` Free Pascal Compiler строже проверяет типы процедурных переменных, чем в режиме `{$mode delphi}`. Процедурный тип `TInteractiveProcObjBuild` определен с параметром типа `Pointer`:

```pascal
TInteractiveProcObjBuild=procedure(const PInteractiveData:Pointer;
  Point:GDBVertex;Click:boolean);
```

Манипулятор был объявлен с типизированным параметром `PGDBObjPolyline`, что вызывало конфликт типов при передаче его адреса в `Get3DPointInteractive`.

In compilation mode `{$mode objfpc}`, the Free Pascal Compiler is stricter with procedural variable type checking than in `{$mode delphi}` mode. The procedural type `TInteractiveProcObjBuild` is defined with a parameter of type `Pointer`. The manipulator was declared with a typed parameter `PGDBObjPolyline`, which caused a type conflict when passing its address to `Get3DPointInteractive`.

## Решение / Solution

Изменен тип параметра `PInteractiveData` с `PGDBObjPolyline` на `Pointer` в объявлении и реализации процедуры `InteractivePolyLineNextVertexManipulator`. Внутри реализации используется стандартная конструкция `absolute` для приведения:

```pascal
pline:PGDBObjPolyline absolute PInteractiveData;
```

Это соответствует паттерну, используемому в других манипуляторах (например, `InteractiveConstructRootManipulator`, `InteractiveLineEndManipulator`).

Changed the type of the `PInteractiveData` parameter from `PGDBObjPolyline` to `Pointer` in both the declaration and implementation of the `InteractivePolyLineNextVertexManipulator` procedure. Inside the implementation, the standard `absolute` construct is used for type casting. This matches the pattern used in other manipulators.

## Изменения / Changes

- ✅ Изменен тип параметра в объявлении процедуры (строка 163)
- ✅ Изменен тип параметра в реализации процедуры (строка 579)
- ✅ Сохранена существующая логика работы манипулятора
- ✅ Коммит соответствует стилю проекта

- ✅ Changed parameter type in procedure declaration (line 163)
- ✅ Changed parameter type in procedure implementation (line 579)
- ✅ Preserved existing manipulator logic
- ✅ Commit follows project style

## Тестирование / Testing

После применения исправления команда `addSpace` в `uzvcommand_space.pas` должна успешно компилироваться. CI проверит сборку проекта.

After applying this fix, the `addSpace` command in `uzvcommand_space.pas` should compile successfully. CI will verify the project build.

## Связанные issues / Related Issues

Fixes #232

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)