### PR TITLE
Optimize DWG owner attach kind lookup

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T07:03:51.814Z for PR creation at branch issue-1234-22f080c54a44 for issue https://github.com/veb86/zcadvelecAI/issues/1234

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T07:03:51.814Z for PR creation at branch issue-1234-22f080c54a44 for issue https://github.com/veb86/zcadvelecAI/issues/1234

--- a/cad_source/zengine/fileformats/DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md
+++ b/cad_source/zengine/fileformats/DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md
@@ -301,3 +301,27 @@ PR #1237 переносит эту работу из hot path:
 4. `EndDWGImport` после `FinalizeImport` выполняет один
    `dwg-import.rebuild-owner-trees` pass по root и block definitions, чтобы
    standalone loader callers не оставались с пустыми spatial trees.
+
+## Статус после PR #1238
+
+Новый замер из issue #1234 после PR #1237 всё ещё показывал
+`dwg-import.resolve-owners` около 9.5-10.4 s. Повторный анализ нашёл ещё один
+остаточный `O(N^2)` участок в самом attach callback:
+
+- `DWGAttachEntityWithContext` на каждый owner attach вызывал
+  `DWGPointerHasKind(Owner, dokBlockInsert)`;
+- `DWGPointerHasKind` линейно обходил весь `LoadCtx.Handles`;
+- для 68081 owner attach и ~70391 handles это снова давало миллиарды
+  сравнений, хотя resolver уже передаёт точный `TargetHandle`.
+
+PR #1238 заменяет эту проверку на `DWGContextTargetHasKind`: lookup идёт через
+`Context.TargetHandle` и `TDWGZCADHandleMap.TryGet`, то есть через уже
+отсортированную handle-map. `DWGAttachEntityWithContext` вычисляет
+`owner_is_insert` один раз и переиспользует значение для verbose/targeted log
+и ветки deferred INSERT children. Та же замена применена к `rsBlockDef` в
+`DWGAttachRefWithContext`, чтобы block-ref attach не возвращал pointer-scan
+паттерн.
+
+Ожидаемый эффект: `dwg-import.resolve-owners` больше не должен зависеть от
+`pending_owners * handles`; оставшаяся работа становится линейной по
+`pending_owners` плюс `O(log handles)` для классификации target handle.

--- a/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
@@ -230,19 +230,17 @@ begin
     Result := LoadDrawing^.BlockDefArray.create(MissingBlockName);
 end;
 
-function DWGPointerHasKind(P: Pointer; Kind: TDWGZCADObjectKind): Boolean;
+function DWGContextTargetHasKind(P: Pointer;
+  const Context: TDWGAttachContext; Kind: TDWGZCADObjectKind): Boolean;
 var
-  I: Integer;
-  Entry: PDWGZCADHandleEntry;
+  Entry: TDWGZCADHandleEntry;
 begin
   Result := False;
   if (LoadCtx = nil) or (P = nil) then
     Exit;
-  for I := 0 to LoadCtx.Handles.Count - 1 do begin
-    Entry := LoadCtx.Handles.EntryAt(I);
-    if (Entry^.Ptr = P) and (Entry^.Kind = Kind) then
-      Exit(True);
-  end;
+  if not LoadCtx.Handles.TryGet(Context.TargetHandle, Entry) then
+    Exit;
+  Result := (Entry.Ptr = P) and (Entry.Kind = Kind);
 end;
 
 function DWGObjTypeIsDimension(ObjType: TObjID): Boolean;
@@ -520,6 +518,7 @@ var
   EntityHandle: QWord;
   OwnerHandle: QWord;
   Reason: TDWGAttachReason;
+  OwnerIsInsert: Boolean;
 begin
   // Reason is forwarded to the logger so unresolved fallbacks are visible to
   // human reviewers without a separate diagnostic pass.
@@ -530,13 +529,14 @@ begin
   EntityHandle := Context.EntityHandle;
   OwnerHandle := Context.TargetHandle;
   Reason := Context.Reason;
+  OwnerIsInsert := DWGContextTargetHasKind(Owner, Context, dokBlockInsert);
   if DWG_VERBOSE_ATTACH_LOG then
     DWGLogInfoFormatStr(
       'DWG [attach] entity=%s owner=%s entity_ptr=%p owner_ptr=%p reason=%s fallback=%s owner_is_insert=%s',
       [DWGHandleLogText(EntityHandle), DWGHandleLogText(OwnerHandle), Entity,
        Owner, DWGAttachReasonToText(Reason),
        BoolToStr(Reason <> arResolved, True),
-       BoolToStr(DWGPointerHasKind(Owner, dokBlockInsert), True)]);
+       BoolToStr(OwnerIsInsert, True)]);
 
   // Issue #1203: точечный лог факта присоединения сущности к владельцу.
   // Срабатывает, когда целевой handle добрался до фазы attach (т.е. shell
@@ -547,12 +547,12 @@ begin
     TargetedLog('attach', EntityHandle,
       Format('reason=%s owner_is_insert=%s',
         [DWGAttachReasonToText(Reason),
-         BoolToStr(DWGPointerHasKind(Owner, dokBlockInsert), True)]));
+         BoolToStr(OwnerIsInsert, True)]));
 
   // INSERT-owned ATTRIB entities are appended after the INSERT has built its
   // block geometry. Adding them now would be undone by BuildGeometry clearing
   // ConstObjArray from the block definition.
-  if DWGPointerHasKind(Owner, dokBlockInsert) then begin
+  if OwnerIsInsert then begin
     pobj^.bp.ListPos.Owner := PGDBObjEntity(Owner);
     if (Reason <> arResolved) and
        DWGShouldEmitFallbackDetail(Reason, EntityHandle) then
@@ -756,7 +756,8 @@ begin
           Exit;
         pInsert := PGDBObjBlockInsert(pobj);
         if (Ref <> nil) and
-          ((Reason <> arResolved) or DWGPointerHasKind(Ref, dokBlockDef)) then
+          ((Reason <> arResolved) or
+           DWGContextTargetHasKind(Ref, Context, dokBlockDef)) then
           pBlockDef := PGDBObjBlockdef(Ref)
         else begin
           pBlockDef := DWGEnsureFallbackBlockDef;

--- a/experiments/test_dwg_owner_attach_hot_path.py
+++ b/experiments/test_dwg_owner_attach_hot_path.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Regression checks for DWG owner attach hot-path lookups."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+IMPORT_SOURCE = ROOT / "cad_source/zengine/fileformats/dwg/uzedwgimport.pas"
+
+
+def read_import_source():
+    return IMPORT_SOURCE.read_text(encoding="utf-8")
+
+
+def extract_between(source, start_token, end_token):
+    start = source.index(start_token)
+    end = source.index(end_token, start + len(start_token))
+    return source[start:end]
+
+
+def test_owner_attach_uses_context_handle_lookup():
+    source = read_import_source()
+    attach_body = extract_between(
+        source,
+        "procedure DWGAttachEntityWithContext",
+        "procedure DWGAttachEntity(Entity",
+    )
+
+    assert "DWGContextTargetHasKind(Owner, Context, dokBlockInsert)" in attach_body
+    assert "DWGPointerHasKind(Owner, dokBlockInsert)" not in attach_body
+
+
+def test_context_kind_helper_uses_handle_map_not_pointer_scan():
+    source = read_import_source()
+    helper_body = extract_between(
+        source,
+        "function DWGContextTargetHasKind",
+        "function DWGObjTypeIsDimension",
+    )
+
+    assert "Context.TargetHandle" in helper_body
+    assert "LoadCtx.Handles.TryGet" in helper_body
+    assert "for I :=" not in helper_body
+    assert "function DWGPointerHasKind" not in source
+
+
+def test_block_ref_attach_uses_context_handle_lookup():
+    source = read_import_source()
+    ref_body = extract_between(
+        source,
+        "procedure DWGAttachRefWithContext",
+        "procedure DWGAttachRef(Entity",
+    )
+
+    assert "DWGContextTargetHasKind(Ref, Context, dokBlockDef)" in ref_body
+    assert "DWGPointerHasKind(Ref, dokBlockDef)" not in ref_body
+
+
+if __name__ == "__main__":
+    test_owner_attach_uses_context_handle_lookup()
+    test_context_kind_helper_uses_handle_map_not_pointer_scan()
+    test_block_ref_attach_uses_context_handle_lookup()
+    print("DWG owner attach hot-path checks passed")


### PR DESCRIPTION
## Summary
- Replace the remaining DWG owner/ref kind checks that scanned every registered handle with `Context.TargetHandle` lookups through `TDWGZCADHandleMap.TryGet`.
- Reuse the computed `owner_is_insert` value across attach logging and INSERT-child deferral.
- Document the post-#1237 bottleneck analysis in `DWG_RESOLVE_REFS_OPTIMIZATION_PLAN.md`.

## Reproduction
- Issue #1234 measurements after PR #1237 still showed `dwg-import.resolve-owners` at roughly 9.5-10.4 s with 68081 pending owners.
- The remaining hot path was `DWGAttachEntityWithContext` calling `DWGPointerHasKind(Owner, dokBlockInsert)` for every owner attach, which linearly scanned all registered handles.

## Tests
- `python3 experiments/test_dwg_owner_attach_hot_path.py`
- `python3 experiments/test_dwg_timing_instrumentation.py`
- `git diff --check`

Pascal compile/build was not run locally because `fpc` and `lazbuild` are not installed in this environment.


Fixes veb86/zcadvelecAI#1234