### PR TITLE
Fix ExplodeBlockProxy compile error

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-21T11:32:50.520Z for PR creation at branch issue-1248-1b4d7199f858 for issue https://github.com/veb86/zcadvelecAI/issues/1248

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-21T11:32:50.520Z for PR creation at branch issue-1248-1b4d7199f858 for issue https://github.com/veb86/zcadvelecAI/issues/1248

--- a/cad_source/zcad/velec/newcommand/uzccommand_explodeblockproxy.pas
+++ b/cad_source/zcad/velec/newcommand/uzccommand_explodeblockproxy.pas
@@ -291,7 +291,7 @@ begin
   if SubEntity^.GetObjType = GDBArcID then
     FlattenArcAnglesToRoot(PGDBObjArc(SubEntity), PGDBObjArc(Cloned),
       ATransform);
-  ApplyEntityScalarScale(Cloned, Cloned^.objMatrix);
+  ApplyEntityScalarScale(Cloned, ATransform);
   { Переносим клон в корень чертежа. После TransformAt его Local
     уже содержит мировые координаты, так что повторные вызовы
     CalcObjMatrix при новом владельце дадут корректную матрицу. }


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1248

## Problem
`uzccommand_explodeblockproxy.pas` failed to compile because `CloneSubEntityToRoot` accessed `Cloned^.objMatrix` through `PGDBObjEntity`. The base `GDBObjEntity` type does not declare `objMatrix`; that field exists only on specific descendant entities.

## Solution
Pass the already-known transformation matrix (`ATransform`) into `ApplyEntityScalarScale` instead of reading `objMatrix` from the generic cloned entity pointer.

This preserves the intended scalar scaling behavior while avoiding an invalid base-type field access.

## Verification
- `git diff --check` passed.
- Local Pascal compile was not run because this environment does not have `fpc` or `lazbuild` installed.