### PR TITLE
Fix ExplodeBlockProxy scalar scaling

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-20T20:00:26.364Z for PR creation at branch issue-1246-54203d5ed53c for issue https://github.com/veb86/zcadvelecAI/issues/1246

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-20T20:00:26.364Z for PR creation at branch issue-1246-54203d5ed53c for issue https://github.com/veb86/zcadvelecAI/issues/1246

--- a/cad_source/zcad/velec/newcommand/uzccommand_explodeblockproxy.pas
+++ b/cad_source/zcad/velec/newcommand/uzccommand_explodeblockproxy.pas
@@ -58,6 +58,7 @@ uses
   uzeentity,
   uzeconsts,
   uzeentarc,
+  uzeenttransformscalars,
   uzeentblockinsert,
   uzeentacdproxy,
   uzeentcomplex,
@@ -290,6 +291,7 @@ begin
   if SubEntity^.GetObjType = GDBArcID then
     FlattenArcAnglesToRoot(PGDBObjArc(SubEntity), PGDBObjArc(Cloned),
       ATransform);
+  ApplyEntityScalarScale(Cloned, Cloned^.objMatrix);
   { Переносим клон в корень чертежа. После TransformAt его Local
     уже содержит мировые координаты, так что повторные вызовы
     CalcObjMatrix при новом владельце дадут корректную матрицу. }

--- a/cad_source/zengine/core/entities/uzeenttransformscalars.pas
+++ b/cad_source/zengine/core/entities/uzeenttransformscalars.pas
@@ -1,0 +1,114 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+unit uzeenttransformscalars;
+{$Mode delphi}{$H+}
+{$INCLUDE zengineconfig.inc}
+
+interface
+
+uses
+  uzeentity,
+  uzegeometrytypes;
+
+function MatrixAxisScaleFactor(const Matrix: TzeTypedMatrix4d;
+  AxisIndex: Integer): Double;
+function MatrixPlanarScaleFactor(const Matrix: TzeTypedMatrix4d): Double;
+procedure ApplyEntityScalarScale(Entity: PGDBObjEntity;
+  const Matrix: TzeTypedMatrix4d);
+
+implementation
+
+uses
+  Math,
+  uzeconsts,
+  uzegeometry,
+  uzeenttext,
+  uzeentmtext,
+  uzeenthatch,
+  uzeentlwpolyline;
+
+function MatrixAxisScaleFactor(const Matrix: TzeTypedMatrix4d;
+  AxisIndex: Integer): Double;
+begin
+  Result := oneVertexlength(PzePoint3d(@Matrix.mtr.v[AxisIndex])^);
+  if Result < eps then
+    Result := 1.0;
+end;
+
+function MatrixPlanarScaleFactor(const Matrix: TzeTypedMatrix4d): Double;
+begin
+  Result :=
+    (MatrixAxisScaleFactor(Matrix, 0) + MatrixAxisScaleFactor(Matrix, 1)) / 2;
+  if Result < eps then
+    Result := 1.0;
+end;
+
+procedure ScaleLWPolylineWidths(LWPolyline: PGDBObjLWPolyline;
+  const ScaleFactor: Double);
+var
+  I: Integer;
+  Width: PGLLWWidth;
+begin
+  if LWPolyline = nil then
+    Exit;
+
+  if SameValue(ScaleFactor, 1.0)
+    or (LWPolyline^.Width2D_in_OCS_Array.Count = 0) then
+    Exit;
+
+  for I := 0 to LWPolyline^.Width2D_in_OCS_Array.Count - 1 do
+  begin
+    Width := LWPolyline^.Width2D_in_OCS_Array.getDataMutable(I);
+    if Width <> nil then
+    begin
+      Width^.startw := Width^.startw * ScaleFactor;
+      Width^.endw := Width^.endw * ScaleFactor;
+      Width^.hw := (not SameValue(Width^.startw, 0.0))
+        or (not SameValue(Width^.endw, 0.0));
+    end;
+  end;
+end;
+
+procedure ApplyEntityScalarScale(Entity: PGDBObjEntity;
+  const Matrix: TzeTypedMatrix4d);
+var
+  PlanarScale: Double;
+begin
+  if Entity = nil then
+    Exit;
+
+  case Entity^.GetObjType of
+    GDBTextID:
+      PGDBObjText(Entity)^.textprop.size :=
+        PGDBObjText(Entity)^.textprop.size * MatrixAxisScaleFactor(Matrix, 1);
+    GDBMTextID:
+      begin
+        PGDBObjMText(Entity)^.textprop.size :=
+          PGDBObjMText(Entity)^.textprop.size * MatrixAxisScaleFactor(Matrix, 1);
+        PGDBObjMText(Entity)^.Width :=
+          PGDBObjMText(Entity)^.Width * MatrixAxisScaleFactor(Matrix, 0);
+      end;
+    GDBHatchID:
+      PGDBObjHatch(Entity)^.Scale :=
+        PGDBObjHatch(Entity)^.Scale * MatrixPlanarScaleFactor(Matrix);
+    GDBLWPolylineID:
+      begin
+        PlanarScale := MatrixPlanarScaleFactor(Matrix);
+        ScaleLWPolylineWidths(PGDBObjLWPolyline(Entity), PlanarScale);
+      end;
+  end;
+end;
+
+end.

--- a/cad_source/zengine/tests/testzengine.lpr
+++ b/cad_source/zengine/tests/testzengine.lpr
@@ -7,7 +7,8 @@ uses
   Classes, consoletestrunner,
   Logtest,BoundaryPathSimpletest,
   uzctEntityArc, uzctmtextwrap, uzctenttextjustify, uzctacadtable, uzctentproxy,
-  uzctentpolyfacemesh, uzctdwgblockreserve, uzctenttextnilstyle;
+  uzctentpolyfacemesh, uzctdwgblockreserve, uzctenttextnilstyle,
+  uzctenttransformscalars;
 
 var
   Application: TTestRunner;

--- a/cad_source/zengine/tests/uzctenttransformscalars.pas
+++ b/cad_source/zengine/tests/uzctenttransformscalars.pas
@@ -1,0 +1,128 @@
+unit uzctenttransformscalars;
+{$Codepage UTF8}
+{$Mode delphi}{$H+}
+
+interface
+
+uses
+  SysUtils,
+  fpcunit,
+  testregistry,
+  uzegeometry,
+  uzegeometrytypes,
+  uzeentity,
+  uzeenttransformscalars,
+  uzeenttext,
+  uzeentmtext,
+  uzeenthatch,
+  uzeentlwpolyline;
+
+type
+  TEntityTransformScalarTest = class(TTestCase)
+  published
+    procedure TextHeightScalesWithTransformedYAxis;
+    procedure MTextHeightAndWidthScaleWithMatrixAxes;
+    procedure HatchPatternScaleUsesPlanarScale;
+    procedure LWPolylineWidthsUsePlanarScale;
+  end;
+
+implementation
+
+procedure TEntityTransformScalarTest.TextHeightScalesWithTransformedYAxis;
+var
+  Text: PGDBObjText;
+  Matrix: TzeTypedMatrix4d;
+begin
+  Text := GDBObjText.CreateInstance;
+  try
+    Text^.textprop.size := 2.0;
+    Matrix := CreateScaleMatrix(0.5);
+
+    ApplyEntityScalarScale(PGDBObjEntity(Text), Matrix);
+
+    CheckEquals(1.0, Text^.textprop.size, 1e-9,
+      'TEXT height must follow the transformed Y axis scale');
+  finally
+    Text^.done;
+    FreeMem(Pointer(Text));
+  end;
+end;
+
+procedure TEntityTransformScalarTest.MTextHeightAndWidthScaleWithMatrixAxes;
+var
+  MText: PGDBObjMText;
+  Matrix: TzeTypedMatrix4d;
+begin
+  MText := GDBObjMText.CreateInstance;
+  try
+    MText^.textprop.size := 4.0;
+    MText^.Width := 8.0;
+    Matrix := CreateScaleMatrix(2.0, 0.5, 1.0);
+
+    ApplyEntityScalarScale(PGDBObjEntity(MText), Matrix);
+
+    CheckEquals(2.0, MText^.textprop.size, 1e-9,
+      'MTEXT height must follow the transformed Y axis scale');
+    CheckEquals(16.0, MText^.Width, 1e-9,
+      'MTEXT width must follow the transformed X axis scale');
+  finally
+    MText^.done;
+    FreeMem(Pointer(MText));
+  end;
+end;
+
+procedure TEntityTransformScalarTest.HatchPatternScaleUsesPlanarScale;
+var
+  Hatch: PGDBObjHatch;
+  Matrix: TzeTypedMatrix4d;
+begin
+  Hatch := GDBObjHatch.CreateInstance;
+  try
+    Hatch^.Scale := 1.0;
+    Matrix := CreateScaleMatrix(0.5);
+
+    ApplyEntityScalarScale(PGDBObjEntity(Hatch), Matrix);
+
+    CheckEquals(0.5, Hatch^.Scale, 1e-9,
+      'HATCH pattern scale must follow uniform block/proxy scale');
+  finally
+    Hatch^.done;
+    FreeMem(Pointer(Hatch));
+  end;
+end;
+
+procedure TEntityTransformScalarTest.LWPolylineWidthsUsePlanarScale;
+var
+  LWPolyline: PGDBObjLWPolyline;
+  WidthRecord: GLLWWidth;
+  StoredWidth: PGLLWWidth;
+  Matrix: TzeTypedMatrix4d;
+begin
+  LWPolyline := GDBObjLWPolyline.CreateInstance;
+  try
+    FillChar(WidthRecord, SizeOf(WidthRecord), 0);
+    WidthRecord.startw := 2.0;
+    WidthRecord.endw := 4.0;
+    WidthRecord.hw := True;
+    LWPolyline^.Width2D_in_OCS_Array.PushBackData(WidthRecord);
+
+    Matrix := CreateScaleMatrix(0.5);
+    ApplyEntityScalarScale(PGDBObjEntity(LWPolyline), Matrix);
+
+    StoredWidth := LWPolyline^.Width2D_in_OCS_Array.getDataMutable(0);
+    CheckEquals(1.0, StoredWidth^.startw, 1e-9,
+      'LWPOLYLINE start width must follow uniform block/proxy scale');
+    CheckEquals(2.0, StoredWidth^.endw, 1e-9,
+      'LWPOLYLINE end width must follow uniform block/proxy scale');
+    CheckTrue(StoredWidth^.hw,
+      'LWPOLYLINE width flag must stay set for non-zero scaled widths');
+  finally
+    LWPolyline^.done;
+    FreeMem(Pointer(LWPolyline));
+  end;
+end;
+
+initialization
+  RegisterTest(TEntityTransformScalarTest);
+
+end.


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1246

## Summary
- scale scalar entity properties when `ExplodeBlockProxy` flattens transformed subentities into the drawing root
- preserve transformed TEXT/MTEXT dimensions, HATCH pattern scale, and LWPOLYLINE widths under block/proxy scale
- add focused regression coverage for the scalar scaling helper

## Reproduction
Exploding a scaled block/proxy cloned subentity geometry with the transformed matrix, then moved the clone to the drawing root where formatting rebuilt local axes. Scalar fields that are not represented by vertex geometry, such as HATCH `Scale`, TEXT height, MTEXT width, and LWPOLYLINE width records, kept their original values instead of following the block/proxy scale.

## Testing
- `git diff --check`
- added `uzctenttransformscalars` tests for TEXT, MTEXT, HATCH, and LWPOLYLINE scalar scaling
- `make tests` could not complete locally because `/usr/bin/lazbuild` is not installed in this container
