### PR TITLE
Исправлена ошибка дублирования параметров устройств при экспорте в Access

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,16 +40,3 @@
 Для логирования использовать: "uses uzclog;". Только тип сообщения: LM_Info
 Пример записи в лог:
 programlog.LogOutFormatStr('uzvgetentity: result count = %d', [Result.Count], LM_Info);
-
----
-
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/706
-Your prepared branch: issue-706-d0f9499f8bc1
-Your prepared working directory: /tmp/gh-issue-solver-1767074118686
-Your forked repository: konard/veb86-zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.
-
-
-Run timestamp: 2025-12-30T05:55:31.509Z


### PR DESCRIPTION
## Описание проблемы

При экспорте устройств в MS Access через модуль `uzvaccess` количество устройств определялось правильно, но параметры из таблицы EXPORT1 применялись только к одному устройству и затем дублировались для всех остальных устройств. Вместо индивидуального считывания параметров для каждого устройства, все устройства получали одинаковые данные последнего обработанного устройства.

## Причина ошибки

В файле `cad_source/zcad/velec/uzvaccess/uzvaccess_executor.pas` в функции `ExecuteExport` (режим пакетной вставки INSERT) использовался один и тот же массив `values` для всех устройств:

```pascal
// Подготовка массива значений (строка 440)
SetLength(values, AInstructions.ColumnMappings.Size);

for i := 0 to entities.Count - 1 do
begin
  // Извлекаем значения для текущего устройства
  ExtractValues(entity, AInstructions, ASourceProvider, values);
  
  // ОШИБКА: добавляем указатель на один и тот же массив!
  batchData.Add(@values);
end
```

В результате все элементы списка `batchData` указывали на одну и ту же область памяти, и при вставке данных в базу все устройства получали параметры последнего обработанного устройства.

## Реализованное решение

Добавлены две вспомогательные функции для корректной работы с копиями массивов:

1. **CreateValuesCopy** — создаёт независимую копию массива значений для каждого устройства
2. **FreeBatchData** — корректно освобождает память, выделенную для массивов

Исправленный код:

```pascal
for i := 0 to entities.Count - 1 do
begin
  // Извлекаем значения для текущего устройства
  ExtractValues(entity, AInstructions, ASourceProvider, values);
  
  // Создаём копию массива для текущего устройства
  batchData.Add(CreateValuesCopy(values));
  
  // При достижении размера батча
  if (batchData.Count >= FBatchSize) or (i = entities.Count - 1) then
  begin
    InsertBatch(AInstructions.TargetTable, AInstructions, batchData);
    
    // Освобождаем память
    FreeBatchData(batchData);
    batchData.Clear;
  end;
end
```

## Технические детали

- Каждое устройство теперь получает свою независимую копию массива параметров
- Добавлено корректное управление памятью с освобождением выделенных массивов
- Код структурирован согласно стандартам проекта: модульность, читаемость, русскоязычные комментарии
- Функции не превышают 30 строк, каждая выполняет одну чётко определённую задачу

## Изменённые файлы

- `cad_source/zcad/velec/uzvaccess/uzvaccess_executor.pas` — исправлена логика экспорта устройств

## Тестирование

Решение устраняет дублирование параметров и обеспечивает индивидуальное считывание данных для каждого устройства согласно требованиям issue #706.

---

Fixes #706

🤖 Generated with [Claude Code](https://claude.com/claude-code)