### PR TITLE
Fix: Проект компилируется, но файлы не загружаются uzeentpolyfacemesh.pas

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,6 +1,0 @@
-# Auto-generated file for PR creation
-# Issue: https://github.com/veb86/zcadvelecAI/issues/758
-# Branch: issue-758-69854dddc0d5
-# Timestamp: 2026-02-13T11:26:34.227Z
-# This file was created with --gitkeep-file flag
-# It will be removed when the task is complete

--- a/cad_source/zengine/core/entities/uzeentpolyfacemesh.pas
+++ b/cad_source/zengine/core/entities/uzeentpolyfacemesh.pas
@@ -272,9 +272,25 @@ begin
           end;
         end;
       end;
-      210, 62, 8:
+      210:
+      begin
+        rdr.ParseDouble;
+      end;
+      220:
+      begin
+        rdr.ParseDouble;
+      end;
+      230:
+      begin
+        rdr.ParseDouble;
+      end;
+      62:
       begin
         rdr.ParseInteger;
+      end;
+      8:
+      begin
+        rdr.ParseString;
       end;
     else
       rdr.ParseString;


### PR DESCRIPTION
## Summary
Исправлена ошибка парсинга DXF файлов с полигональными сетками (polyfacemesh).

## Проблема
При загрузке DXF файлов происходила ошибка \"Failed to read data from register\" в `uzeentpolyfacemesh.pas:277` из-за неправильной обработки групповых кодов DXF.

## Решение
Исправлена обработка DXF групповых кодов:
- Коды 210, 220, 230 (направление экструзии) должны парситься как double
- Код 62 (цвет) должен парситься как integer  
- Код 8 (имя слоя) должен парситься как string

Ранее все эти коды обрабатывались одинаково - как целые числа, что приводило к повреждению потока данных и ошибке чтения.

## Изменения
- `cad_source/zengine/core/entities/uzeentpolyfacemesh.pas`: Разделена обработка групповых кодов 210, 220, 230, 62 и 8

## Тестирование
Проверено на файле `_vl_line.dxf` из блоков электротехнических схем.

Fixes veb86/zcadvelecAI#758