### PR TITLE
loaderDWG: fix DWG TEXT CJK template decoding

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T19:04:14.651Z for PR creation at branch issue-1243-e1457adce381 for issue https://github.com/veb86/zcadvelecAI/issues/1243

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T19:04:14.651Z for PR creation at branch issue-1243-e1457adce381 for issue https://github.com/veb86/zcadvelecAI/issues/1243

--- a/cad_source/components/fpdwg/uzedwgtext.pas
+++ b/cad_source/components/fpdwg/uzedwgtext.pas
@@ -39,6 +39,7 @@ procedure DWGSafeDecodeText(const p: BITCODE_T; Version: DWG_VERSION_TYPE;
   Codepage: Integer; out text: string); overload;
 function DWGDecodedTextForZCAD(const Text: string): string;
 function DWGDecodedTextToZCADString(const Text: string): UnicodeString;
+function DWGDecodedTextToZCADTemplate(const Text: string): UnicodeString;
 
 implementation
 
@@ -205,19 +206,72 @@ begin
   Result := True;
 end;
 
+function DWGByteIsPrintableASCII(B: Byte): Boolean;
+begin
+  Result := (B = 9) or (B = 10) or (B = 13) or ((B >= 32) and (B <= 126));
+end;
+
+function DWGCodeUnitLooksLikeUTF16Text(CodeUnit: Word): Boolean;
+begin
+  Result := ((CodeUnit >= $4E00) and (CodeUnit <= $9FFF)) or
+    ((CodeUnit >= $3040) and (CodeUnit <= $30FF)) or
+    ((CodeUnit >= $FF00) and (CodeUnit <= $FFEF));
+end;
+
+function DWGTextHasAnsiASCIIPrefix(const p: BITCODE_T): Boolean;
+const
+  MaxProbeBytes = 32;
+var
+  I, FirstNul: Integer;
+begin
+  Result := False;
+  FirstNul := -1;
+  for I := 0 to MaxProbeBytes - 1 do
+  begin
+    if PAnsiChar(p)[I] = #0 then
+    begin
+      FirstNul := I;
+      Break;
+    end;
+    if not DWGByteIsPrintableASCII(Ord(PAnsiChar(p)[I])) then
+      Exit;
+  end;
+
+  if FirstNul <= 1 then
+    Exit;
+
+  I := 1;
+  while I < FirstNul do
+  begin
+    if PAnsiChar(p)[I] <> #0 then
+    begin
+      Result := True;
+      Exit;
+    end;
+    Inc(I, 2);
+  end;
+end;
+
 function DWGTextLooksLikeUTF16LE(const p: BITCODE_T): Boolean;
 const
-  MaxProbeChars = 8;
+  MaxProbeChars = 16;
 var
-  I, Pairs, Score: Integer;
+  I, Pairs, Score, StrongPairs: Integer;
   Lo, Hi: Byte;
+  CodeUnit: Word;
 begin
   Result := False;
   if (p = nil) or (PAnsiChar(p)[0] = #0) then
     Exit;
+  { LibreDWG exposes BITCODE_T as PAnsiChar even when the payload is UTF-16LE.
+    Score UTF-16 code units, but reject ordinary single-byte ASCII first so
+    R2007+ codepage strings such as "Hello" do not become CJK-looking pairs. }
+  if DWGTextHasAnsiASCIIPrefix(p) then
+    Exit;
 
   Pairs := 0;
   Score := 0;
+  StrongPairs := 0;
   for I := 0 to MaxProbeChars - 1 do
   begin
     Lo := Ord(PAnsiChar(p)[I * 2]);
@@ -226,18 +280,36 @@ begin
       Break;
 
     Inc(Pairs);
-    if Hi = 0 then
-      Inc(Score, 2)
+    CodeUnit := Word(Lo) or (Word(Hi) shl 8);
+    if (Hi = 0) and DWGByteIsPrintableASCII(Lo) then
+    begin
+      Inc(Score, 4);
+      Inc(StrongPairs);
+    end
     else if Hi in [$01..$06] then
-      Inc(Score, 2)
+    begin
+      Inc(Score, 3);
+      Inc(StrongPairs);
+    end
+    else if DWGCodeUnitLooksLikeUTF16Text(CodeUnit) then
+    begin
+      Inc(Score, 3);
+      Inc(StrongPairs);
+    end
+    else if (CodeUnit >= $D800) and (CodeUnit <= $DFFF) then
+      Dec(Score, 3)
+    else if (CodeUnit >= $E000) and (CodeUnit <= $F8FF) then
+      Dec(Score, 3)
+    else if CodeUnit < 32 then
+      Dec(Score, 2)
     else
-      Dec(Score, 2);
+      Inc(Score);
 
     if (Lo = 0) and (Hi <> 0) then
       Dec(Score, 2);
   end;
 
-  Result := (Pairs > 0) and (Score >= 2);
+  Result := (Pairs > 0) and (StrongPairs > 0) and (Score >= 4);
 end;
 
 function DWGDecodeUTF16Text(const p: BITCODE_T): string;
@@ -290,6 +362,20 @@ begin
     DWGSafeDecodeText returns UTF-8 bytes, so decode UTF-8 explicitly instead
     of letting a plain UnicodeString cast use the process default code page. }
   Result := UTF8Decode(Text);
+end;
+
+function DWGDecodedTextToZCADTemplate(const Text: string): UnicodeString;
+var
+  I: Integer;
+  Decoded: UnicodeString;
+begin
+  Decoded := DWGDecodedTextToZCADString(Text);
+  Result := '';
+  for I := 1 to Length(Decoded) do
+    if Ord(Decoded[I]) > 127 then
+      Result := Result + '\U+' + IntToHex(Ord(Decoded[I]), 4)
+    else
+      Result := Result + Decoded[I];
 end;
 
 end.

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgentattrib.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgentattrib.pas
@@ -78,7 +78,8 @@ begin
   PObj^.textprop.upsidedown := (Generation and 4) <> 0;
   DWGSafeDecodeText(TextValue, DWGContext.DWGVer, DWGContext.DWGCodePage,
     Value);
-  PObj^.Content := DWGDecodedTextToZCADString(Value);
+  PObj^.Template := DWGDecodedTextToZCADTemplate(Value);
+  PObj^.Content := PObj^.Template;
   ApplyTextRotation(PObj, Rotation);
 end;
 

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgentmtext.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgentmtext.pas
@@ -74,7 +74,8 @@ begin
     pobj^.linespacef := Props.LineSpaceFactor
   else
     pobj^.linespacef := 1;
-  pobj^.Content := DWGDecodedTextToZCADString(Props.Value);
+  pobj^.Template := DWGDecodedTextToZCADTemplate(Props.Value);
+  pobj^.Content := pobj^.Template;
   ApplyMTextRotation(pobj, Props.Rotation);
   if GetLoadCtx <> nil then
     DWGRegisterEntityShellWithTextStyleRef(PGDBObjEntity(pobj), DWGObject,

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgenttext.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgenttext.pas
@@ -72,7 +72,8 @@ begin
     Props.VertAlignment);
   pobj^.textprop.backward := (Props.Generation and 2) <> 0;
   pobj^.textprop.upsidedown := (Props.Generation and 4) <> 0;
-  pobj^.Content := DWGDecodedTextToZCADString(Props.Value);
+  pobj^.Template := DWGDecodedTextToZCADTemplate(Props.Value);
+  pobj^.Content := pobj^.Template;
   ApplyTextRotation(pobj, Props.Rotation);
   if GetLoadCtx <> nil then
     DWGRegisterEntityShellWithTextStyleRef(PGDBObjEntity(pobj), DWGObject,

--- a/cad_source/zengine/fileformats/dwg/tests/uzedwgtestdwgproc.pas
+++ b/cad_source/zengine/fileformats/dwg/tests/uzedwgtestdwgproc.pas
@@ -136,7 +136,9 @@ type
     procedure BITCODET2TextUsesHeaderCodepage;
     procedure BITCODET2TextKeepsR2010UnicodeTableName;
     procedure BITCODET2TextDecodesR2013SingleByteCP1251;
+    procedure BITCODET2TextKeepsR2013SingleByteASCII;
     procedure CopyTextToZCADStringKeepsR2010ChineseValue;
+    procedure CopyTextToZCADTemplateEscapesIssue1243R2010Value;
     procedure CopyTextCopiesGeometry;
     procedure CopyTextDecodesCP1251Value;
     procedure CopyTextPreservesAlignmentFlags;
@@ -1656,6 +1658,23 @@ begin
   AssertEquals(Expected, Decoded);
 end;
 
+procedure TFPDWGProcTextTest.BITCODET2TextKeepsR2013SingleByteASCII;
+var
+  RawDWG: Dwg_Data;
+  DWGContext: TDWGCtx;
+  RawText, Decoded: AnsiString;
+begin
+  FillChar(RawDWG, SizeOf(RawDWG), 0);
+  RawDWG.header.version := R_2013;
+  RawDWG.header.codepage := 29;
+  DWGContext.CreateRec(RawDWG);
+  RawText := 'Hello';
+
+  BITCODE_T2Text(PChar(RawText), DWGContext, Decoded);
+
+  AssertEquals(RawText, Decoded);
+end;
+
 procedure TFPDWGProcTextTest.CopyTextToZCADStringKeepsR2010ChineseValue;
 var
   Text: Dwg_Entity_TEXT;
@@ -1674,6 +1693,30 @@ begin
   Stored := DWGDecodedTextToZCADString(Props.Value);
 
   AssertEquals(Expected, string(UTF8Encode(Stored)));
+end;
+
+procedure TFPDWGProcTextTest.CopyTextToZCADTemplateEscapesIssue1243R2010Value;
+var
+  Text: Dwg_Entity_TEXT;
+  Props: TDWGTextProps;
+  RawText: UnicodeString;
+  Expected, ExpectedTemplate: AnsiString;
+  Stored: UnicodeString;
+begin
+  FillChar(Text, SizeOf(Text), 0);
+  Expected := #$E5#$B7#$A5#$E7#$A8#$8B#$E5#$90#$8D#$E7#$A7#$B0 +
+    #$EF#$BC#$88'SUBJECT'#$EF#$BC#$89#$EF#$BC#$9A;
+  ExpectedTemplate :=
+    '\U+5DE5\U+7A0B\U+540D\U+79F0\U+FF08SUBJECT\U+FF09\U+FF1A';
+  RawText := UTF8Decode(Expected);
+  Text.text_value := PAnsiChar(PUnicodeChar(RawText));
+
+  DWGCopyTextProps(Text, R_2010, 29, Props);
+  Stored := DWGDecodedTextToZCADString(Props.Value);
+
+  AssertEquals(Expected, string(UTF8Encode(Stored)));
+  AssertEquals(ExpectedTemplate,
+    string(DWGDecodedTextToZCADTemplate(Props.Value)));
 end;
 
 procedure TFPDWGProcTextTest.CopyTextCopiesGeometry;


### PR DESCRIPTION
Fixes #1243

## Summary
- recognize R2007+ DWG UTF-16LE text whose first characters are CJK or fullwidth BMP characters, not only Latin/Cyrillic ranges
- convert decoded DWG TEXT, MTEXT, and ATTRIB values into ZCAD-compatible `\U+XXXX` templates so the normal formatter fills `TxtContent` from `TxtTemplate` like the DXF loader
- add regression coverage for the exact reported `工程名称（SUBJECT）：` TEXT payload and for single-byte ASCII so the UTF-16 heuristic does not over-decode codepage strings

## Reproduction
The reported DWG payload begins with UTF-16LE bytes for `工程名称（SUBJECT）：`. The previous detector rejected those CJK/fullwidth code units, then decoded the bytes through CP1251 until the first ASCII UTF-16 NUL, producing values like `е]\vz Tрy\bяS`.

## Testing
- `git diff --check`
- decoder simulation for issue UTF-16LE, CP1251, single-byte ASCII, and UTF-16 ASCII cases
- `make tests` was attempted and is blocked in this checkout before compilation: `cad_source/components/zcontainers/tests` is missing, and `/usr/bin/fpc` plus `/usr/bin/lazbuild` are not installed

No after screenshot is included because the available environment cannot build/run the Lazarus UI; the fix is covered at the DWG text decode/template mapping layer.