### PR TITLE
loaderDWG: fix DWG TEXT Unicode decoding

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T13:53:49.102Z for PR creation at branch issue-1243-0cec0117c1c9 for issue https://github.com/veb86/zcadvelecAI/issues/1243

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T13:53:49.102Z for PR creation at branch issue-1243-0cec0117c1c9 for issue https://github.com/veb86/zcadvelecAI/issues/1243

--- a/cad_source/components/fpdwg/uzedwgtext.pas
+++ b/cad_source/components/fpdwg/uzedwgtext.pas
@@ -29,15 +29,16 @@ interface
 uses
   SysUtils, dwg;
 
-{ Decode a LibreDWG-allocated BITCODE_T payload into a Pascal string. The
-  binding exposes BITCODE_T as a C string pointer, so callers get codepage
-  text unless the payload itself looks like UTF-16LE. Tolerates a nil pointer:
-  the caller gets an empty string instead of an AV. }
+{ Decode a LibreDWG-allocated BITCODE_T payload into UTF-8 bytes stored in a
+  Pascal string. The binding exposes BITCODE_T as a C string pointer, so the
+  decoder applies the DWG header codepage or the UTF-16LE path explicitly.
+  Tolerates a nil pointer: the caller gets an empty string instead of an AV. }
 procedure DWGSafeDecodeText(const p: BITCODE_T; Version: DWG_VERSION_TYPE;
   out text: string); overload;
 procedure DWGSafeDecodeText(const p: BITCODE_T; Version: DWG_VERSION_TYPE;
   Codepage: Integer; out text: string); overload;
 function DWGDecodedTextForZCAD(const Text: string): string;
+function DWGDecodedTextToZCADString(const Text: string): UnicodeString;
 
 implementation
 
@@ -239,6 +240,11 @@ begin
   Result := (Pairs > 0) and (Score >= 2);
 end;
 
+function DWGDecodeUTF16Text(const p: BITCODE_T): string;
+begin
+  Result := string(UTF8Encode(UnicodeString(PUnicodeChar(p))));
+end;
+
 procedure DWGSafeDecodeText(const p: BITCODE_T; Version: DWG_VERSION_TYPE;
   out text: string);
 begin
@@ -246,7 +252,7 @@ begin
   if p = nil then
     Exit;
   if (Version > R_2004) and DWGTextLooksLikeUTF16LE(p) then
-    text := punicodechar(p)
+    text := DWGDecodeUTF16Text(p)
   else
     text := pchar(p);
 end;
@@ -261,7 +267,7 @@ begin
   if (Codepage = DWG_CP_UTF16) or
     ((Version > R_2004) and DWGTextLooksLikeUTF16LE(p)) then
   begin
-    text := punicodechar(p);
+    text := DWGDecodeUTF16Text(p);
     Exit;
   end;
 
@@ -272,10 +278,18 @@ end;
 
 function DWGDecodedTextForZCAD(const Text: string): string;
 begin
-  { DWGSafeDecodeText already returns the byte string ZCAD stores for both
-    codepage-based and UTF-16 DWGs. Keep this post-decode step explicit so
-    table/block mappers do not apply another locale conversion. }
+  { DWGSafeDecodeText already returns the UTF-8 byte string table/block mappers
+    expect. Keep this post-decode step explicit so those mappers do not apply
+    another locale conversion. }
   Result := Text;
+end;
+
+function DWGDecodedTextToZCADString(const Text: string): UnicodeString;
+begin
+  { TEXT/MTEXT entity fields are TDXFEntsInternalStringType = UnicodeString.
+    DWGSafeDecodeText returns UTF-8 bytes, so decode UTF-8 explicitly instead
+    of letting a plain UnicodeString cast use the process default code page. }
+  Result := UTF8Decode(Text);
 end;
 
 end.

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgentattrib.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgentattrib.pas
@@ -78,7 +78,7 @@ begin
   PObj^.textprop.upsidedown := (Generation and 4) <> 0;
   DWGSafeDecodeText(TextValue, DWGContext.DWGVer, DWGContext.DWGCodePage,
     Value);
-  PObj^.Content := UnicodeString(Value);
+  PObj^.Content := DWGDecodedTextToZCADString(Value);
   ApplyTextRotation(PObj, Rotation);
 end;
 

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgentdimension.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgentdimension.pas
@@ -119,7 +119,7 @@ begin
   DWGSafeDecodeText(PCommon^.user_text, DWGContext.DWGVer,
     DWGContext.DWGCodePage, Value);
   if Value <> '' then
-    PGDBObjDimension(PObj)^.dimtext := UnicodeString(Value);
+    PGDBObjDimension(PObj)^.dimtext := DWGDecodedTextToZCADString(Value);
 end;
 
 procedure RegisterDimensionShell(PObj: PGDBObjEntity;

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgentmtext.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgentmtext.pas
@@ -18,7 +18,7 @@ interface
 
 uses
   SysUtils,
-  dwg, dwgproc,uzedwghandle,
+  dwg, dwgproc, uzedwghandle, uzedwgtext,
   uzedrawingsimple,
   uzeentmtext, uzeentabstracttext, uzeentity,
   uzegeometry,
@@ -55,7 +55,6 @@ procedure AddMTextEntity(var ZContext: TZDrawingContext;
 var
   pobj: PGDBObjMText;
   Props: TDWGMTextProps;
-  uniValue: UnicodeString;
 begin
   // Issue #1203: точечный лог входа в mapper MTEXT. Если этого сообщения
   // нет в логе для интересующего handle — значит, parseDwg_Data не дошёл
@@ -75,10 +74,7 @@ begin
     pobj^.linespacef := Props.LineSpaceFactor
   else
     pobj^.linespacef := 1;
-  // Same widening contract as AddTextEntity — DWGSafeDecodeText already
-  // returned the payload as RTL string; the FPC compiler promotes it.
-  uniValue := UnicodeString(Props.Value);
-  pobj^.Content := uniValue;
+  pobj^.Content := DWGDecodedTextToZCADString(Props.Value);
   ApplyMTextRotation(pobj, Props.Rotation);
   if GetLoadCtx <> nil then
     DWGRegisterEntityShellWithTextStyleRef(PGDBObjEntity(pobj), DWGObject,

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgenttext.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgenttext.pas
@@ -18,7 +18,7 @@ interface
 
 uses
   SysUtils,
-  dwg, dwgproc,uzedwghandle,
+  dwg, dwgproc, uzedwghandle, uzedwgtext,
   uzedrawingsimple,
   uzegeometry,
   uzeenttext, uzeentabstracttext, uzeentity,
@@ -54,7 +54,6 @@ var
   pobj: PGDBObjText;
   Props: TDWGTextProps;
   TextX, TextY, TextZ: Double;
-  uniValue: UnicodeString;
 begin
   pobj := AllocAndInitText(nil);
   DWGCopyTextProps(PText^, DWGContext.DWGVer, DWGContext.DWGCodePage, Props);
@@ -73,12 +72,7 @@ begin
     Props.VertAlignment);
   pobj^.textprop.backward := (Props.Generation and 2) <> 0;
   pobj^.textprop.upsidedown := (Props.Generation and 4) <> 0;
-  // Stage 5 (TZ §12.5): DWGSafeDecodeText already returns the payload as a
-  // RTL string (UTF-16 path goes through punicodechar -> system codepage).
-  // Assigning to a UnicodeString-typed Content lets FPC promote it back via
-  // the default conversion.
-  uniValue := UnicodeString(Props.Value);
-  pobj^.Content := uniValue;
+  pobj^.Content := DWGDecodedTextToZCADString(Props.Value);
   ApplyTextRotation(pobj, Props.Rotation);
   if GetLoadCtx <> nil then
     DWGRegisterEntityShellWithTextStyleRef(PGDBObjEntity(pobj), DWGObject,

--- a/cad_source/zengine/fileformats/dwg/tests/uzedwgtestdwgproc.pas
+++ b/cad_source/zengine/fileformats/dwg/tests/uzedwgtestdwgproc.pas
@@ -136,6 +136,7 @@ type
     procedure BITCODET2TextUsesHeaderCodepage;
     procedure BITCODET2TextKeepsR2010UnicodeTableName;
     procedure BITCODET2TextDecodesR2013SingleByteCP1251;
+    procedure CopyTextToZCADStringKeepsR2010ChineseValue;
     procedure CopyTextCopiesGeometry;
     procedure CopyTextDecodesCP1251Value;
     procedure CopyTextPreservesAlignmentFlags;
@@ -1653,6 +1654,26 @@ begin
   BITCODE_T2Text(PChar(RawText), DWGContext, Decoded);
 
   AssertEquals(Expected, Decoded);
+end;
+
+procedure TFPDWGProcTextTest.CopyTextToZCADStringKeepsR2010ChineseValue;
+var
+  Text: Dwg_Entity_TEXT;
+  Props: TDWGTextProps;
+  RawText: UnicodeString;
+  Expected: AnsiString;
+  Stored: UnicodeString;
+begin
+  FillChar(Text, SizeOf(Text), 0);
+  Expected := #$E4#$BA#$A7#$E5#$93#$81#$E5#$BA#$94#$E7#$94#$A8 +
+    ' (SUBJECT) : PIC30';
+  RawText := UTF8Decode(Expected);
+  Text.text_value := PAnsiChar(PUnicodeChar(RawText));
+
+  DWGCopyTextProps(Text, R_2010, 29, Props);
+  Stored := DWGDecodedTextToZCADString(Props.Value);
+
+  AssertEquals(Expected, string(UTF8Encode(Stored)));
 end;
 
 procedure TFPDWGProcTextTest.CopyTextCopiesGeometry;


### PR DESCRIPTION
Fixes #1243

## Summary
- decode DWG UTF-16 text payloads to UTF-8 explicitly instead of relying on the process default codepage
- convert decoded DWG entity text to UnicodeString with UTF8Decode before storing TEXT, MTEXT, ATTRIB, and dimension user text fields
- add a regression test for an R2010 Chinese TEXT value matching the reported mojibake scenario

## Testing
- git diff --check
- fpc -Fu.. -Fu../.. -Fu../model -Fu../mappers fpdwg_tests.lpr (blocked locally: fpc is not installed in this environment)

Screenshots are not included because the change is in the loader text conversion path; the issue screenshots were used to identify the DWG-vs-DXF text corruption.