### PR TITLE
loaderDWG: resolve dimension text styles

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-21T19:40:01.643Z for PR creation at branch issue-1250-5a2c013857a1 for issue https://github.com/veb86/zcadvelecAI/issues/1250

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-21T19:40:01.643Z for PR creation at branch issue-1250-5a2c013857a1 for issue https://github.com/veb86/zcadvelecAI/issues/1250

--- a/cad_source/zengine/fileformats/dwg/tests/uzedwgtestloadcontext.pas
+++ b/cad_source/zengine/fileformats/dwg/tests/uzedwgtestloadcontext.pas
@@ -109,6 +109,8 @@ type
     procedure BrokenBlockRefFallsBackWithWarning;
     procedure AttribOwnerInsertResolvesToInsertContainer;
     procedure DimStyleDeclaredAfterDimensionResolvesAtEnd;
+    procedure DimStyleTextStyleDeclaredAfterDimStyleResolvesAtEnd;
+    procedure NullDimStyleTextStyleFallsBackToStandard;
     procedure NullDimStyleFallsBackToDefault;
     procedure BlockDefRefAcceptsModelSpaceForInsert;
   end;
@@ -1843,6 +1845,69 @@ begin
   end;
 end;
 
+procedure TDWGLoadContextStage6Test.DimStyleTextStyleDeclaredAfterDimStyleResolvesAtEnd;
+var
+  Ctx: TDWGZCADLoadContext;
+  Pending: PDWGZCADPendingRef;
+  Recorder: TFakeRefRecorder;
+  DimStyle, TextStyle, StdText: Pointer;
+begin
+  Ctx := TDWGZCADLoadContext.Create;
+  try
+    DimStyle := MakePtr($622);
+    TextStyle := MakePtr($623);
+    StdText := MakePtr($6F4);
+    SetLength(Recorder.Calls, 0);
+    Ctx.SetRefAttachProc(@FakeRefAttach, @Recorder);
+    Ctx.SetFallbackTextStyle(StdText);
+    Ctx.RegisterShell($622, dokDimStyle, DimStyle, 0);
+    Ctx.QueueRefResolve(DimStyle, $622, $623, dokTextStyle,
+      rsDimStyleTextStyle, nil);
+    Ctx.RegisterShell($623, dokTextStyle, TextStyle, 1);
+
+    Ctx.ResolveRefs;
+
+    Pending := Ctx.FindPendingRef($622, rsDimStyleTextStyle);
+    AssertNotNull(Pending);
+    AssertEquals(Ord(asAttached), Ord(Pending^.AttachState));
+    AssertEquals(Ord(arResolved), Ord(Pending^.AttachReason));
+    AssertEquals(PtrInt(TextStyle), PtrInt(Pending^.AttachedRef));
+    AssertEquals(1, Length(Recorder.Calls));
+    AssertEquals(Ord(rsDimStyleTextStyle), Ord(Recorder.Calls[0].Slot));
+    AssertEquals(PtrInt(DimStyle), PtrInt(Recorder.Calls[0].Entity));
+    AssertEquals(PtrInt(TextStyle), PtrInt(Recorder.Calls[0].Ref));
+  finally
+    Ctx.Free;
+  end;
+end;
+
+procedure TDWGLoadContextStage6Test.NullDimStyleTextStyleFallsBackToStandard;
+var
+  Ctx: TDWGZCADLoadContext;
+  Pending: PDWGZCADPendingRef;
+  DimStyle, StdText: Pointer;
+begin
+  Ctx := TDWGZCADLoadContext.Create;
+  try
+    DimStyle := MakePtr($624);
+    StdText := MakePtr($6F5);
+    Ctx.SetFallbackTextStyle(StdText);
+    Ctx.RegisterShell($624, dokDimStyle, DimStyle, 0);
+    Ctx.QueueRefResolve(DimStyle, $624, 0, dokTextStyle,
+      rsDimStyleTextStyle, nil);
+
+    Ctx.ResolveRefs;
+
+    Pending := Ctx.FindPendingRef($624, rsDimStyleTextStyle);
+    AssertNotNull(Pending);
+    AssertEquals(Ord(asFallback), Ord(Pending^.AttachState));
+    AssertEquals(Ord(arRefNull), Ord(Pending^.AttachReason));
+    AssertEquals(PtrInt(StdText), PtrInt(Pending^.AttachedRef));
+  finally
+    Ctx.Free;
+  end;
+end;
+
 procedure TDWGLoadContextStage6Test.NullDimStyleFallsBackToDefault;
 var
   Ctx: TDWGZCADLoadContext;
@@ -3430,6 +3495,8 @@ begin
     DWGObjectKindToLogText(dokBlockInsert));
   AssertEquals('layer linetype slot', 'layer-linetype',
     DWGRefSlotToLogText(rsLayerLineType));
+  AssertEquals('dimstyle textstyle slot', 'dimstyle-textstyle',
+    DWGRefSlotToLogText(rsDimStyleTextStyle));
   AssertEquals('created shell state', 'created',
     DWGShellStateToLogText(msCreated));
   AssertEquals('fallback attach state', 'fallback',

--- a/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
@@ -616,6 +616,15 @@ begin
     Result := '(unnamed linetype)';
 end;
 
+function DWGTextStyleNameForLog(TextStyle: PGDBTextStyle): string;
+begin
+  if TextStyle = nil then
+    Exit('(nil textstyle)');
+  Result := TextStyle^.Name;
+  if Result = '' then
+    Result := '(unnamed textstyle)';
+end;
+
 function DWGRefContextForLog(const Context: TDWGAttachContext): string;
 begin
   Result := 'handle=' + IntToHex(Context.EntityHandle, 1) +
@@ -634,6 +643,7 @@ var
   pobj: PGDBObjEntity;
   player: PGDBLayerProp;
   pDimStyle: PGDBDimStyle;
+  pTextStyle: PGDBTextStyle;
   pBlockDef: PGDBObjBlockdef;
   pInsert: PGDBObjBlockInsert;
   Slot: TDWGZCADRefSlot;
@@ -725,6 +735,24 @@ begin
             'entity %s %s textstyle fallback (%s)',
             [HexStr(PtrUInt(pobj), 16), DWGRefContextForLog(Context),
              DWGAttachReasonToText(Reason)]);
+      end;
+    rsDimStyleTextStyle:
+      begin
+        pDimStyle := PGDBDimStyle(Entity);
+        if pDimStyle = nil then
+          Exit;
+        pTextStyle := PGDBTextStyle(Ref);
+        if (pTextStyle = nil) and (LoadDrawing <> nil) then
+          pTextStyle := DWGEnsureTextStyle(LoadDrawing^);
+        if pTextStyle <> nil then
+          pDimStyle^.Text.DIMTXSTY := pTextStyle;
+        if (Reason <> arResolved) and
+           DWGShouldEmitFallbackDetail(Reason, EntityHandle) then
+          DWGLogWarningFormatStr(
+            'dimstyle %s %s textstyle fallback (%s) -> %s',
+            [pDimStyle^.Name, DWGRefContextForLog(Context),
+             DWGAttachReasonToText(Reason),
+             DWGTextStyleNameForLog(pTextStyle)]);
       end;
     rsDimStyle:
       begin

--- a/cad_source/zengine/fileformats/dwg/uzedwgloadcontext.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgloadcontext.pas
@@ -946,8 +946,10 @@ begin
     rsLineType,
     rsLayerLineType:
       Result := FFallbackLineType;
-    rsTextStyle: Result := FFallbackTextStyle;
-    rsDimStyle:  Result := FFallbackDimStyle;
+    rsTextStyle,
+    rsDimStyleTextStyle:
+      Result := FFallbackTextStyle;
+    rsDimStyle: Result := FFallbackDimStyle;
   else
     Result := nil;
   end;

--- a/cad_source/zengine/fileformats/dwg/uzedwglog.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwglog.pas
@@ -80,9 +80,10 @@ begin
     rsLayer:         Result := 'layer';
     rsLineType:      Result := 'linetype';
     rsTextStyle:     Result := 'textstyle';
-    rsDimStyle:      Result := 'dimstyle';
-    rsBlockDef:      Result := 'block-def';
-    rsLayerLineType: Result := 'layer-linetype';
+    rsDimStyle:          Result := 'dimstyle';
+    rsBlockDef:          Result := 'block-def';
+    rsDimStyleTextStyle: Result := 'dimstyle-textstyle';
+    rsLayerLineType:     Result := 'layer-linetype';
   else
     Result := 'slot-' + IntToStr(Ord(Slot));
   end;

--- a/cad_source/zengine/fileformats/dwg/uzedwgsidefiles.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgsidefiles.pas
@@ -229,9 +229,10 @@ begin
     rsLayer:         Result := 'rsLayer';
     rsLineType:      Result := 'rsLineType';
     rsTextStyle:     Result := 'rsTextStyle';
-    rsDimStyle:      Result := 'rsDimStyle';
-    rsBlockDef:      Result := 'rsBlockDef';
-    rsLayerLineType: Result := 'rsLayerLineType';
+    rsDimStyle:          Result := 'rsDimStyle';
+    rsBlockDef:          Result := 'rsBlockDef';
+    rsDimStyleTextStyle: Result := 'rsDimStyleTextStyle';
+    rsLayerLineType:     Result := 'rsLayerLineType';
   else
     Result := 'rs?';
   end;

--- a/cad_source/zengine/fileformats/dwg/uzedwgtables.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgtables.pas
@@ -408,6 +408,8 @@ var
   PDimStyle: PGDBDimStyle;
   Name: string;
   Handle: QWord;
+  TextStyleCandidates: TDWGRefHandleCandidates;
+  FallbackTextStyle: PGDBTextStyle;
   Ctx: TDWGZCADLoadContext;
 begin
   BITCODE_T2Text(PDWGDimStyle^.name, DWGContext, Name);
@@ -428,17 +430,28 @@ begin
   if PDimStyle = nil then
     PDimStyle := DWGEnsureDimStyle(ZContext.PDrawing^);
   ApplyDimStyleScalars(PDimStyle, PDWGDimStyle);
-  if (PDimStyle <> nil) and (PDimStyle^.Text.DIMTXSTY = nil) then
-    PDimStyle^.Text.DIMTXSTY := ZContext.PDrawing^.TextStyleTable.FindStyle(
-      'Standard', False);
+  FallbackTextStyle := nil;
+  if PDimStyle <> nil then begin
+    if PDimStyle^.Text.DIMTXSTY = nil then
+      PDimStyle^.Text.DIMTXSTY := ZContext.PDrawing^.TextStyleTable.FindStyle(
+        'Standard', False);
+    FallbackTextStyle := PDimStyle^.Text.DIMTXSTY;
+  end;
   if (PDimStyle <> nil) and (ZContext.PDrawing^.CurrentDimStyle = nil) then
     ZContext.PDrawing^.CurrentDimStyle := PDimStyle;
 
   Ctx := GetLoadCtx;
   if Ctx <> nil then begin
     Handle := DWGObjectHandleValue(DWGObject);
-    if Handle <> 0 then
+    if Handle <> 0 then begin
       Ctx.RegisterShell(Handle, dokDimStyle, PDimStyle, -1);
+      if (PDimStyle <> nil) and
+         DWGRefHandleCandidatesValue(PDWGDimStyle^.DIMTXSTY,
+           TextStyleCandidates) then
+        Ctx.QueueRefResolveCandidates(PDimStyle, Handle,
+          TextStyleCandidates.Values, TextStyleCandidates.Count, dokTextStyle,
+          rsDimStyleTextStyle, FallbackTextStyle);
+    end;
   end;
 end;
 

--- a/cad_source/zengine/fileformats/dwg/uzedwgtypes.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgtypes.pas
@@ -143,7 +143,11 @@ type
     { Issue #1122: layer.LT refs target a PGDBLayerProp, not an entity vp
       record. Keep this as a distinct slot so the callback cannot write the
       resolved LTYPE pointer into entity memory when the target is a layer. }
-    rsLayerLineType
+    rsLayerLineType,
+    { Issue #1250: DIMSTYLE.DIMTXSTY refs target a PGDBDimStyle, not a
+      text entity. Resolve them through their own slot so dimension text can
+      honor a fixed-height text style before falling back to DIMTXT. }
+    rsDimStyleTextStyle
   );
 
   { Attach callback context supplied by the resolver from the exact pending


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1250

## Problem
DWG DIMSTYLE records copied `DIMTXT` and `DIMSCALE`, but ignored the `DIMTXSTY` handle. Dimensions therefore kept the fallback `Standard` text style, so the existing dimension renderer could not apply a fixed text-style height before falling back to `DIMTXT * DIMSCALE`.

## Solution
- Add a dedicated deferred ref slot for `DIMSTYLE.DIMTXSTY` so the loader resolves the text style onto the imported dimstyle.
- Attach the resolved `PGDBTextStyle` to `PGDBDimStyle.Text.DIMTXSTY`, with the existing Standard text style fallback.
- Add resolver regression coverage for dimstyle text styles declared after the dimstyle and for null text-style fallback.

## Testing
- `git diff --check`
- `fpc -Fu.. -Fu../.. -Fu../model -Fu../mappers fpdwg_tests.lpr` was attempted from `cad_source/components/fpdwg/inspector/tests/` and is blocked locally because `fpc` is not installed in this environment.

No screenshot is included because the fix is in the DWG loader reference-resolution path and is covered by focused resolver tests.
