### PR TITLE
Исправлена ошибка EVariantTypeMismatch при валидации типов {test1}–{test4}

### DIFF
--- a/cad_source/zcad/velec/uzvsqlite/uzvsqlite_executor.pas
+++ b/cad_source/zcad/velec/uzvsqlite/uzvsqlite_executor.pas
@@ -435,26 +435,46 @@ begin
     end;
 
     // Валидируем и преобразуем тип
-    if not FValidator.ValidateAndConvert(
-      rawValue,
-      mapping.DataType,
-      convertedValue
-    ) then
-    begin
-      programlog.LogOutFormatStr(
-        'uzvsqlite: Ошибка валидации значения для колонки "%s"',
-        [mapping.ColumnName],
-        LM_Info
-      );
-
-      if FConfig.ErrorMode = emStop then
+    try
+      if not FValidator.ValidateAndConvert(
+        rawValue,
+        mapping.DataType,
+        convertedValue
+      ) then
       begin
-        Result := False;
-        Exit;
-      end;
+        programlog.LogOutFormatStr(
+          'uzvsqlite: Ошибка валидации для колонки "%s"',
+          [mapping.ColumnName],
+          LM_Info
+        );
 
-      // В мягком режиме используем значение по умолчанию
-      convertedValue := Null;
+        if FConfig.ErrorMode = emStop then
+        begin
+          Result := False;
+          Exit;
+        end;
+
+        // В мягком режиме используем значение по умолчанию
+        convertedValue := Null;
+      end;
+    except
+      on E: Exception do
+      begin
+        programlog.LogOutFormatStr(
+          'uzvsqlite: Исключение при валидации '
+          + 'колонки "%s": %s',
+          [mapping.ColumnName, E.Message],
+          LM_Info
+        );
+
+        if FConfig.ErrorMode = emStop then
+        begin
+          Result := False;
+          Exit;
+        end;
+
+        convertedValue := Null;
+      end;
     end;
 
     AValues[i] := convertedValue;
@@ -589,23 +609,41 @@ begin
       hasAnyValue := True;
 
     // Валидируем и преобразуем тип
-    if not FValidator.ValidateAndConvert(
-      rawValue,
-      mapping.DataType,
-      convertedValue
-    ) then
-    begin
-      programlog.LogOutFormatStr(
-        'uzvsqlite: Ошибка валидации значения для колонки "%s" (итерация %d)',
-        [mapping.ColumnName, ALoopNum],
-        LM_Info
-      );
+    try
+      if not FValidator.ValidateAndConvert(
+        rawValue,
+        mapping.DataType,
+        convertedValue
+      ) then
+      begin
+        programlog.LogOutFormatStr(
+          'uzvsqlite: Ошибка валидации для колонки "%s" '
+          + '(итерация %d)',
+          [mapping.ColumnName, ALoopNum],
+          LM_Info
+        );
 
-      if FConfig.ErrorMode = emStop then
-        Exit; // Result = False
+        if FConfig.ErrorMode = emStop then
+          Exit; // Result = False
 
-      // В мягком режиме используем значение по умолчанию
-      convertedValue := Null;
+        // В мягком режиме используем значение по умолчанию
+        convertedValue := Null;
+      end;
+    except
+      on E: Exception do
+      begin
+        programlog.LogOutFormatStr(
+          'uzvsqlite: Исключение при валидации колонки '
+          + '"%s" (итерация %d): %s',
+          [mapping.ColumnName, ALoopNum, E.Message],
+          LM_Info
+        );
+
+        if FConfig.ErrorMode = emStop then
+          Exit; // Result = False
+
+        convertedValue := Null;
+      end;
     end;
 
     AValues[i] := convertedValue;

--- a/cad_source/zcad/velec/uzvsqlite/uzvsqlite_validator.pas
+++ b/cad_source/zcad/velec/uzvsqlite/uzvsqlite_validator.pas
@@ -159,6 +159,7 @@ function TTypeValidator.ValidateInteger(
 var
   valueStr: String;
   floatValue: Double;
+  varType: Word;
 begin
   Result := True;
   AResult := 0;
@@ -173,16 +174,70 @@ begin
     Exit;
   end;
 
-  // Попытка прямого преобразования
-  try
-    AResult := VarAsType(AValue, varInteger);
-    Exit;
-  except
-    // Ничего не делаем, пробуем другие способы
+  // Определяем фактический тип Variant для безопасной обработки
+  varType := VarType(AValue) and varTypeMask;
+
+  // Если значение уже целое число — берём напрямую
+  if varType in [varSmallInt, varInteger, varShortInt,
+    varByte, varWord, varLongWord] then
+  begin
+    try
+      AResult := AValue;
+      Exit;
+    except
+      // При ошибке пробуем через строку
+    end;
   end;
 
-  // Попытка преобразования через строку
-  valueStr := Trim(VarToStr(AValue));
+  // Для boolean: True = 1, False = 0
+  if varType = varBoolean then
+  begin
+    if AValue then
+      AResult := 1
+    else
+      AResult := 0;
+    Exit;
+  end;
+
+  // Для вещественных — округляем (с учётом строгого режима)
+  if varType in [varSingle, varDouble, varCurrency] then
+  begin
+    try
+      floatValue := AValue;
+      AResult := Round(floatValue);
+
+      if FStrictMode then
+      begin
+        programlog.LogOutFormatStr(
+          'uzvsqlite: Строгий режим: '
+          + 'недопустимое преобразование float→integer: %s',
+          [VarToStr(AValue)],
+          LM_Info
+        );
+        Result := False;
+      end;
+      Exit;
+    except
+      // При ошибке пробуем через строку
+    end;
+  end;
+
+  // Преобразование через строку — универсальный способ
+  try
+    valueStr := Trim(VarToStr(AValue));
+  except
+    on E: Exception do
+    begin
+      programlog.LogOutFormatStr(
+        'uzvsqlite: Ошибка получения строки из Variant: %s',
+        [E.Message],
+        LM_Info
+      );
+      AResult := 0;
+      Result := False;
+      Exit;
+    end;
+  end;
 
   try
     // Проверяем, не является ли это числом с плавающей точкой
@@ -191,13 +246,11 @@ begin
       floatValue := StrToFloat(valueStr);
       AResult := Round(floatValue);
 
-      if not FStrictMode then
-      begin
-      end
-      else
+      if FStrictMode then
       begin
         programlog.LogOutFormatStr(
-          'uzvsqlite: Строгий режим: недопустимое преобразование float→integer: %s',
+          'uzvsqlite: Строгий режим: '
+          + 'недопустимое преобразование float→integer: %s',
           [valueStr],
           LM_Info
         );
@@ -229,6 +282,7 @@ function TTypeValidator.ValidateFloat(
 ): Boolean;
 var
   valueStr: String;
+  varType: Word;
 begin
   Result := True;
   AResult := 0.0;
@@ -243,16 +297,58 @@ begin
     Exit;
   end;
 
-  // Попытка прямого преобразования
-  try
-    AResult := VarAsType(AValue, varDouble);
-    Exit;
-  except
-    // Ничего не делаем, пробуем другие способы
+  // Определяем фактический тип Variant для безопасной обработки
+  varType := VarType(AValue) and varTypeMask;
+
+  // Если значение уже вещественное — берём напрямую
+  if varType in [varSingle, varDouble, varCurrency] then
+  begin
+    try
+      AResult := AValue;
+      Exit;
+    except
+      // При ошибке пробуем через строку
+    end;
   end;
 
-  // Попытка преобразования через строку
-  valueStr := Trim(VarToStr(AValue));
+  // Целочисленные типы — безопасно приводим к Double
+  if varType in [varSmallInt, varInteger, varShortInt,
+    varByte, varWord, varLongWord, varInt64, varQWord] then
+  begin
+    try
+      AResult := AValue;
+      Exit;
+    except
+      // При ошибке пробуем через строку
+    end;
+  end;
+
+  // Для boolean: True = 1.0, False = 0.0
+  if varType = varBoolean then
+  begin
+    if AValue then
+      AResult := 1.0
+    else
+      AResult := 0.0;
+    Exit;
+  end;
+
+  // Преобразование через строку — универсальный способ
+  try
+    valueStr := Trim(VarToStr(AValue));
+  except
+    on E: Exception do
+    begin
+      programlog.LogOutFormatStr(
+        'uzvsqlite: Ошибка получения строки из Variant: %s',
+        [E.Message],
+        LM_Info
+      );
+      AResult := 0.0;
+      Result := False;
+      Exit;
+    end;
+  end;
 
   try
     AResult := StrToFloat(valueStr);
@@ -277,6 +373,7 @@ function TTypeValidator.ValidateBoolean(
 var
   valueStr: String;
   valueInt: Integer;
+  varType: Word;
 begin
   Result := True;
   AResult := False;
@@ -291,30 +388,71 @@ begin
     Exit;
   end;
 
-  // Попытка прямого преобразования
-  try
-    AResult := VarAsType(AValue, varBoolean);
+  // Определяем фактический тип Variant для безопасной обработки
+  varType := VarType(AValue) and varTypeMask;
+
+  // Если значение уже boolean — берём напрямую
+  if varType = varBoolean then
+  begin
+    AResult := AValue;
     Exit;
-  except
-    // Ничего не делаем, пробуем другие способы
   end;
 
-  // Попытка преобразования через строку
-  valueStr := LowerCase(Trim(VarToStr(AValue)));
+  // Для числовых типов: 0 = False, остальное = True
+  if varType in [varSmallInt, varInteger, varShortInt,
+    varByte, varWord, varLongWord, varInt64, varQWord] then
+  begin
+    try
+      AResult := (AValue <> 0);
+      Exit;
+    except
+      // При ошибке пробуем через строку
+    end;
+  end;
+
+  // Для вещественных типов: 0.0 = False, остальное = True
+  if varType in [varSingle, varDouble, varCurrency] then
+  begin
+    try
+      AResult := (Double(AValue) <> 0.0);
+      Exit;
+    except
+      // При ошибке пробуем через строку
+    end;
+  end;
+
+  // Преобразование через строку — универсальный способ
+  try
+    valueStr := LowerCase(Trim(VarToStr(AValue)));
+  except
+    on E: Exception do
+    begin
+      programlog.LogOutFormatStr(
+        'uzvsqlite: Ошибка получения строки из Variant: %s',
+        [E.Message],
+        LM_Info
+      );
+      AResult := False;
+      Result := False;
+      Exit;
+    end;
+  end;
 
   try
     // Проверяем строковые представления
-    if (valueStr = 'true') or (valueStr = '1') or (valueStr = 'yes') or (valueStr = 'y') then
+    if (valueStr = 'true') or (valueStr = '1')
+      or (valueStr = 'yes') or (valueStr = 'y') then
     begin
       AResult := True;
     end
-    else if (valueStr = 'false') or (valueStr = '0') or (valueStr = 'no') or (valueStr = 'n') then
+    else if (valueStr = 'false') or (valueStr = '0')
+      or (valueStr = 'no') or (valueStr = 'n') then
     begin
       AResult := False;
     end
     else if TryStrToInt(valueStr, valueInt) then
     begin
-      // Попытка интерпретировать как число (0 = false, остальное = true)
+      // Интерпретируем как число (0 = false, остальное = true)
       AResult := (valueInt <> 0);
     end
     else


### PR DESCRIPTION
## 🎯 Решение проблемы

Исправлена критическая ошибка `EVariantTypeMismatch`, возникающая при использовании функций `{test1}`, `{test2}`, `{test3}`, `{test4}` в таблице экспорта SQLite.

### 📋 Ссылка на issue
Fixes #725

### 🐛 Описание проблемы

При экспорте данных с использованием функций `{test1}`–`{test4}` происходило необработанное исключение `EVariantTypeMismatch` (call stack из issue: `FPC_RAISEEXCEPTION → LSTRTOBOOLEAN → VARIANTTYPEMISMATCH → ValidateBoolean:296`).

**Корневая причина:** метод `ValidateBoolean` использовал `VarAsType(AValue, varBoolean)` для прямого приведения типов. Когда в Variant передавалась строка, не являющаяся допустимым булевым значением (например `'OBJ_NONAME'` из `{test4}`), FPC внутренне вызывал `LStrToBoolean`, что приводило к исключению `EVariantTypeMismatch`.

Хотя вокруг `VarAsType` был блок `try-except`, в некоторых сборках FPC исключение `EVariantTypeMismatch` могло не перехватываться корректно через `except` без фильтра.

### ✅ Решение

#### 1. Безопасная валидация типов (`uzvsqlite_validator.pas`)

**ValidateBoolean, ValidateInteger, ValidateFloat** — заменена стратегия «попробовать VarAsType и перехватить исключение» на безопасную проверку `VarType(AValue) and varTypeMask`:

- Если тип Variant совпадает с целевым — значение берётся напрямую
- Для совместимых типов (int→bool, float→int, bool→int) — выполняется безопасное преобразование
- Для строк — парсинг через строковые представления (`'true'`, `'false'`, `'1'`, `'0'`, `'yes'`, `'no'`)
- `VarAsType` больше не вызывается, что исключает `EVariantTypeMismatch`

#### 2. Защита от исключений в исполнителе (`uzvsqlite_executor.pas`)

Добавлена дополнительная обёртка `try-except` вокруг вызова `ValidateAndConvert` в методах:
- `ExtractValues` (однократный экспорт)
- `ExtractLoopValues` (цикловой экспорт)

Это гарантирует, что любое непредвиденное исключение при валидации не приведёт к аварийному завершению программы, а будет залогировано и обработано в зависимости от `ErrorMode`.

### 📝 Изменённые файлы

- `cad_source/zcad/velec/uzvsqlite/uzvsqlite_validator.pas` — переписаны `ValidateBoolean`, `ValidateInteger`, `ValidateFloat` с проверкой `VarType` вместо `VarAsType`
- `cad_source/zcad/velec/uzvsqlite/uzvsqlite_executor.pas` — добавлена обработка исключений вокруг `ValidateAndConvert`

### 🧪 Тестирование

Для проверки исправления:
1. Настроить таблицу экспорта с колонками:
   | com | nameTF | param | typeTF |
   |---|---|---|---|
   | tTable | Table1 | | |
   | typeData | device | | |
   | setcolumn | A | {test1} | string |
   | setcolumn | B | {test2} | integer |
   | setcolumn | C | {test3} | float |
   | setcolumn | D | {test4} | boolean |
2. Запустить экспорт
3. Убедиться, что экспорт не вызывает `EVariantTypeMismatch`
4. Проверить логи на корректные сообщения валидации

### 📊 Статистика

- **Добавлено:** 237 строк
- **Удалено:** 61 строка
- **Изменено:** 2 файла

---

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>