### PR TITLE
Исправить загрузку кастомных DXF-сущностей как proxy-графики

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-19T13:57:20.579Z for PR creation at branch issue-801-88fdfc29bea2 for issue https://github.com/veb86/zcadvelecAI/issues/801


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#801

## Проблема

После активации `FindOrProxyEntInfo` в `addentitiesfromdxf` возникала ошибка
`Failed to read data from register` в `TZMEMREADER.PARSEINTEGER2` при загрузке
DXF-файлов, не содержащих proxy-графику. Ошибка происходила в
`GDBObjBlockdef.LoadFromDXF` (uzeblockdef.pas:85).

## Корневая причина

Функция `FindOrProxyEntInfo` перехватывала структурный маркер `ENDBLK` как
неизвестную сущность и загружала его через прокси-класс `GDBObjAcdProxy`.
Прокси поглощал данные ENDBLK-секции (читал до следующего group=0).
После этого `GDBObjBlockdef.LoadFromDXF` пытался `ParseInteger`, но вместо
кода группы находил строку следующей сущности — отсюда исключение.

Аналогичная проблема возникала бы с `gotodxf`: если бы `FindOrProxyEntInfo`
вернул False для `ENDBLK` и была бы вызвана `gotodxf`, данные тоже были бы
поглощены.

## Исправление

В `addentitiesfromdxf` добавлена проверка `s <> exitString` в двух местах:

1. **Перед `FindOrProxyEntInfo`** — структурные маркеры DXF (`ENDBLK`, `ENDSEC`)
   не загружаются как сущности (ни как зарегистрированные, ни как proxy).

2. **Перед `gotodxf`** — данные exitString не пропускаются, они остаются
   в потоке для `GDBObjBlockdef.LoadFromDXF`.

Логика цикла: когда `s = exitString`, цикл завершится сам на следующей
проверке условия. Данные после exitString должны быть доступны для
`GDBObjBlockdef.LoadFromDXF`.

## Результат

- Файлы **без proxy-графики** загружаются корректно (ошибка ParseInteger устранена)
- Файлы **с proxy-графикой** (`SPDSPOLYMORPHMARK` и др.) по-прежнему загружаются
  как `GDBObjAcdProxy` и отображаются в виде ограничивающей рамки
- `HATCH`-объекты по-прежнему корректно пропускаются через `gotodxf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)