### PR TITLE
Fix compilation error in uzeentpolyfacemesh.pas

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/veb86/zcadvelecAI/issues/756
-# Branch: issue-756-22215f1df630
-# Timestamp: 2026-02-13T10:46:38.647Z
-# This file was created with --gitkeep-file flag
-# It will be removed when the task is complete

--- a/cad_source/zengine/core/entities/uzeentpolyfacemesh.pas
+++ b/cad_source/zengine/core/entities/uzeentpolyfacemesh.pas
@@ -110,8 +110,6 @@ var
   isProcessingVertex: Boolean;
   isFaceRecord: Boolean;
   isPolyFaceVertex: Boolean;
-  declaredVertexCount: Integer;
-  declaredFaceCount: Integer;
 
   procedure AddCurrentFace;
   begin
@@ -139,19 +137,12 @@ begin
   isProcessingVertex := False;
   isFaceRecord := False;
   isPolyFaceVertex := False;
-  declaredVertexCount := 0;
-  declaredFaceCount := 0;
 
   currentFace.VertexCount := 0;
   currentFace.Vertex1 := 0;
   currentFace.Vertex2 := 0;
   currentFace.Vertex3 := 0;
   currentFace.Vertex4 := 0;
-
-  if declaredVertexCount > 0 then
-    context.GDBVertexLoadCache.Reserve(declaredVertexCount);
-  if declaredFaceCount > 0 then
-    FFaces.Reserve(declaredFaceCount);
 
   byt := rdr.ParseInteger;
   while not rdr.EOF do begin
@@ -214,7 +205,7 @@ begin
             rdr.ParseInteger;
         end
         else if not isProcessingVertex then begin
-          declaredVertexCount := rdr.ParseInteger;
+          rdr.ParseInteger;
         end
         else
           rdr.ParseInteger;
@@ -229,7 +220,7 @@ begin
           end;
         end
         else if not isProcessingVertex then begin
-          declaredFaceCount := rdr.ParseInteger;
+          rdr.ParseInteger;
         end
         else
           rdr.ParseInteger;


### PR DESCRIPTION
## Summary
Fixes compilation error in uzeentpolyfacemesh.pas (issue #756).

The code was trying to use the non-existent `Reserve` method on GDBVector-based objects (`context.GDBVertexLoadCache` and `FFaces`). This caused compilation errors:
- `uzeentpolyfacemesh.pas(152,32) Error: Identifier idents no member "Reserve"`
- `uzeentpolyfacemesh.pas(154,12) Error: Identifier idents no member "Reserve"`

## Changes
- Removed the non-existent Reserve calls (lines 151-154)
- Removed unused variables `declaredVertexCount` and `declaredFaceCount`
- Simplified the DXF parsing to still read but discard the vertex/face count values

The Reserve functionality was never going to work anyway since:
1. The Reserve method doesn't exist in GZVector
2. The Reserve calls were placed BEFORE the values were read from the DXF file, so they would always be 0

The vectors will still work correctly as they grow dynamically when needed.