### PR TITLE
Fix DWG layer off state import

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T08:00:10.031Z for PR creation at branch issue-1239-12f648312661 for issue https://github.com/veb86/zcadvelecAI/issues/1239

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T08:00:10.031Z for PR creation at branch issue-1239-12f648312661 for issue https://github.com/veb86/zcadvelecAI/issues/1239

--- a/cad_source/components/fpdwg/uzedwghandle.pas
+++ b/cad_source/components/fpdwg/uzedwghandle.pas
@@ -752,10 +752,7 @@ begin
   if (Props.ColorIndex <= 0) or (Props.ColorIndex > 255) then
     Props.ColorIndex := 7;
   Props.LineWeight := DWGLineWeightToDXF(PLayer^.linewt);
-  // AutoCAD/DXF encodes layer off by negating group 62. Some R2007 DWGs
-  // arrive from LibreDWG with off=1 while the color index is positive; in
-  // that contradictory case AutoCAD shows the layer as on, so trust color.
-  Props.On := not DWGColorIsOff(PLayer^.color);
+  Props.On := PLayer^.off = 0;
   Props.Locked := PLayer^.locked <> 0;
   Props.Plot := PLayer^.plotflag <> 0;
   Result := True;

--- a/cad_source/zengine/fileformats/dwg/tests/uzedwgtestdwgproc.pas
+++ b/cad_source/zengine/fileformats/dwg/tests/uzedwgtestdwgproc.pas
@@ -60,11 +60,11 @@ type
     procedure EntityLineTypeFlag3ReadsExplicitHandle;
     procedure EntityCommonPropsCopiesVisualFields;
     procedure EntityCommonPropsNormalizeByLayerColorAndLineWeight;
-    procedure LayerVisualPropsPositiveColorKeepsLayerOn;
+    procedure LayerVisualPropsExplicitFlagsDriveLayerStates;
     procedure LayerVisualPropsByLayerMethodKeepsRawACI;
     procedure LayerVisualPropsRawACIBeatsDecodedWhiteFallback;
     procedure LayerVisualPropsTruecolorPackedACIBeatsByLayerFallback;
-    procedure LayerVisualPropsNegativeColorTurnsLayerOff;
+    procedure LayerVisualPropsNegativeColorKeepsExplicitOnState;
     procedure HeaderCurrentLayerHandleReadsCLAYER;
     procedure HeaderCurrentLineTypeHandleReadsCELTYPE;
     procedure HeaderCurrentTextStyleHandleReadsTEXTSTYLE;
@@ -928,7 +928,7 @@ begin
   AssertFalse('visible by default', Props.Invisible);
 end;
 
-procedure TFPDWGProcHandleTest.LayerVisualPropsPositiveColorKeepsLayerOn;
+procedure TFPDWGProcHandleTest.LayerVisualPropsExplicitFlagsDriveLayerStates;
 var
   Layer: Dwg_Object_LAYER;
   Props: TDWGLayerVisualProps;
@@ -944,10 +944,19 @@ begin
   AssertTrue(DWGLayerVisualPropsValue(@Layer, Props));
   AssertEquals('ACI color copied', 7, Props.ColorIndex);
   AssertEquals('lineweight 31 is ByLwDefault', -3, Props.LineWeight);
-  AssertTrue('positive color keeps layer visible despite raw off flag',
+  AssertFalse('explicit off flag hides layer despite positive color',
     Props.On);
   AssertTrue('locked copied', Props.Locked);
   AssertTrue('plot flag copied', Props.Plot);
+
+  Layer.off := 0;
+  Layer.locked := 0;
+  Layer.plotflag := 0;
+
+  AssertTrue(DWGLayerVisualPropsValue(@Layer, Props));
+  AssertTrue('cleared off flag turns layer on', Props.On);
+  AssertFalse('cleared lock flag unlocks layer', Props.Locked);
+  AssertFalse('cleared plot flag disables plotting', Props.Plot);
 end;
 
 procedure TFPDWGProcHandleTest.LayerVisualPropsByLayerMethodKeepsRawACI;
@@ -1017,7 +1026,7 @@ begin
   AssertEquals('packed TRUECOLOR CMC keeps blue ACI', 5, Props.ColorIndex);
 end;
 
-procedure TFPDWGProcHandleTest.LayerVisualPropsNegativeColorTurnsLayerOff;
+procedure TFPDWGProcHandleTest.LayerVisualPropsNegativeColorKeepsExplicitOnState;
 var
   Layer: Dwg_Object_LAYER;
   Props: TDWGLayerVisualProps;
@@ -1032,7 +1041,12 @@ begin
   AssertEquals('negative ACI color normalized for display', 3,
     Props.ColorIndex);
   AssertEquals('lineweight 29 is ByLayer', -1, Props.LineWeight);
-  AssertFalse('negative color means layer is off', Props.On);
+  AssertTrue('cleared off flag keeps layer visible despite negative color',
+    Props.On);
+
+  Layer.off := 1;
+  AssertTrue(DWGLayerVisualPropsValue(@Layer, Props));
+  AssertFalse('set off flag hides layer after color normalization', Props.On);
 end;
 
 procedure TFPDWGProcHandleTest.HeaderCurrentLayerHandleReadsCLAYER;


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1239.

## Summary
DWG layer import now uses LibreDWG's explicit `LAYER.off` flag for ZCAD layer visibility instead of inferring on/off state from the sign of the layer color index. Color decoding still normalizes the visual layer color, but it no longer overrides the raw layer state.

## Reproduction
A DWG layer record with `color.index = 7` and `off = 1` was imported as visible because `DWGLayerVisualPropsValue` trusted the positive color index. The updated regression test models that record and asserts the imported layer is off.

## Changes
- Updated `DWGLayerVisualPropsValue` to set `Props.On` from `PLayer^.off`.
- Updated layer visual-property tests to cover explicit off/on flags, including the case where a negative color index should not hide a layer unless `off` is set.
- Removed the temporary PR scaffold `.gitkeep`.

## Verification
- `git diff --check`
- `make -C cad_source/zengine/tests checkvars`
- Local Pascal test execution was not possible in this container because `fpc` and `lazbuild` are not installed.
