### PR TITLE
Исправлена ошибка компиляции uzvsqlite_validator.pas: конфликт имени varType с VarType()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,16 +40,3 @@
 Для логирования использовать: "uses uzclog;". Только тип сообщения: LM_Info
 Пример записи в лог:
 programlog.LogOutFormatStr('uzvgetentity: result count = %d', [Result.Count], LM_Info);
-
----
-
-Issue to solve: https://github.com/veb86/zcadvelecAI/issues/727
-Your prepared branch: issue-727-7cd356752d63
-Your prepared working directory: /tmp/gh-issue-solver-1770411955310
-Your forked repository: konard/veb86-zcadvelecAI
-Original repository (upstream): veb86/zcadvelecAI
-
-Proceed.
-
-
-Run timestamp: 2026-02-06T21:06:09.284Z


### PR DESCRIPTION
## Описание

Fixes veb86/zcadvelecAI#727

Исправлена ошибка компиляции в `uzvsqlite_validator.pas`:
```
uzvsqlite_validator.pas(178,21) Error: Syntax error, ";" expected but "(" found
```

## Причина ошибки

В Free Pascal с директивой `{$mode objfpc}` идентификаторы **регистронезависимы**. Локальная переменная `varType: Word` затеняла встроенную функцию `VarType()` из модуля `Variants`.

Когда компилятор встречал `varType(AValue)` на строке 178, он интерпретировал `varType` как локальную переменную типа `Word`, а не как функцию — отсюда синтаксическая ошибка (нельзя вызвать переменную типа `Word` как функцию).

## Решение

Переименована локальная переменная `varType` → `actualVarType` в трёх функциях класса `TTypeValidator`:
- `ValidateInteger` (строка 162)
- `ValidateFloat` (строка 285)
- `ValidateBoolean` (строка 376)

Изменение минимально и не затрагивает логику работы — меняется только имя локальной переменной, чтобы устранить конфликт со встроенной функцией `VarType()`.

---
*Этот PR создан автоматически AI-помощником*