### PR TITLE
loaderDWG: optimize DWG owner tree rebuild

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T05:28:56.543Z for PR creation at branch issue-1234-d675170828a9 for issue https://github.com/veb86/zcadvelecAI/issues/1234

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T05:28:56.543Z for PR creation at branch issue-1234-d675170828a9 for issue https://github.com/veb86/zcadvelecAI/issues/1234

--- a/cad_source/zengine/containers/UGDBVisibleTreeArray.pas
+++ b/cad_source/zengine/containers/UGDBVisibleTreeArray.pas
@@ -32,6 +32,7 @@ GDBObjEntityTreeArray= object(GDBObjEntityOpenArray)
                             procedure done;virtual;
                             procedure free;virtual;
                             function AddPEntity(var entity:GDBObjEntity):TArrayIndex;virtual;
+                            function AddPEntityToArrayOnly(var entity:GDBObjEntity):TArrayIndex;virtual;
                             procedure RemoveFromTree(p:PGDBObjEntity);
 
                       end;
@@ -65,6 +66,12 @@ begin
   ObjTree.AddObjectToNodeTree(PGDBObjEntity(p^));}
   //result:=inherited PushBackPointerToEntity({ppointer(p)^}@entity);
   //{pGDBObjEntity(p^)}entity.bp.ListPos.SelfIndex:=result;
+end;
+function GDBObjEntityTreeArray.AddPEntityToArrayOnly;
+begin
+  result:=inherited AddPEntity(entity);
+  entity.bp.TreePos.Owner:=nil;
+  entity.bp.TreePos.SelfIndexInNode:=-1;
 end;
 constructor GDBObjEntityTreeArray.init;
 begin

--- a/cad_source/zengine/core/entities/uzeentgenericsubentry.pas
+++ b/cad_source/zengine/core/entities/uzeentgenericsubentry.pas
@@ -86,6 +86,7 @@ type
       var drawing:TDrawingDef);virtual;
     //** Добавляет объект в область ConstructObjRoot или mainObjRoot или итд. Пример добавления gdb.GetCurrentDWG^.ConstructObjRoot.AddMi(@sampleObj);
     procedure AddMi(var pobj:PGDBObjSubordinated);virtual;
+    procedure AddMiToArrayOnly(var pobj:PGDBObjSubordinated);virtual;
     procedure ImEdited(pobj:PGDBObjSubordinated;
       pobjinarray:integer;var drawing:TDrawingDef);virtual;
     function ReturnLastOnMouse(InSubEntry:boolean):PGDBObjEntity;
@@ -431,6 +432,14 @@ end;
 procedure GDBObjGenericSubEntry.AddMi;
 begin
   ObjArray.AddPEntity(pGDBObjEntity(pobj)^);
+  pGDBObjEntity(pobj)^.bp.ListPos.Owner:=@self;
+  if assigned(pGDBObjEntity(pobj)^.EntExtensions) then
+    pGDBObjEntity(pobj)^.EntExtensions.RunSetRoot(pobj,@self);
+end;
+
+procedure GDBObjGenericSubEntry.AddMiToArrayOnly;
+begin
+  ObjArray.AddPEntityToArrayOnly(pGDBObjEntity(pobj)^);
   pGDBObjEntity(pobj)^.bp.ListPos.Owner:=@self;
   if assigned(pGDBObjEntity(pobj)^.EntExtensions) then
     pGDBObjEntity(pobj)^.EntExtensions.RunSetRoot(pobj,@self);

--- a/cad_source/zengine/fileformats/DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md
+++ b/cad_source/zengine/fileformats/DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md
@@ -279,3 +279,25 @@ DWG timing: phase=dwg-import.resolve-owners elapsed_ms=... pending_owners=68081 
    реальные замеры после P1-P3 покажут заметный остаточный вклад.
 5. **P6**: оставить счетчики в timing summary, чтобы следующие оптимизации
    проверялись цифрами, а не только субъективным временем загрузки.
+
+## Статус после PR #1237
+
+После P1/P3/P5 `dwg-import.resolve-refs` перестал быть bottleneck'ом
+(`unique_ref_keys` показывает, что повторяющиеся ссылки обслуживаются cache).
+Оставшийся замер issue #1234 показал, что `dwg-import.resolve-owners`
+тратит основное время уже не на поиск owner-а, а на `AddMi`:
+каждая из десятков тысяч owner-attach операций сразу вставляла entity в
+`ObjTree`, хотя DWG load потом все равно выполняет отдельные tree rebuild
+фазы.
+
+PR #1237 переносит эту работу из hot path:
+
+1. `GDBObjEntityTreeArray.AddPEntityToArrayOnly` добавляет entity в `ObjArray`
+   и обновляет `ListPos`, но не делает `ObjTree.AddObjectToNodeTree`.
+2. `GDBObjGenericSubEntry.AddMiToArrayOnly` сохраняет семантику owner/root
+   metadata и `EntExtensions.RunSetRoot`.
+3. `DWGAttachEntityWithContext` использует array-only attach во время
+   `ResolveOwners`.
+4. `EndDWGImport` после `FinalizeImport` выполняет один
+   `dwg-import.rebuild-owner-trees` pass по root и block definitions, чтобы
+   standalone loader callers не оставались с пустыми spatial trees.

--- a/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
@@ -564,7 +564,10 @@ begin
 
   newowner := PGDBObjGenericSubEntry(Owner);
 
-  newowner^.AddMi(PGDBObjSubordinated(pobj));
+  // DWG owner resolution is a bulk-load phase. Keep the entity list and
+  // owner metadata current here, then rebuild spatial trees once after
+  // finalization instead of updating the tree for every pending owner.
+  newowner^.AddMiToArrayOnly(PGDBObjSubordinated(pobj));
   if (Reason <> arResolved) and
      DWGShouldEmitFallbackDetail(Reason, EntityHandle) then
     DWGLogWarningFormatStr('entity %s attached via fallback (%s)',
@@ -1045,6 +1048,39 @@ begin
   end;
 end;
 
+procedure DWGRebuildOwnerTrees(Drawing: PTSimpleDrawing);
+var
+  I: Integer;
+  RootEntities, BlockDefEntities, RebuiltBlockDefs: Integer;
+  BlockDef: PGDBObjBlockdef;
+begin
+  if Drawing = nil then
+    Exit;
+
+  RootEntities := 0;
+  BlockDefEntities := 0;
+  RebuiltBlockDefs := 0;
+  if Drawing^.pObjRoot <> nil then begin
+    RootEntities := Drawing^.pObjRoot^.ObjArray.Count;
+    Drawing^.pObjRoot^.ObjArray.ObjTree.MakeTreeFrom(
+      Drawing^.pObjRoot^.ObjArray, Drawing^.pObjRoot^.vp.BoundingBox, nil);
+  end;
+
+  for I := 0 to Drawing^.BlockDefArray.Count - 1 do begin
+    BlockDef := PGDBObjBlockdef(Drawing^.BlockDefArray.getDataMutable(I));
+    if BlockDef = nil then
+      Continue;
+    Inc(RebuiltBlockDefs);
+    Inc(BlockDefEntities, BlockDef^.ObjArray.Count);
+    BlockDef^.ObjArray.ObjTree.MakeTreeFrom(
+      BlockDef^.ObjArray, BlockDef^.vp.BoundingBox, nil);
+  end;
+
+  DWGLogInfoFormatStr(
+    'DWG owner trees rebuilt: root_entities=%d blockdefs=%d blockdef_entities=%d',
+    [RootEntities, RebuiltBlockDefs, BlockDefEntities]);
+end;
+
 procedure EndDWGImport(var ZContext: TZDrawingContext);
 var
   TotalTimer, PhaseTimer: TTimeMeter;
@@ -1129,6 +1165,14 @@ begin
       FinalizeImport(LoadCtx, ZContext.PDrawing, ZContext.DC);
     finally
       DWGFinishTimer(PhaseTimer, 'dwg-import.finalize',
+        Format('handles=%d', [LoadCtx.Handles.Count]));
+    end;
+
+    PhaseTimer := TTimeMeter.StartMeasure;
+    try
+      DWGRebuildOwnerTrees(ZContext.PDrawing);
+    finally
+      DWGFinishTimer(PhaseTimer, 'dwg-import.rebuild-owner-trees',
         Format('handles=%d', [LoadCtx.Handles.Count]));
     end;
   finally


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1234

## Summary

- Optimizes the remaining `dwg-import.resolve-owners` hot path by avoiding per-owner incremental `ObjTree.AddObjectToNodeTree` calls during bulk DWG owner attachment.
- Adds an array-only entity attach path that preserves `ObjArray`, `ListPos`, and `EntExtensions.RunSetRoot` semantics.
- Rebuilds DWG owner spatial trees once after `FinalizeImport` and logs the new `dwg-import.rebuild-owner-trees` timing phase.
- Updates `DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md` with the post-PR #1237 status.

## Reproduction Context

The latest issue log after PR #1236 showed `dwg-import.resolve-refs` down to about `25ms`, while `dwg-import.resolve-owners` still took about `10391ms` for `pending_owners=68081`. The remaining work was no longer handle lookup; it was repeated `AddMi -> ObjTree.AddObjectToNodeTree` work during owner attach.

## Verification

- `git -c core.whitespace=cr-at-eol diff --check` passed.
- `make checkvars` completed; it still prints existing environment warnings about missing git tags and `~/.lazarus/packagefiles.xml`.
- `make tests` could not run in this checkout because `cad_source/components/zcontainers/tests` is missing.
- `make -C cad_source/zengine/tests clean all` could not compile because `/home/box/lazarus/lazbuild` is not installed.
- `cd cad_source/components/fpdwg/inspector/tests && fpc -Fu.. -Fu../.. -Fu../model -Fu../mappers fpdwg_tests.lpr` could not compile because `fpc` is not installed.
