### PR TITLE
Развитие команды uzvcommand_space.pas: добавлены расширения extdrVariables и extdrIncludingVolume

### DIFF
--- a/cad_source/zcad/velec/space/uzvcommand_space.pas
+++ b/cad_source/zcad/velec/space/uzvcommand_space.pas
@@ -62,6 +62,10 @@ uses
                        //базовые типы
   uzcstrconsts,        //resource strings
                        //строковые константы
+  uzcenitiesvariablesextender,  //entity variables extender
+                                //расширение переменных примитивов
+  uzcextdrincludingvolume,      //including volume extender
+                                //расширение включающего объема
   uzccominteractivemanipulators; //interactive manipulators
                                   //интерактивные манипуляторы
 
@@ -236,6 +240,19 @@ begin
     // Проверяем что введено минимум 3 точки для создания пространства
     // Check that at least 3 points were entered to create a space
     if pointCount >= 3 then begin
+      // Добавляем расширения к полилинии перед сохранением
+      // Add extensions to polyline before saving
+
+      // Добавляем расширение extdrVariables для хранения переменных
+      // Add extdrVariables extension for storing variables
+      if ppolyline^.GetExtension<TVariablesExtender> = nil then
+        AddVariablesToEntity(ppolyline);
+
+      // Добавляем расширение extdrIncludingVolume для работы с объемом
+      // Add extdrIncludingVolume extension for volume operations
+      if ppolyline^.GetExtension<TIncludingVolumeExtender> = nil then
+        AddVolumeExtenderToEntity(ppolyline);
+
       // Удаляем штриховку из конструкторской области (она была только для визуализации)
       // Remove hatch from construct root (it was only for visualization)
       drawings.GetCurrentDWG^.ConstructObjRoot.ObjArray.RemoveData(phatch);


### PR DESCRIPTION
## 🎯 Описание / Description

Добавлена поддержка расширений extdrVariables и extdrIncludingVolume для полилинии, создаваемой командой addSpace.

Added support for extdrVariables and extdrIncludingVolume extensions for the polyline created by the addSpace command.

## ✅ Что сделано / What was done

### 1. Добавлено расширение extdrVariables

**Назначение:** Хранилище дополнительных типизированных данных (переменных) привязанных к примитиву полилинии.

**Возможности:**
- Каждая переменная имеет имя, тип и пользовательское имя
- Переменные доступны для редактирования в инспекторе объектов
- Поддержка простых и сложных типов данных
- Возможность экспорта/импорта данных

**Purpose:** Storage for additional typed data (variables) attached to the polyline entity.

**Features:**
- Each variable has a name, type, and user-friendly name
- Variables are accessible for editing in the object inspector
- Support for simple and complex data types
- Ability to export/import data

### 2. Добавлено расширение extdrIncludingVolume

**Назначение:** Позволяет полилинии работать как ограничивающий объем для других примитивов.

**Возможности:**
- Автоматическое определение примитивов внутри контура полилинии
- Связывание переменных с примитивами внутри объема
- Поддержка устройств (DEVICE) и текстов внутри контура

**Purpose:** Allows the polyline to work as a bounding volume for other entities.

**Features:**
- Automatic detection of entities inside the polyline contour
- Variable linking with entities inside the volume
- Support for devices (DEVICE) and texts inside the contour

## 🔧 Технические детали / Technical details

**Файл:** `cad_source/zcad/velec/space/uzvcommand_space.pas`

**Изменения в коде:**
1. Добавлены модули:
   - `uzcenitiesvariablesextender` - поддержка расширения переменных
   - `uzcextdrincludingvolume` - поддержка расширения объема

2. Добавлен код после успешного создания полилинии (≥3 точки):
   ```pascal
   // Добавляем расширение extdrVariables для хранения переменных
   if ppolyline^.GetExtension<TVariablesExtender> = nil then
     AddVariablesToEntity(ppolyline);

   // Добавляем расширение extdrIncludingVolume для работы с объемом
   if ppolyline^.GetExtension<TIncludingVolumeExtender> = nil then
     AddVolumeExtenderToEntity(ppolyline);
   ```

3. Расширения добавляются автоматически при создании пространства
4. Проверка на наличие расширений предотвращает дублирование

## 📋 Связанные issue / Related issues

Addresses #232

## 🧪 Тестирование / Testing

Для тестирования:
1. Запустите команду `addSpace`
2. Укажите минимум 3 точки для создания пространства
3. Завершите команду (Enter)
4. Выделите созданную полилинию
5. Проверьте в инспекторе объектов наличие расширений extdrVariables и extdrIncludingVolume
6. Убедитесь что можно добавлять и редактировать переменные

For testing:
1. Run the `addSpace` command
2. Specify at least 3 points to create a space
3. Complete the command (Enter)
4. Select the created polyline
5. Check in the object inspector for the presence of extdrVariables and extdrIncludingVolume extensions
6. Verify that you can add and edit variables

## 📝 Примечания / Notes

- Альфа-канал (прозрачность) был исключен из этой задачи по запросу владельца проекта
- Штриховка используется только для визуализации процесса построения и не сохраняется на чертеже
- Расширения добавляются только к успешно созданным полилиниям (с минимум 3 точками)

- Alpha channel (transparency) was excluded from this task per project owner request
- Hatch is used only for visualization during construction and is not saved to the drawing
- Extensions are only added to successfully created polylines (with at least 3 points)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes veb86/zcadvelecAI#232