### PR TITLE
Add ZCAD command line output to uzvsplineconvert

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,3 @@ Your forked repository: konard/zcadvelecAI
 Original repository (upstream): veb86/zcadvelecAI
 
 Proceed.
-
----
-
-Issue to solve: undefined
-Your prepared branch: issue-271-b52afd7e
-Your prepared working directory: /tmp/gh-issue-solver-1760791386519
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Summary

This PR adds ZCAD command line output to all informational messages in the `uzvsplineconvert` module, as requested in issue #271.

**Changes:**
- Added `uzcinterface` to the uses section to import `zcUI`
- Added `zcUI.TextMessage(..., TMWOHistoryOut)` calls alongside all existing `programlog.LogOutStr()` calls
- All informational output (on-curve points, control points, knot vector, and expected results) now displays in ZCAD's command line

**Example pattern applied:**
```pascal
programlog.LogOutStr('Message', LM_Info, UnitsInitializeLMId);
zcUI.TextMessage('Message', TMWOHistoryOut);
```

This ensures users see the output both in the log and in the ZCAD command line interface.

Resolves #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)