### PR TITLE
loaderDWG: optimize repeated DWG ref resolution

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-19T20:39:17.137Z for PR creation at branch issue-1234-9fb03804d45b for issue https://github.com/veb86/zcadvelecAI/issues/1234

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-19T20:39:17.137Z for PR creation at branch issue-1234-9fb03804d45b for issue https://github.com/veb86/zcadvelecAI/issues/1234

--- a/cad_source/zengine/fileformats/DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md
+++ b/cad_source/zengine/fileformats/DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md
@@ -34,6 +34,21 @@ DWG timing: phase=dwg-import.resolve-owners elapsed_ms=39425 pending_owners=6808
 
 Для 68081 owner-записи это примерно `4 635 090 642` проверок в среднем.
 
+## Статус после issue #1234
+
+Ветка `issue-1234-9fb03804d45b` продолжает этот план после уже внесенного
+контекстного attach-callback пути:
+
+- P3 реализован для ссылок: `TDWGZCADResolver` хранит per-import cache по
+  `(Slot, ExpectedKind, InlineRef, Fallback, RefCandidates)` и повторно
+  использует найденный pointer/resolved handle для следующих entity refs.
+- P2 частично закрыт для горячего attach-пути: массовые успешные
+  `DWG [attach]`, `DWG [attach-ref]` и layer-linetype info строки теперь
+  выключены быстрым флагом `DWG_VERBOSE_ATTACH_LOG`; targeted и fallback
+  diagnostics остаются включенными.
+- P6 расширен счетчиками `ref_cache_hits`, `ref_cache_misses`,
+  `unique_ref_keys` в timing detail, resolve-summary и diagnostic side-files.
+
 ## Что происходит внутри `dwg-import.resolve-refs`
 
 1. `EndDWGImport` запускает таймер `dwg-import.resolve-refs` и вызывает

--- a/cad_source/zengine/fileformats/dwg/tests/uzedwgtestloadcontext.pas
+++ b/cad_source/zengine/fileformats/dwg/tests/uzedwgtestloadcontext.pas
@@ -56,6 +56,7 @@ type
     procedure MissingLayerHandleFallsBackToSystemLayer;
     procedure LineTypeKindMismatchFallsBackToByLayer;
     procedure AlternateLayerHandleResolvesAfterPrimaryKindMismatch;
+    procedure RepeatedAlternateLayerRefsUseResolverCache;
     procedure ResolveRefsIsIdempotent;
     procedure SecondQueueForSameSlotReplacesFirst;
     procedure LayerLineTypeUsesLayerSlot;
@@ -1143,6 +1144,63 @@ begin
     AssertEquals(PtrInt(Layer), PtrInt(Pending^.AttachedRef));
     AssertEquals(1, Ctx.RefAttachCount);
     AssertEquals(0, Ctx.RefFallbackCount);
+    AssertEquals(0, Ctx.WarningCount);
+  finally
+    Ctx.Free;
+  end;
+end;
+
+procedure TDWGLoadContextRefTest.RepeatedAlternateLayerRefsUseResolverCache;
+var
+  Ctx: TDWGZCADLoadContext;
+  PendingA, PendingB: PDWGZCADPendingRef;
+  Recorder: TFakeRefRecorder;
+  EntityA, EntityB, WrongLineType, Layer, SysLayer: Pointer;
+  Handles: array[0..1] of TDWGZCADHandle;
+begin
+  // Issue #1234 / P3: large drawings repeat the same layer/linetype/style
+  // targets thousands of times. Resolve the first unique candidate set once,
+  // then reuse the pointer and the alternate handle selected after the primary
+  // kind mismatch for subsequent entities.
+  Ctx := TDWGZCADLoadContext.Create;
+  try
+    EntityA := MakePtr($E41);
+    EntityB := MakePtr($E42);
+    WrongLineType := MakePtr($A42);
+    Layer := MakePtr($A43);
+    SysLayer := MakePtr($5A);
+    Handles[0] := $100B;
+    Handles[1] := $9D67;
+    SetLength(Recorder.Calls, 0);
+    Ctx.SetRefAttachProc(@FakeRefAttach, @Recorder);
+    Ctx.SetFallbackLayer(SysLayer);
+    Ctx.RegisterShell($1041, dokEntity, EntityA, 0);
+    Ctx.RegisterShell($1042, dokEntity, EntityB, 1);
+    Ctx.RegisterShell($100B, dokLineType, WrongLineType, 2);
+    Ctx.RegisterShell($9D67, dokLayer, Layer, 3);
+    Ctx.QueueRefResolveCandidates(EntityA, $1041, Handles, 2,
+      dokLayer, rsLayer, nil);
+    Ctx.QueueRefResolveCandidates(EntityB, $1042, Handles, 2,
+      dokLayer, rsLayer, nil);
+
+    Ctx.ResolveRefs;
+
+    PendingA := Ctx.FindPendingRef($1041, rsLayer);
+    PendingB := Ctx.FindPendingRef($1042, rsLayer);
+    AssertNotNull(PendingA);
+    AssertNotNull(PendingB);
+    AssertEquals(Ord(asAttached), Ord(PendingA^.AttachState));
+    AssertEquals(Ord(asAttached), Ord(PendingB^.AttachState));
+    AssertEquals(Int64($9D67), Int64(PendingA^.RefHandle));
+    AssertEquals(Int64($9D67), Int64(PendingB^.RefHandle));
+    AssertEquals(PtrInt(Layer), PtrInt(PendingA^.AttachedRef));
+    AssertEquals(PtrInt(Layer), PtrInt(PendingB^.AttachedRef));
+    AssertEquals(2, Length(Recorder.Calls));
+    AssertEquals(2, Ctx.RefAttachCount);
+    AssertEquals(0, Ctx.RefFallbackCount);
+    AssertEquals(1, Ctx.RefCacheMisses);
+    AssertEquals(1, Ctx.RefCacheHits);
+    AssertEquals(1, Ctx.RefCacheKeys);
     AssertEquals(0, Ctx.WarningCount);
   finally
     Ctx.Free;
@@ -2286,6 +2344,8 @@ begin
     DWGWriteSummaryTxt(Ctx, TempPath('.dwg'), Path);
     Text := ReadAllText(Path);
     AssertTrue('handles_total line', Pos('handles_total: 1', Text) > 0);
+    AssertTrue('ref cache line', Pos('ref_cache_hits: 0', Text) > 0);
+    AssertTrue('unique refs line', Pos('unique_ref_keys: 0', Text) > 0);
     AssertTrue('1410 reported', Pos('1410 (ref kind mismatch)', Text) > 0);
     AssertTrue('1402 reported', Pos('1402 (owner not found)', Text) > 0);
     AssertTrue('kind histogram', Pos('dokEntity: 1', Text) > 0);
@@ -2311,6 +2371,8 @@ begin
       hooks exist so a downstream script can do its own structured read. }
     AssertTrue('top brace',  Pos('{', Text) > 0);
     AssertTrue('file key',   Pos('"file":', Text) > 0);
+    AssertTrue('cache hits', Pos('"ref_cache_hits": 0', Text) > 0);
+    AssertTrue('cache keys', Pos('"unique_ref_keys": 0', Text) > 0);
     AssertTrue('kinds key',  Pos('"kinds":', Text) > 0);
     AssertTrue('warnings',   Pos('"warnings":', Text) > 0);
     AssertTrue('1410 entry', Pos('"1410": 1', Text) > 0);
@@ -3419,6 +3481,8 @@ begin
   TargetedLogParseTargetList(DWG_TARGET_HANDLE_LIST, Target);
   AssertEquals('targeted handle constant is empty by default',
     0, Target.Count);
+  AssertFalse('verbose attach logging disabled by default',
+    DWG_VERBOSE_ATTACH_LOG);
 
   TargetedLogClear;
   TargetedLogRefresh;

--- a/cad_source/zengine/fileformats/dwg/uzedwgdiagnostics.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgdiagnostics.pas
@@ -116,6 +116,9 @@ type
     CycleCount: Integer;
     RefAttachCount: Integer;
     RefFallbackCount: Integer;
+    RefCacheHits: Integer;
+    RefCacheMisses: Integer;
+    RefCacheKeys: Integer;
     UnknownEntities: Integer;
     UnknownObjects: Integer;
     ProxiesLoaded: Integer;
@@ -396,6 +399,9 @@ begin
   CycleCount := 0;
   RefAttachCount := 0;
   RefFallbackCount := 0;
+  RefCacheHits := 0;
+  RefCacheMisses := 0;
+  RefCacheKeys := 0;
   UnknownEntities := 0;
   UnknownObjects := 0;
   ProxiesLoaded := 0;

--- a/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
@@ -530,11 +530,13 @@ begin
   EntityHandle := Context.EntityHandle;
   OwnerHandle := Context.TargetHandle;
   Reason := Context.Reason;
-  DWGLogInfoFormatStr(
-    'DWG [attach] entity=%s owner=%s entity_ptr=%p owner_ptr=%p reason=%s fallback=%s owner_is_insert=%s',
-    [DWGHandleLogText(EntityHandle), DWGHandleLogText(OwnerHandle), Entity,
-     Owner, DWGAttachReasonToText(Reason), BoolToStr(Reason <> arResolved, True),
-     BoolToStr(DWGPointerHasKind(Owner, dokBlockInsert), True)]);
+  if DWG_VERBOSE_ATTACH_LOG then
+    DWGLogInfoFormatStr(
+      'DWG [attach] entity=%s owner=%s entity_ptr=%p owner_ptr=%p reason=%s fallback=%s owner_is_insert=%s',
+      [DWGHandleLogText(EntityHandle), DWGHandleLogText(OwnerHandle), Entity,
+       Owner, DWGAttachReasonToText(Reason),
+       BoolToStr(Reason <> arResolved, True),
+       BoolToStr(DWGPointerHasKind(Owner, dokBlockInsert), True)]);
 
   // Issue #1203: точечный лог факта присоединения сущности к владельцу.
   // Срабатывает, когда целевой handle добрался до фазы attach (т.е. shell
@@ -640,11 +642,12 @@ begin
   EntityHandle := Context.EntityHandle;
   RefHandle := Context.TargetHandle;
   Reason := Context.Reason;
-  DWGLogInfoFormatStr(
-    'DWG [attach-ref] entity=%s ref=%s slot=%s entity_ptr=%p ref_ptr=%p reason=%s fallback=%s',
-    [DWGHandleLogText(EntityHandle), DWGHandleLogText(RefHandle),
-     DWGRefSlotToLogText(Slot), Entity, Ref, DWGAttachReasonToText(Reason),
-     BoolToStr(Reason <> arResolved, True)]);
+  if DWG_VERBOSE_ATTACH_LOG then
+    DWGLogInfoFormatStr(
+      'DWG [attach-ref] entity=%s ref=%s slot=%s entity_ptr=%p ref_ptr=%p reason=%s fallback=%s',
+      [DWGHandleLogText(EntityHandle), DWGHandleLogText(RefHandle),
+       DWGRefSlotToLogText(Slot), Entity, Ref, DWGAttachReasonToText(Reason),
+       BoolToStr(Reason <> arResolved, True)]);
   // Issue #1203: точечный лог разрешения ссылки. Полезен, чтобы понять,
   // на какой слот (layer/linetype/textstyle/dimstyle/blockdef) ушёл
   // fallback и в каком состоянии (Reason).
@@ -696,7 +699,7 @@ begin
                DWGAttachReasonToText(Reason),
                DWGLTypeNameForLog(PGDBLtypeProp(Ref))]);
         end
-        else
+        else if DWG_VERBOSE_ATTACH_LOG then
           DWGLogInfoFormatStr('layer %s %s linetype -> %s',
             [DWGLayerNameForLog(player), DWGRefContextForLog(Context),
              DWGLTypeNameForLog(PGDBLtypeProp(Ref))]);
@@ -1060,9 +1063,10 @@ begin
       LoadCtx.ResolveRefs;
     finally
       DWGFinishTimer(PhaseTimer, 'dwg-import.resolve-refs',
-        Format('pending_refs=%d refs_attached=%d refs_fallback=%d',
+        Format('pending_refs=%d refs_attached=%d refs_fallback=%d ref_cache_hits=%d ref_cache_misses=%d unique_ref_keys=%d',
           [LoadCtx.PendingRefs.Count, LoadCtx.RefAttachCount,
-           LoadCtx.RefFallbackCount]));
+           LoadCtx.RefFallbackCount, LoadCtx.RefCacheHits,
+           LoadCtx.RefCacheMisses, LoadCtx.RefCacheKeys]));
     end;
 
     PhaseTimer := TTimeMeter.StartMeasure;
@@ -1094,10 +1098,11 @@ begin
     PhaseTimer := TTimeMeter.StartMeasure;
     try
       DWGLogInfoFormatStr(
-        'DWG [resolve-summary] handles=%d pending_owners=%d pending_refs=%d attached=%d fallback=%d cycles=%d refs_attached=%d refs_fallback=%d proxy_loaded=%d proxy_failed=%d unknown_entities=%d unknown_objects=%d freed_raw_drops=%d warnings=%d',
+        'DWG [resolve-summary] handles=%d pending_owners=%d pending_refs=%d attached=%d fallback=%d cycles=%d refs_attached=%d refs_fallback=%d ref_cache_hits=%d ref_cache_misses=%d unique_ref_keys=%d proxy_loaded=%d proxy_failed=%d unknown_entities=%d unknown_objects=%d freed_raw_drops=%d warnings=%d',
         [LoadCtx.Handles.Count, LoadCtx.PendingOwners.Count,
          LoadCtx.PendingRefs.Count, LoadCtx.AttachCount, LoadCtx.FallbackCount,
          LoadCtx.CycleCount, LoadCtx.RefAttachCount, LoadCtx.RefFallbackCount,
+         LoadCtx.RefCacheHits, LoadCtx.RefCacheMisses, LoadCtx.RefCacheKeys,
          LoadCtx.ProxiesLoaded, LoadCtx.ProxiesFailed, LoadCtx.UnknownEntities,
          LoadCtx.UnknownObjects, LoadCtx.DroppedDueToFreedRaw,
          LoadCtx.WarningCount]);

--- a/cad_source/zengine/fileformats/dwg/uzedwgloadcontext.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgloadcontext.pas
@@ -261,6 +261,9 @@ type
     property CycleCount: Integer read FStats.CycleCount;
     property RefAttachCount: Integer read FStats.RefAttachCount;
     property RefFallbackCount: Integer read FStats.RefFallbackCount;
+    property RefCacheHits: Integer read FStats.RefCacheHits;
+    property RefCacheMisses: Integer read FStats.RefCacheMisses;
+    property RefCacheKeys: Integer read FStats.RefCacheKeys;
     property UnknownEntities: Integer read FStats.UnknownEntities;
     property UnknownObjects: Integer read FStats.UnknownObjects;
     property ProxiesLoaded: Integer read FStats.ProxiesLoaded;

--- a/cad_source/zengine/fileformats/dwg/uzedwglog.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwglog.pas
@@ -20,6 +20,13 @@ uses
   uzbLogTypes,
   uzedwgtypes;
 
+const
+  { High-volume resolved attach traces are diagnostic-only. Keep disabled for
+    normal imports so resolving 100k+ refs/owners does not spend time
+    formatting per-entity info lines. Targeted and fallback diagnostics remain
+    active through their dedicated gates. }
+  DWG_VERBOSE_ATTACH_LOG = False;
+
 var
   { Dedicated DWG loader diagnostics module. It is registered without
     EEnable, so normal imports stay quiet unless the user enables it with

--- a/cad_source/zengine/fileformats/dwg/uzedwgresolver.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgresolver.pas
@@ -51,6 +51,30 @@ type
     function GetStatsRef: PDWGImportStats; virtual; abstract;
   end;
 
+  TDWGRefResolveCacheKey = record
+    Slot: TDWGZCADRefSlot;
+    ExpectedKind: TDWGZCADObjectKind;
+    InlineRef: Boolean;
+    Fallback: Pointer;
+    RefCount: Integer;
+    RefHandles: array[0..DWG_ZCAD_MAX_REF_HANDLE_CANDIDATES - 1]
+      of TDWGZCADHandle;
+  end;
+
+  TDWGRefResolveCacheValue = record
+    Ref: Pointer;
+    RefHandle: TDWGZCADHandle;
+    State: TDWGAttachState;
+    Reason: TDWGAttachReason;
+  end;
+
+  TDWGRefResolveCacheEntry = record
+    Used: Boolean;
+    Hash: QWord;
+    Key: TDWGRefResolveCacheKey;
+    Value: TDWGRefResolveCacheValue;
+  end;
+
   { Stand-alone resolver state. Holds only the cycle-detection stack so a
     second concurrent resolver (e.g. a future raw-scan pre-resolver) can
     coexist with the main load context. The host supplies pending lookup
@@ -59,9 +83,20 @@ type
   private
     FHost: TDWGResolverHost;
     FResolveStack: array of TDWGZCADHandle;
+    FRefCache: array of TDWGRefResolveCacheEntry;
+    FRefCacheCount: Integer;
     procedure PushStack(Handle: TDWGZCADHandle);
     procedure PopStack;
     function StackContains(Handle: TDWGZCADHandle): Boolean;
+    function RefCacheHash(const Key: TDWGRefResolveCacheKey): QWord;
+    function RefCacheKeysEqual(const A, B: TDWGRefResolveCacheKey): Boolean;
+    procedure EnsureRefCacheCapacity;
+    procedure InsertRefCacheEntry(const Key: TDWGRefResolveCacheKey;
+      Hash: QWord; const Value: TDWGRefResolveCacheValue);
+    function TryGetRefCache(const Key: TDWGRefResolveCacheKey;
+      out Value: TDWGRefResolveCacheValue): Boolean;
+    procedure StoreRefCache(const Key: TDWGRefResolveCacheKey;
+      const Value: TDWGRefResolveCacheValue);
     procedure FinishOwner(Pending: PDWGZCADPendingOwner; Owner: Pointer;
       State: TDWGAttachState; Reason: TDWGAttachReason);
     procedure FinishRef(Pending: PDWGZCADPendingRef; Ref: Pointer;
@@ -106,6 +141,145 @@ end;
 procedure TDWGZCADResolver.ResetStack;
 begin
   SetLength(FResolveStack, 0);
+end;
+
+function TDWGZCADResolver.RefCacheHash(
+  const Key: TDWGRefResolveCacheKey): QWord;
+var
+  I: Integer;
+
+  procedure Mix(Value: QWord);
+  begin
+    Result := ((Result shl 7) or (Result shr 57)) xor Value
+      xor QWord($9E3779B9);
+  end;
+begin
+  Result := QWord(Ord(Key.Slot)) + 1;
+  Mix(QWord(Ord(Key.ExpectedKind)));
+  if Key.InlineRef then
+    Mix(1)
+  else
+    Mix(0);
+  Mix(QWord(PtrUInt(Key.Fallback)));
+  Mix(QWord(Key.RefCount));
+  for I := 0 to High(Key.RefHandles) do
+    Mix(Key.RefHandles[I]);
+  if Result = 0 then
+    Result := 1;
+end;
+
+function TDWGZCADResolver.RefCacheKeysEqual(
+  const A, B: TDWGRefResolveCacheKey): Boolean;
+var
+  I: Integer;
+begin
+  Result := (A.Slot = B.Slot)
+    and (A.ExpectedKind = B.ExpectedKind)
+    and (A.InlineRef = B.InlineRef)
+    and (A.Fallback = B.Fallback)
+    and (A.RefCount = B.RefCount);
+  if not Result then
+    Exit;
+  for I := 0 to High(A.RefHandles) do
+    if A.RefHandles[I] <> B.RefHandles[I] then
+      Exit(False);
+end;
+
+procedure TDWGZCADResolver.EnsureRefCacheCapacity;
+var
+  OldCache: array of TDWGRefResolveCacheEntry;
+  I, NewCapacity: Integer;
+begin
+  if Length(FRefCache) = 0 then
+  begin
+    SetLength(FRefCache, 256);
+    Exit;
+  end;
+  if (FRefCacheCount + 1) * 10 < Length(FRefCache) * 7 then
+    Exit;
+
+  OldCache := FRefCache;
+  NewCapacity := Length(FRefCache) * 2;
+  SetLength(FRefCache, 0);
+  SetLength(FRefCache, NewCapacity);
+  FRefCacheCount := 0;
+  for I := 0 to High(OldCache) do
+    if OldCache[I].Used then
+      InsertRefCacheEntry(OldCache[I].Key, OldCache[I].Hash,
+        OldCache[I].Value);
+end;
+
+procedure TDWGZCADResolver.InsertRefCacheEntry(
+  const Key: TDWGRefResolveCacheKey; Hash: QWord;
+  const Value: TDWGRefResolveCacheValue);
+var
+  Index, Mask: Integer;
+begin
+  Mask := Length(FRefCache) - 1;
+  Index := Integer(Hash and QWord(Mask));
+  while FRefCache[Index].Used do
+    Index := (Index + 1) and Mask;
+  FRefCache[Index].Used := True;
+  FRefCache[Index].Hash := Hash;
+  FRefCache[Index].Key := Key;
+  FRefCache[Index].Value := Value;
+  Inc(FRefCacheCount);
+end;
+
+function TDWGZCADResolver.TryGetRefCache(
+  const Key: TDWGRefResolveCacheKey;
+  out Value: TDWGRefResolveCacheValue): Boolean;
+var
+  Hash: QWord;
+  Index, Mask: Integer;
+begin
+  Result := False;
+  if Length(FRefCache) = 0 then
+    Exit;
+  Hash := RefCacheHash(Key);
+  Mask := Length(FRefCache) - 1;
+  Index := Integer(Hash and QWord(Mask));
+  while FRefCache[Index].Used do
+  begin
+    if (FRefCache[Index].Hash = Hash)
+      and RefCacheKeysEqual(FRefCache[Index].Key, Key) then
+    begin
+      Value := FRefCache[Index].Value;
+      Exit(True);
+    end;
+    Index := (Index + 1) and Mask;
+  end;
+end;
+
+procedure TDWGZCADResolver.StoreRefCache(
+  const Key: TDWGRefResolveCacheKey;
+  const Value: TDWGRefResolveCacheValue);
+var
+  Hash: QWord;
+  Index, Mask: Integer;
+  Stats: PDWGImportStats;
+begin
+  EnsureRefCacheCapacity;
+  Hash := RefCacheHash(Key);
+  Mask := Length(FRefCache) - 1;
+  Index := Integer(Hash and QWord(Mask));
+  while FRefCache[Index].Used do
+  begin
+    if (FRefCache[Index].Hash = Hash)
+      and RefCacheKeysEqual(FRefCache[Index].Key, Key) then
+    begin
+      FRefCache[Index].Value := Value;
+      Exit;
+    end;
+    Index := (Index + 1) and Mask;
+  end;
+  FRefCache[Index].Used := True;
+  FRefCache[Index].Hash := Hash;
+  FRefCache[Index].Key := Key;
+  FRefCache[Index].Value := Value;
+  Inc(FRefCacheCount);
+  Stats := FHost.GetStatsRef;
+  Inc(Stats^.RefCacheKeys);
 end;
 
 procedure TDWGZCADResolver.FinishOwner(Pending: PDWGZCADPendingOwner;
@@ -351,6 +525,9 @@ var
   FailureHandle: TDWGZCADHandle;
   FailureText: String;
   HaveFailure: Boolean;
+  CacheKey: TDWGRefResolveCacheKey;
+  CacheValue: TDWGRefResolveCacheValue;
+  Stats: PDWGImportStats;
 
   procedure AddLocalCandidate(AHandle: TDWGZCADHandle);
   var
@@ -380,6 +557,29 @@ var
     FailureHandle := AHandle;
     FailureText := AText;
   end;
+
+  procedure BuildCacheKey;
+  var
+    J: Integer;
+  begin
+    FillChar(CacheKey, SizeOf(CacheKey), 0);
+    CacheKey.Slot := Pending^.Slot;
+    CacheKey.ExpectedKind := Pending^.ExpectedKind;
+    CacheKey.InlineRef := Pending^.InlineRef;
+    CacheKey.Fallback := Fallback;
+    CacheKey.RefCount := Candidates.Count;
+    for J := 0 to Candidates.Count - 1 do
+      CacheKey.RefHandles[J] := Candidates.Values[J];
+  end;
+
+  procedure StoreResolvedRef(ARef: Pointer; ARefHandle: TDWGZCADHandle);
+  begin
+    CacheValue.Ref := ARef;
+    CacheValue.RefHandle := ARefHandle;
+    CacheValue.State := asAttached;
+    CacheValue.Reason := arResolved;
+    StoreRefCache(CacheKey, CacheValue);
+  end;
 begin
   if Pending = nil then
     Exit;
@@ -392,17 +592,30 @@ begin
   if Fallback = nil then
     Fallback := FHost.FallbackForSlot(Pending^.Slot);
 
-  if Pending^.InlineRef and (Fallback <> nil) then
-  begin
-    FinishRef(Pending, Fallback, asAttached, arResolved);
-    Exit;
-  end;
-
   Candidates := Pending^.RefCandidates;
   if Candidates.Count > High(Candidates.Values) + 1 then
     Candidates.Count := High(Candidates.Values) + 1;
   if (Candidates.Count = 0) and (Pending^.RefHandle <> 0) then
     AddLocalCandidate(Pending^.RefHandle);
+  BuildCacheKey;
+
+  Stats := FHost.GetStatsRef;
+  if TryGetRefCache(CacheKey, CacheValue) then
+  begin
+    Inc(Stats^.RefCacheHits);
+    Pending^.RefHandle := CacheValue.RefHandle;
+    FinishRef(Pending, CacheValue.Ref, CacheValue.State,
+      CacheValue.Reason);
+    Exit;
+  end;
+  Inc(Stats^.RefCacheMisses);
+
+  if Pending^.InlineRef and (Fallback <> nil) then
+  begin
+    StoreResolvedRef(Fallback, Pending^.RefHandle);
+    FinishRef(Pending, Fallback, asAttached, arResolved);
+    Exit;
+  end;
 
   if Candidates.Count = 0 then
   begin
@@ -440,6 +653,7 @@ begin
              IntToHex(Pending^.EntityHandle, 1)]));
         Continue;
       end;
+      StoreResolvedRef(Entry.Ptr, Pending^.RefHandle);
       FinishRef(Pending, Entry.Ptr, asAttached, arResolved);
       Exit;
     end;
@@ -467,6 +681,7 @@ begin
       Continue;
     end;
 
+    StoreResolvedRef(Entry.Ptr, Pending^.RefHandle);
     FinishRef(Pending, Entry.Ptr, asAttached, arResolved);
     Exit;
   end;

--- a/cad_source/zengine/fileformats/dwg/uzedwgsidefiles.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgsidefiles.pas
@@ -578,6 +578,9 @@ begin
     Sink.WriteLine('cycles: ' + IntToStr(Ctx.CycleCount));
     Sink.WriteLine('refs_attached: ' + IntToStr(Ctx.RefAttachCount));
     Sink.WriteLine('refs_fallback: ' + IntToStr(Ctx.RefFallbackCount));
+    Sink.WriteLine('ref_cache_hits: ' + IntToStr(Ctx.RefCacheHits));
+    Sink.WriteLine('ref_cache_misses: ' + IntToStr(Ctx.RefCacheMisses));
+    Sink.WriteLine('unique_ref_keys: ' + IntToStr(Ctx.RefCacheKeys));
     Sink.WriteLine('unknown_entities: ' + IntToStr(Ctx.UnknownEntities));
     Sink.WriteLine('unknown_objects: ' + IntToStr(Ctx.UnknownObjects));
     Sink.WriteLine('proxies_loaded: ' + IntToStr(Ctx.ProxiesLoaded));
@@ -673,6 +676,9 @@ begin
     Sink.WriteRaw('  "cycles": ' + IntToStr(Ctx.CycleCount) + ',' + LineEnding);
     Sink.WriteRaw('  "refs_attached": ' + IntToStr(Ctx.RefAttachCount) + ',' + LineEnding);
     Sink.WriteRaw('  "refs_fallback": ' + IntToStr(Ctx.RefFallbackCount) + ',' + LineEnding);
+    Sink.WriteRaw('  "ref_cache_hits": ' + IntToStr(Ctx.RefCacheHits) + ',' + LineEnding);
+    Sink.WriteRaw('  "ref_cache_misses": ' + IntToStr(Ctx.RefCacheMisses) + ',' + LineEnding);
+    Sink.WriteRaw('  "unique_ref_keys": ' + IntToStr(Ctx.RefCacheKeys) + ',' + LineEnding);
     Sink.WriteRaw('  "unknown_entities": ' + IntToStr(Ctx.UnknownEntities) + ',' + LineEnding);
     Sink.WriteRaw('  "unknown_objects": ' + IntToStr(Ctx.UnknownObjects) + ',' + LineEnding);
     Sink.WriteRaw('  "warnings_total": ' + IntToStr(Ctx.WarningCount) + ',' + LineEnding);


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1234

## What changed
- Added a per-import DWG ref-resolution cache keyed by slot, expected kind, inline flag, fallback pointer, and candidate handles. Repeated layer/linetype/style/block refs reuse the resolved pointer and resolved handle instead of repeating handle-map lookups.
- Gated high-volume successful attach info traces behind `DWG_VERBOSE_ATTACH_LOG`, while preserving targeted logs and fallback diagnostics.
- Added `ref_cache_hits`, `ref_cache_misses`, and `unique_ref_keys` to timing details, resolve-summary output, and diagnostic side-files.
- Documented the issue #1234 status in `DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md`.

## Tests
- `git diff --check` passed.
- Added regression coverage in `uzedwgtestloadcontext.pas` for repeated alternate ref candidates using the resolver cache, plus side-file assertions for the new counters.
- `make tests` was attempted, but this prepared environment cannot run it: `fpc` and `lazbuild` are missing, and `cad_source/components/zcontainers/tests` is absent. The saved log is `/tmp/issue-1234-make-tests.log`.