### PR TITLE
Фильтрация невидимых примитивов динамических блоков по коду DXF 60

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-17T21:28:12.060Z for PR creation at branch issue-788-ae91fd11fb32 for issue https://github.com/veb86/zcadvelecAI/issues/788

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-03-17T21:28:12.060Z for PR creation at branch issue-788-ae91fd11fb32 for issue https://github.com/veb86/zcadvelecAI/issues/788

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -50,6 +50,8 @@ type
     Handle:QWord;
     Upgrade:TEntUpgradeInfo;
     ExtAttrib2:boolean;
+    // Признак невидимости примитива из группового кода DXF 60 (1 = невидим)
+    DXFInvisible:boolean;
   end;
 
   GDBObjEntity=object(GDBObjSubordinated)
@@ -1094,6 +1096,12 @@ begin
     end;
     62:begin
       vp.color:=rdr.ParseInteger;
+      Result:=True;
+    end;
+    60:begin
+      // Групповой код 60: признак видимости примитива.
+      // Значение 1 означает невидимый примитив (скрыт в динамическом блоке).
+      AddExtAttrib^.DXFInvisible := rdr.ParseInteger = 1;
       Result:=True;
     end;
     370:begin

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -335,6 +335,16 @@ begin
       zTraceLn('{D+}[DXF_CONTENTS]AddEntitiesFromDXF.Found primitive %s',[s]);
       pobj := EntInfoData.AllocAndInitEntity(nil);
       PGDBObjEntity(pobj)^.LoadFromDXF(rdr,PExtLoadData,drawing,context);
+      // Фильтрация невидимых примитивов по групповому коду DXF 60.
+      // Если примитив помечен как невидимый (код 60 = 1), он не добавляется в сцену,
+      // не участвует в выборе и не влияет на габаритный контейнер блока.
+      if (PGDBObjEntity(pobj)^.PExtAttrib <> nil) and
+         PGDBObjEntity(pobj)^.PExtAttrib^.DXFInvisible then begin
+        zDebugLn('{I}[DXF_CONTENTS]Пропускаем невидимый примитив (DXF код 60=1): %s',[s]);
+        pobj^.done;
+        Freemem(pointer(pobj));
+        Continue;
+      end;
       if (PGDBObjEntity(pobj)^.vp.Layer=@DefaultErrorLayer)or(PGDBObjEntity(pobj)^.vp.Layer=nil) then
         PGDBObjEntity(pobj)^.vp.Layer:=drawing.LayerTable.GetSystemLayer;
       if (PGDBObjEntity(pobj)^.vp.LineType=nil) then


### PR DESCRIPTION
## Описание

Реализована фильтрация геометрических примитивов при чтении анонимных блоков (`*U...`) на основе значения группового кода 60 (Visibility) в соответствии со спецификацией DXF.

Ранее ZCAD отображал все геометрические примитивы динамических блоков одновременно, включая те, которые должны быть скрыты в текущем состоянии видимости. Теперь примитивы с кодом 60 = 1 (невидимые) полностью исключаются из сцены.

## Изменения

### `cad_source/zengine/core/entities/uzeentity.pas`
- В запись `TExtAttrib` добавлено поле `DXFInvisible: boolean` для хранения признака невидимости примитива из кода DXF 60
- В метод `LoadFromDXFObjShared` добавлена обработка группового кода 60: если значение равно 1, устанавливается `PExtAttrib^.DXFInvisible := true`

### `cad_source/zengine/fileformats/uzeffdxf.pas`
- В процедуру `addentitiesfromdxf` добавлена проверка после загрузки примитива: если `PExtAttrib^.DXFInvisible = true`, примитив освобождается и не добавляется в сцену

## Логика фильтрации (согласно требованиям issue #788)

| Код 60 | Значение | Результат |
|--------|----------|-----------|
| Отсутствует | — | Примитив **видимый** |
| Присутствует | 0 | Примитив **видимый** |
| Присутствует | 1 | Примитив **невидимый** — не добавляется в сцену, не участвует в выборе, не влияет на bounding box |

## Связанное

Closes #788