### PR TITLE
Исправлена ошибка дублирования параметров устройств при экспорте

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,16 +40,3 @@
 Для логирования использовать: "uses uzclog;". Только тип сообщения: LM_Info
 Пример записи в лог:
 programlog.LogOutFormatStr('uzvgetentity: result count = %d', [Result.Count], LM_Info);
-
----
-
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/711
-Your prepared branch: issue-711-558e077306e5
-Your prepared working directory: /tmp/gh-issue-solver-1767823645887
-Your forked repository: konard/veb86-zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.
-
-
-Run timestamp: 2026-01-07T22:07:38.599Z


### PR DESCRIPTION
## 📋 Описание проблемы

При экспорте устройств количество определялось правильно, но параметры из таблицы EXPORT1 применялись только к первому устройству и затем дублировались для всех остальных устройств. Вместо этого необходимо было считывать параметры индивидуально для каждого устройства и заполнять таблицу корректно.

## 🔍 Анализ причины

Проблема обнаружена в файле `cad_source/zcad/velec/uzvsqlite/uzvsqlite_executor.pas` в режиме пакетной вставки (INSERT):

1. Создавался один общий массив `values` для всех устройств
2. При обработке каждого устройства значения извлекались в этот же массив
3. В пакет добавлялся только **указатель** на этот массив: `batchData.Add(@values)`
4. На следующей итерации массив `values` перезаписывался данными следующего устройства
5. В итоге все записи в пакете ссылались на данные **последнего** устройства

## ✅ Решение

Для каждого устройства теперь создаётся отдельный массив значений:

1. Выделяется новая память: `New(pValues)`
2. Создаётся массив нужного размера: `SetLength(pValues^, Length(values))`
3. Значения копируются из временного массива: `pValues^[j] := values[j]`
4. В пакет добавляется указатель на новый массив: `batchData.Add(pValues)`

Это гарантирует, что каждое устройство сохраняет свои индивидуальные параметры.

## 🧹 Управление памятью

Добавлено корректное освобождение памяти для выделенных массивов:
- После вставки каждого пакета
- В блоке `finally` для оставшихся массивов

## 📝 Изменённые файлы

- `cad_source/zcad/velec/uzvsqlite/uzvsqlite_executor.pas:395-570`

## 🔗 Связанные задачи

Fixes #711

---
🤖 Этот PR был создан автоматически AI issue solver