### PR TITLE
Исправлено дублирование записей в undo/redo для электронных таблиц

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,15 +60,3 @@ Original repository (upstream): veb86/zcadvelecAI
 Proceed.
 
 Run timestamp: 2025-11-06T10:13:26.916Z
-
----
-
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/665
-Your prepared branch: issue-665-db4694ed609c
-Your prepared working directory: /tmp/gh-issue-solver-1765313173159
-Your forked repository: konard/veb86-zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.
-
-Run timestamp: 2025-12-09T20:46:24.598Z


### PR DESCRIPTION
## 📋 Описание проблемы

Issue #665 сообщал о двух проблемах с функционалом undo/redo в модуле электронных таблиц:

1. **Смена фокуса ячеек записывалась в undo/redo** (хотя не должна)
2. **Дублирование записей при редактировании**: После завершения редактирования ячейки в стеке undo создавались две одинаковые записи с состоянием до начала редактирования

### Симптомы

При последовательном заполнении ячеек (A1 → A2 → A3):
- Отмена последней ячейки (A3): требуется **1 нажатие** Undo
- Отмена предыдущих ячеек (A2, A1): требуется **2 нажатия** Undo на каждую

Это создавало непоследовательное поведение и путало пользователей.

## 🔍 Анализ причин

### Архитектура редактирования

В модуле `uzvspreadsheet` существует два пути редактирования ячеек:

1. **Прямое редактирование в сетке**: через события `OnWorksheetGridSelectEditor` и `OnWorksheetGridEditingDone`
2. **Редактирование через поле ввода**: через функцию `ApplyCellContent` (при редактировании в отдельном поле `FEditCellContent`)

### Корневая причина дублирования

Оба пути вызывали `SpreadsheetUndoManager.BeginChange()`, что приводило к созданию двух undo-записей для одной операции редактирования:

```pascal
// Первый вызов в OnWorksheetGridSelectEditor (строка 396)
SpreadsheetUndoManager.BeginChange(row, col, 'Изменение ячейки ' + cellAddress);

// Второй вызов в ApplyCellContent (строка 540)
SpreadsheetUndoManager.BeginChange(row, col, 'Изменение ячейки ' + cellAddress);
```

### О первой проблеме (фокус ячеек)

При анализе кода выяснилось, что **смена фокуса НЕ записывалась** в undo/redo:
- `OnWorksheetGridSelection` (вызывается при смене выбранной ячейки) только обновляет информацию, не вызывая `BeginChange`
- Реальная проблема была именно в дублировании записей при редактировании

## ✅ Решение

### Реализованный подход

Добавлен механизм отслеживания создания undo-записи для предотвращения дублирования:

1. **Новая переменная-флаг**: `FUndoSavedForCurrentEdit: Boolean`
   - Отслеживает, была ли уже создана undo-запись для текущей операции редактирования

2. **Инициализация**: Флаг сбрасывается при начале каждой новой операции редактирования

3. **Защита от дублирования в `ApplyCellContent`**:
   ```pascal
   // Проверяем: это новая ячейка или ещё не сохраняли undo для текущей?
   if (not FUndoSavedForCurrentEdit) or
      (row <> FEditingRow) or (col <> FEditingCol) then
   begin
     SpreadsheetUndoManager.BeginChange(row, col, 'Изменение ячейки ' + cellAddress);
     FUndoSavedForCurrentEdit := True;
     FEditingRow := row;
     FEditingCol := col;
   end;
   ```

4. **Сброс флага**: При завершении редактирования (`OnWorksheetGridEditingDone`)

### Изменённые файлы

- `cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas`

### Детали изменений

1. Добавлена переменная `FUndoSavedForCurrentEdit: Boolean` (строка 97)
2. Инициализация в `DoCreate` (строка 157)
3. Установка флага в `OnWorksheetGridSelectEditor` при вызове `BeginChange` (строка 400)
4. Проверка флага и координат ячейки в `ApplyCellContent` перед созданием undo-записи (строки 546-558)
5. Сброс флага в `OnWorksheetGridEditingDone` (строка 438)

## 🧪 Ожидаемый результат

После исправления:
- ✅ Каждая операция редактирования создаёт ровно **одну** undo-запись
- ✅ Отмена любой ячейки требует **1 нажатие** Undo (последовательное поведение)
- ✅ Undo/Redo работает корректно как для редактирования в сетке, так и через отдельное поле ввода
- ✅ Нет дублирующихся записей в истории изменений

## 📝 Связанные issue

Fixes #665

---

🤖 Создано автоматически AI issue solver