### PR TITLE
Добавлена регистрация команды importDialux для запуска распознавания светильников Dialux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,12 +37,3 @@
 
 Финальная цель стандарта — обеспечение единообразия оформления, лёгкости понимания и высокой поддерживаемости кода. Результатом применения данных правил должен стать проект, в котором отсутствуют длинные неструктурированные блоки, все элементы разделены по смыслу, функции компактны и читаемы, а комментарии чётко поясняют назначение логики и намерения программиста.
 
----
-
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/452
-Your prepared branch: issue-452-948c49ff388a
-Your prepared working directory: /tmp/gh-issue-solver-1762332355115
-Your forked repository: konard/zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.


### PR DESCRIPTION
## Решение для issue #452

Добавлена регистрация команды `importDialux` для запуска распознавания светильников из файлов Dialux.

### Проблема
Модуль dialuximport был реализован, но команда не была зарегистрирована в системе ZCAD, поэтому пользователи не могли её запустить.

### Решение
Добавлена секция `initialization` в файл `uzvdialuxlumimporter_main.pas` для регистрации команды в системе ZCAD.

### Изменения
- **Файл**: `cad_source/zcad/velec/dialuximport/uzvdialuxlumimporter_main.pas`
- **Изменение**: Добавлена секция initialization с вызовом `CreateZCADCommand`
- **Команда**: Зарегистрирована команда `importDialux` с функцией `ImportDialuxLuminaires_com`

### Использование
После сборки проекта пользователи смогут запустить команду:
```
importDialux
```

Команда выполняет следующие действия:
1. Проверяет наличие выделенных объектов
2. Парсит элементы из слоёв DLX_LUM и DLX_LUMKEY_IDX
3. Распознаёт светильники, сопоставляя геометрию с текстовыми метками
4. Выводит результаты анализа и список загруженных блоков с префиксом VELEC

### Технические детали
Реализация следует стандартам проекта:
- Регистрация команды по образцу существующих команд (например, `exportDialux`)
- Добавлены комментарии на русском и английском языках
- Соблюдены правила оформления кода из CLAUDE.md

### Связанные файлы
Модуль dialuximport состоит из:
- `uzvdialuxlumimporter_main.pas` - основная логика команды
- `uzvdialuxlumimporter_structs.pas` - структуры данных и константы
- `uzvdialuxlumimporter_parser.pas` - парсинг выделенных элементов
- `uzvdialuxlumimporter_recognizer.pas` - распознавание светильников
- `uzvdialuxlumimporter_blocks.pas` - работа с блоками
- `uzvdialuxlumimporter_utils.pas` - утилиты и вспомогательные функции

---
Fixes #452

🤖 Generated with [Claude Code](https://claude.com/claude-code)