### PR TITLE
DXF: add LEADER entity support

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-29T21:20:08.781Z for PR creation at branch issue-1252-72ba2acebfb1 for issue https://github.com/veb86/zcadvelecAI/issues/1252

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-29T21:20:08.781Z for PR creation at branch issue-1252-72ba2acebfb1 for issue https://github.com/veb86/zcadvelecAI/issues/1252

--- a/cad_source/zcad.lpi
+++ b/cad_source/zcad.lpi
@@ -501,7 +501,7 @@
         <PackageName Value="LCL"/>
       </Item29>
     </RequiredPackages>
-    <Units Count="181">
+    <Units Count="182">
       <Unit0>
         <Filename Value="zcad.pas"/>
         <IsPartOfProject Value="True"/>
@@ -1297,6 +1297,10 @@
         <Filename Value="zcad/commands/uzccommand_dataexport.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit180>
+      <Unit181>
+        <Filename Value="zengine/core/entities/uzeentleader.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit181>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/cad_source/zcad.pas
+++ b/cad_source/zcad.pas
@@ -103,6 +103,7 @@ uses
   uzeentpolylinegeneric,
   uzeentpolyline,
   uzeentpolyfacemesh,
+  uzeentleader,
   uzeEntSpline,
   uzeenttable,
 

--- a/cad_source/zengine/core/entities/uzeentleader.pas
+++ b/cad_source/zengine/core/entities/uzeentleader.pas
@@ -1,0 +1,310 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+
+unit uzeentleader;
+{$Mode delphi}{$H+}
+{$INCLUDE zengineconfig.inc}
+
+interface
+
+uses
+  uzeentityfactory,uzgldrawcontext,uzedrawingdef,uzecamera,UGDBVectorSnapArray,
+  uzestyleslayers,uzeentsubordinated,uzeentcurve,UGDBSelectedObjArray,
+  uzeentity,uzctnrVectorBytesStream,uzeTypes,uzeconsts,uzglviewareadata,
+  uzegeometrytypes,uzegeometry,uzeffdxfsupport,SysUtils,uzesnap,
+  uzMVReader,uzCtnrVectorpBaseEntity;
+
+type
+  PGDBObjLeader=^GDBObjLeader;
+
+  GDBObjLeader=object(GDBObjCurve)
+    DimStyleName:string;
+    ArrowHeadFlag:integer;
+    PathType:integer;
+    AnnotationType:integer;
+    HookLineDirectionFlag:integer;
+    HookLineFlag:integer;
+    TextHeight:double;
+    TextWidth:double;
+    AnnotationHandle:TDWGHandle;
+    NormalVector:TzePoint3d;
+    HorizontalDirection:TzePoint3d;
+    BlockOffset:TzePoint3d;
+    AnnotationOffset:TzePoint3d;
+
+    constructor init(own:Pointer;layeraddres:PGDBLayerProp;LW:smallint);
+    constructor initnul(owner:PGDBObjGenericWithSubordinated);
+    destructor done;virtual;
+
+    procedure LoadFromDXF(var rdr:TZMemReader;ptu:PExtensionData;
+      var drawing:TDrawingDef;var context:TIODXFLoadContext);virtual;
+    procedure SaveToDXF(var outStream:TZctnrVectorBytes;
+      var drawing:TDrawingDef;var IODXFContext:TIODXFSaveContext);virtual;
+    procedure FormatEntity(var drawing:TDrawingDef;
+      var DC:TDrawContext;Stage:TEFStages=EFAllStages);virtual;
+    procedure DrawGeometry(lw:integer;var DC:TDrawContext;
+      const inFrustumState:TInBoundingVolume);virtual;
+    function Clone(own:Pointer):PGDBObjEntity;virtual;
+    function GetObjTypeName:string;virtual;
+    function GetObjType:TObjID;virtual;
+    function CalcTrueInFrustum(
+      const frustum:TzeFrustum):TInBoundingVolume;virtual;
+    class function CreateInstance:PGDBObjLeader;static;
+  end;
+
+  function AllocAndInitLeader(owner:PGDBObjGenericWithSubordinated):PGDBObjLeader;
+
+implementation
+
+procedure InitLeaderDefaults(var Leader:GDBObjLeader);
+begin
+  Leader.DimStyleName:='';
+  Leader.ArrowHeadFlag:=1;
+  Leader.PathType:=0;
+  Leader.AnnotationType:=3;
+  Leader.HookLineDirectionFlag:=0;
+  Leader.HookLineFlag:=0;
+  Leader.TextHeight:=0;
+  Leader.TextWidth:=0;
+  Leader.AnnotationHandle:=0;
+  Leader.NormalVector:=CreateVertex(0,0,1);
+  Leader.HorizontalDirection:=CreateVertex(1,0,0);
+  Leader.BlockOffset:=NulVertex;
+  Leader.AnnotationOffset:=NulVertex;
+end;
+
+function IsZeroVertex(const Vertex:TzePoint3d):boolean;
+begin
+  Result:=(Vertex.x=0)and(Vertex.y=0)and(Vertex.z=0);
+end;
+
+function IsSameVertex(const Left,Right:TzePoint3d):boolean;
+begin
+  Result:=(Left.x=Right.x)and(Left.y=Right.y)and(Left.z=Right.z);
+end;
+
+constructor GDBObjLeader.init(own:Pointer;layeraddres:PGDBLayerProp;LW:smallint);
+begin
+  inherited init(own,layeraddres,lw);
+  InitLeaderDefaults(self);
+end;
+
+constructor GDBObjLeader.initnul(owner:PGDBObjGenericWithSubordinated);
+begin
+  inherited initnul(owner);
+  bp.ListPos.Owner:=owner;
+  InitLeaderDefaults(self);
+end;
+
+destructor GDBObjLeader.done;
+begin
+  DimStyleName:='';
+  inherited;
+end;
+
+procedure GDBObjLeader.LoadFromDXF(var rdr:TZMemReader;ptu:PExtensionData;
+  var drawing:TDrawingDef;var context:TIODXFLoadContext);
+var
+  DXFGroupCode:integer;
+  CurrentVertex:TzePoint3d;
+  HasCurrentVertex:boolean;
+  VertexCount:integer;
+
+  procedure PushCurrentVertex;
+  begin
+    if HasCurrentVertex then begin
+      VertexArrayInOCS.PushBackData(CurrentVertex);
+      CurrentVertex:=NulVertex;
+      HasCurrentVertex:=False;
+    end;
+  end;
+
+begin
+  VertexArrayInOCS.Clear;
+  CurrentVertex:=NulVertex;
+  HasCurrentVertex:=False;
+  VertexCount:=0;
+
+  DXFGroupCode:=rdr.ParseInteger;
+  while DXFGroupCode<>0 do begin
+    if not LoadFromDXFObjShared(rdr,DXFGroupCode,ptu,drawing,context) then
+      if dxfLoadGroupCodeString(rdr,3,DXFGroupCode,DimStyleName,context.Header) then
+      else if dxfLoadGroupCodeInteger(rdr,71,DXFGroupCode,ArrowHeadFlag) then
+      else if dxfLoadGroupCodeInteger(rdr,72,DXFGroupCode,PathType) then
+      else if dxfLoadGroupCodeInteger(rdr,73,DXFGroupCode,AnnotationType) then
+      else if dxfLoadGroupCodeInteger(rdr,74,DXFGroupCode,HookLineDirectionFlag) then
+      else if dxfLoadGroupCodeInteger(rdr,75,DXFGroupCode,HookLineFlag) then
+      else if dxfLoadGroupCodeInteger(rdr,76,DXFGroupCode,VertexCount) then
+      else if dxfLoadGroupCodeDouble(rdr,40,DXFGroupCode,TextHeight) then
+      else if dxfLoadGroupCodeDouble(rdr,41,DXFGroupCode,TextWidth) then
+      else if dxfLoadGroupCodeVertex(rdr,210,DXFGroupCode,NormalVector) then
+      else if dxfLoadGroupCodeVertex(rdr,211,DXFGroupCode,HorizontalDirection) then
+      else if dxfLoadGroupCodeVertex(rdr,212,DXFGroupCode,BlockOffset) then
+      else if dxfLoadGroupCodeVertex(rdr,213,DXFGroupCode,AnnotationOffset) then
+      else begin
+        case DXFGroupCode of
+          10:begin
+            PushCurrentVertex;
+            CurrentVertex:=NulVertex;
+            CurrentVertex.x:=rdr.ParseDouble;
+            HasCurrentVertex:=True;
+          end;
+          20:begin
+            CurrentVertex.y:=rdr.ParseDouble;
+            HasCurrentVertex:=True;
+          end;
+          30:begin
+            CurrentVertex.z:=rdr.ParseDouble;
+            HasCurrentVertex:=True;
+            PushCurrentVertex;
+          end;
+          340:begin
+            AnnotationHandle:=DXFHandle(rdr.ParseShortString);
+          end;
+        else
+          rdr.SkipString;
+        end;
+      end;
+    DXFGroupCode:=rdr.ParseInteger;
+  end;
+
+  PushCurrentVertex;
+  VertexArrayInOCS.Shrink;
+end;
+
+procedure GDBObjLeader.SaveToDXF(var outStream:TZctnrVectorBytes;
+  var drawing:TDrawingDef;var IODXFContext:TIODXFSaveContext);
+var
+  i:integer;
+begin
+  SaveToDXFObjPrefix(outStream,'LEADER','AcDbLeader',IODXFContext);
+  if DimStyleName<>'' then
+    dxfStringout(outStream,3,DimStyleName,IODXFContext.Header);
+  dxfIntegerout(outStream,71,ArrowHeadFlag);
+  dxfIntegerout(outStream,72,PathType);
+  dxfIntegerout(outStream,73,AnnotationType);
+  dxfIntegerout(outStream,74,HookLineDirectionFlag);
+  dxfIntegerout(outStream,75,HookLineFlag);
+  if TextHeight<>0 then
+    dxfDoubleout(outStream,40,TextHeight);
+  if TextWidth<>0 then
+    dxfDoubleout(outStream,41,TextWidth);
+  dxfIntegerout(outStream,76,VertexArrayInOCS.Count);
+  for i:=0 to VertexArrayInOCS.Count-1 do
+    dxfvertexout(outStream,10,VertexArrayInOCS.Items[i]);
+  if AnnotationHandle<>0 then
+    dxfStringWithoutEncodeOut(outStream,340,IntToHex(AnnotationHandle,0));
+  if not IsSameVertex(NormalVector,CreateVertex(0,0,1)) then
+    dxfvertexout(outStream,210,NormalVector);
+  if not IsSameVertex(HorizontalDirection,CreateVertex(1,0,0)) then
+    dxfvertexout(outStream,211,HorizontalDirection);
+  if not IsZeroVertex(BlockOffset) then
+    dxfvertexout(outStream,212,BlockOffset);
+  if not IsZeroVertex(AnnotationOffset) then
+    dxfvertexout(outStream,213,AnnotationOffset);
+end;
+
+procedure GDBObjLeader.FormatEntity(var drawing:TDrawingDef;
+  var DC:TDrawContext;Stage:TEFStages=EFAllStages);
+begin
+  if assigned(EntExtensions) then
+    EntExtensions.RunOnBeforeEntityFormat(@self,drawing,DC);
+
+  if (Stage=EFAllStages)or(EFCalcEntityCS in Stage) then begin
+    FormatWithoutSnapArray;
+    calcbb(dc);
+    CalcActualVisible(dc.DrawingContext.VActuality);
+  end;
+
+  if ((Stage=EFAllStages)or(EFDraw in Stage))and
+     (not (ESTemp in State))and(DCODrawable in DC.Options) then begin
+    Representation.Clear;
+    if VertexArrayInWCS.Count>1 then
+      Representation.DrawPolyLineWithLT(dc,VertexArrayInWCS,vp,False,False);
+  end;
+
+  if assigned(EntExtensions) then
+    EntExtensions.RunOnAfterEntityFormat(@self,drawing,DC);
+end;
+
+procedure GDBObjLeader.DrawGeometry(lw:integer;var DC:TDrawContext;
+  const inFrustumState:TInBoundingVolume);
+begin
+  Representation.DrawGeometry(DC,VP.BoundingBox,inFrustumState);
+end;
+
+function GDBObjLeader.Clone(own:Pointer):PGDBObjEntity;
+var
+  Leader:PGDBObjLeader;
+begin
+  Leader:=AllocAndInitLeader(PGDBObjGenericWithSubordinated(own));
+  Leader^.DimStyleName:=DimStyleName;
+  Leader^.ArrowHeadFlag:=ArrowHeadFlag;
+  Leader^.PathType:=PathType;
+  Leader^.AnnotationType:=AnnotationType;
+  Leader^.HookLineDirectionFlag:=HookLineDirectionFlag;
+  Leader^.HookLineFlag:=HookLineFlag;
+  Leader^.TextHeight:=TextHeight;
+  Leader^.TextWidth:=TextWidth;
+  Leader^.AnnotationHandle:=AnnotationHandle;
+  Leader^.NormalVector:=NormalVector;
+  Leader^.HorizontalDirection:=HorizontalDirection;
+  Leader^.BlockOffset:=BlockOffset;
+  Leader^.AnnotationOffset:=AnnotationOffset;
+  CopyVPto(Leader^);
+  CopyExtensionsTo(Leader^);
+  Leader^.VertexArrayInOCS.SetSize(VertexArrayInOCS.Count);
+  VertexArrayInOCS.copyto(Leader^.VertexArrayInOCS);
+  Leader^.bp.ListPos.Owner:=own;
+  Result:=Leader;
+end;
+
+function GDBObjLeader.GetObjTypeName:string;
+begin
+  Result:=ObjN_GDBObjLeader;
+end;
+
+function GDBObjLeader.GetObjType:TObjID;
+begin
+  Result:=GDBLeaderID;
+end;
+
+function GDBObjLeader.CalcTrueInFrustum(
+  const frustum:TzeFrustum):TInBoundingVolume;
+begin
+  Result:=VertexArrayInWCS.CalcTrueInFrustum(frustum,False);
+end;
+
+function AllocLeader:PGDBObjLeader;
+begin
+  Getmem(pointer(Result),sizeof(GDBObjLeader));
+  FillChar(Result^,sizeof(GDBObjLeader),0);
+end;
+
+function AllocAndInitLeader(owner:PGDBObjGenericWithSubordinated):PGDBObjLeader;
+begin
+  Result:=AllocLeader;
+  Result^.initnul(owner);
+  Result^.bp.ListPos.Owner:=owner;
+end;
+
+class function GDBObjLeader.CreateInstance:PGDBObjLeader;
+begin
+  Result:=AllocAndInitLeader(nil);
+end;
+
+begin
+  RegisterDXFEntity(GDBLeaderID,'LEADER','Leader',@AllocLeader,@AllocAndInitLeader);
+end.

--- a/cad_source/zengine/core/uzeconsts.pas
+++ b/cad_source/zengine/core/uzeconsts.pas
@@ -51,6 +51,7 @@ const {as_normal=0;
   GDBHatchID = 16;
   GDBPolyFaceMeshID = 17;
   GDBGenericPolylineID = 18;
+  GDBLeaderID = 19;
 
   GDBNetID = 100;
   GDBDeviceID = 101;
@@ -163,6 +164,7 @@ const {as_normal=0;
   ObjN_GDBObjElLeader='GDBObjElLeader';
   ObjN_GDBObjHatch='GDBObjHatch';
   ObjN_GDBObjPolyFaceMesh='GDBObjPolyFaceMesh';
+  ObjN_GDBObjLeader='GDBObjLeader';
   ObjN_GDBObjAcadTable='GDBObjAcadTable';
   { Наименование типа для прокси-объекта AutoCAD }
   ObjN_GDBObjAcdProxy='GDBObjAcdProxy';

--- a/cad_source/zengine/tests/testzengine.lpr
+++ b/cad_source/zengine/tests/testzengine.lpr
@@ -7,7 +7,7 @@ uses
   Classes, consoletestrunner,
   Logtest,BoundaryPathSimpletest,
   uzctEntityArc, uzctmtextwrap, uzctenttextjustify, uzctacadtable, uzctentproxy,
-  uzctentpolyfacemesh, uzctdwgblockreserve, uzctenttextnilstyle,
+  uzctentpolyfacemesh, uzctentleader, uzctdwgblockreserve, uzctenttextnilstyle,
   uzctenttransformscalars;
 
 var

--- a/cad_source/zengine/tests/uzctentleader.pas
+++ b/cad_source/zengine/tests/uzctentleader.pas
@@ -1,0 +1,204 @@
+unit uzctentleader;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  SysUtils,
+  Interfaces,
+  fpcunit,
+  testregistry,
+  uzeconsts,
+  uzeentity,
+  uzeentityfactory,
+  uzeentleader,
+  uzeffdxf,
+  uzeffmanager,
+  uzegeometry,
+  uzegeometrytypes,
+  uzedrawingsimple,
+  uzgldrawcontext,
+  uzeTypes;
+
+type
+  TLeaderEntityTest = class(TTestCase)
+  published
+    procedure RegistersDXFEntity;
+    procedure MinimalDXFLoadsLeaderEntity;
+    procedure CloneCopiesVerticesAndMetadata;
+  end;
+
+implementation
+
+const
+  DXF_LEADER_ENTITY_CONTENT =
+    '  0' + #13#10 + 'SECTION'  + #13#10 +
+    '  2' + #13#10 + 'HEADER'   + #13#10 +
+    '  0' + #13#10 + 'ENDSEC'   + #13#10 +
+    '  0' + #13#10 + 'SECTION'  + #13#10 +
+    '  2' + #13#10 + 'TABLES'   + #13#10 +
+    '  0' + #13#10 + 'ENDSEC'   + #13#10 +
+    '  0' + #13#10 + 'SECTION'  + #13#10 +
+    '  2' + #13#10 + 'ENTITIES' + #13#10 +
+    '  0' + #13#10 + 'LEADER'   + #13#10 +
+    '  5' + #13#10 + '297'      + #13#10 +
+    '330' + #13#10 + '1F'       + #13#10 +
+    '100' + #13#10 + 'AcDbEntity' + #13#10 +
+    '  8' + #13#10 + '0'        + #13#10 +
+    '100' + #13#10 + 'AcDbLeader' + #13#10 +
+    '  3' + #13#10 + 'ISO-25'   + #13#10 +
+    ' 73' + #13#10 + '0'        + #13#10 +
+    ' 74' + #13#10 + '0'        + #13#10 +
+    ' 75' + #13#10 + '1'        + #13#10 +
+    ' 40' + #13#10 + '15.02046384720327' + #13#10 +
+    ' 41' + #13#10 + '13.60845839017735' + #13#10 +
+    ' 76' + #13#10 + '3'        + #13#10 +
+    ' 10' + #13#10 + '1.0'      + #13#10 +
+    ' 20' + #13#10 + '2.0'      + #13#10 +
+    ' 30' + #13#10 + '0.0'      + #13#10 +
+    ' 10' + #13#10 + '3.0'      + #13#10 +
+    ' 20' + #13#10 + '4.0'      + #13#10 +
+    ' 30' + #13#10 + '0.0'      + #13#10 +
+    ' 10' + #13#10 + '5.0'      + #13#10 +
+    ' 20' + #13#10 + '6.0'      + #13#10 +
+    ' 30' + #13#10 + '0.0'      + #13#10 +
+    '340' + #13#10 + '298'      + #13#10 +
+    '213' + #13#10 + '5.609187033556736' + #13#10 +
+    '223' + #13#10 + '30.6637564603418'  + #13#10 +
+    '233' + #13#10 + '0.0'      + #13#10 +
+    '  0' + #13#10 + 'ENDSEC'   + #13#10 +
+    '  0' + #13#10 + 'EOF'      + #13#10;
+
+function WriteLeaderTempDXF(const Content:string):string;
+var
+  F:TextFile;
+begin
+  Result:=GetTempDir+'test_leader_'+IntToStr(Random(MaxInt))+'.dxf';
+  AssignFile(F,Result);
+  Rewrite(F);
+  Write(F,Content);
+  CloseFile(F);
+end;
+
+function LoadLeaderDXFContent(const Content:string;
+  var Drawing:TSimpleDrawing):integer;
+var
+  DC:TDrawContext;
+  TempFile:string;
+  ZDC:TZDrawingContext;
+begin
+  TempFile:=WriteLeaderTempDXF(Content);
+  try
+    Drawing.init(nil);
+    DC:=Drawing.CreateDrawingRC;
+    ZDC.CreateRec(Drawing,Drawing.pObjRoot^,TLOLoad,DC);
+    AddFromDXF(TempFile,ZDC);
+    Result:=Drawing.pObjRoot^.ObjArray.Count;
+  finally
+    SysUtils.DeleteFile(TempFile);
+  end;
+end;
+
+procedure TLeaderEntityTest.RegistersDXFEntity;
+var
+  Info:TEntInfoData;
+begin
+  CheckTrue(DXFName2EntInfoData.MyGetValue('LEADER',Info),
+    'LEADER must be registered as a DXF entity');
+  CheckEquals(GDBLeaderID,Info.EntityID,'LEADER must use the leader entity id');
+end;
+
+procedure TLeaderEntityTest.MinimalDXFLoadsLeaderEntity;
+var
+  Drawing:TSimpleDrawing;
+  Entity:PGDBObjEntity;
+  EntityCount:integer;
+  Leader:PGDBObjLeader;
+  Vertex:PzePoint3d;
+begin
+  EntityCount:=LoadLeaderDXFContent(DXF_LEADER_ENTITY_CONTENT,Drawing);
+  try
+    CheckEquals(1,EntityCount,'DXF LEADER must load as one entity');
+    Entity:=PGDBObjEntity(Drawing.pObjRoot^.ObjArray.GetData(0));
+    CheckEquals(GDBLeaderID,Entity^.GetObjType);
+
+    Leader:=PGDBObjLeader(Entity);
+    CheckEquals('ISO-25',Leader^.DimStyleName);
+    CheckEquals(0,Leader^.AnnotationType);
+    CheckEquals(0,Leader^.HookLineDirectionFlag);
+    CheckEquals(1,Leader^.HookLineFlag);
+    CheckEquals(15.02046384720327,Leader^.TextHeight,1e-9);
+    CheckEquals(13.60845839017735,Leader^.TextWidth,1e-9);
+    CheckEquals(Int64($298),Int64(Leader^.AnnotationHandle));
+    CheckEquals(3,Leader^.VertexArrayInOCS.Count);
+
+    Vertex:=Leader^.VertexArrayInOCS.getDataMutable(2);
+    CheckEquals(5.0,Vertex^.x,1e-9);
+    CheckEquals(6.0,Vertex^.y,1e-9);
+    CheckEquals(0.0,Vertex^.z,1e-9);
+    CheckEquals(5.609187033556736,Leader^.AnnotationOffset.x,1e-9);
+    CheckEquals(30.6637564603418,Leader^.AnnotationOffset.y,1e-9);
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TLeaderEntityTest.CloneCopiesVerticesAndMetadata;
+var
+  Leader:PGDBObjLeader;
+  Clone:PGDBObjLeader;
+  Vertex:PzePoint3d;
+begin
+  Leader:=AllocAndInitLeader(nil);
+  try
+    Leader^.DimStyleName:='ISO-25';
+    Leader^.ArrowHeadFlag:=0;
+    Leader^.PathType:=1;
+    Leader^.AnnotationType:=2;
+    Leader^.HookLineDirectionFlag:=1;
+    Leader^.HookLineFlag:=1;
+    Leader^.TextHeight:=15.5;
+    Leader^.TextWidth:=13.25;
+    Leader^.AnnotationHandle:=$298;
+    Leader^.NormalVector:=CreateVertex(0,0,1);
+    Leader^.HorizontalDirection:=CreateVertex(1,0,0);
+    Leader^.AnnotationOffset:=CreateVertex(5.6,30.6,0);
+    Leader^.AddVertex(CreateVertex(1,2,3));
+    Leader^.AddVertex(CreateVertex(4,5,6));
+
+    Clone:=PGDBObjLeader(Leader^.Clone(nil));
+    try
+      CheckEquals(ObjN_GDBObjLeader,Clone^.GetObjTypeName);
+      CheckEquals(GDBLeaderID,Clone^.GetObjType);
+      CheckEquals('ISO-25',Clone^.DimStyleName);
+      CheckEquals(0,Clone^.ArrowHeadFlag);
+      CheckEquals(1,Clone^.PathType);
+      CheckEquals(2,Clone^.AnnotationType);
+      CheckEquals(1,Clone^.HookLineDirectionFlag);
+      CheckEquals(1,Clone^.HookLineFlag);
+      CheckEquals(15.5,Clone^.TextHeight,1e-9);
+      CheckEquals(13.25,Clone^.TextWidth,1e-9);
+      CheckEquals(Int64($298),Int64(Clone^.AnnotationHandle));
+      CheckEquals(2,Clone^.VertexArrayInOCS.Count);
+
+      Vertex:=Clone^.VertexArrayInOCS.getDataMutable(1);
+      CheckEquals(4.0,Vertex^.x,1e-9);
+      CheckEquals(5.0,Vertex^.y,1e-9);
+      CheckEquals(6.0,Vertex^.z,1e-9);
+      CheckEquals(5.6,Clone^.AnnotationOffset.x,1e-9);
+      CheckEquals(30.6,Clone^.AnnotationOffset.y,1e-9);
+    finally
+      Clone^.done;
+      FreeMem(Pointer(Clone));
+    end;
+  finally
+    Leader^.done;
+    FreeMem(Pointer(Leader));
+  end;
+end;
+
+initialization
+  RegisterTest(TLeaderEntityTest);
+
+end.


### PR DESCRIPTION
## Summary
- Added native `GDBObjLeader` support and registered DXF `LEADER` in the entity factory.
- Parse/save LEADER dimstyle, flags, text size, vertices, annotation handle, normal/horizontal vectors, and block/annotation offsets.
- Wire the unit into `zcad` and the Lazarus project, and render the leader path as an open curve polyline.
- Added zengine tests for DXF registration, minimal LEADER loading, and clone metadata/vertex copying.

## Reproduction
Before this change, `cad_source/test/simpleleader.dxf` contains a `LEADER` entity that has no native entity implementation/registration. The new `MinimalDXFLoadsLeaderEntity` test covers a minimal LEADER fixture and asserts it loads as `GDBLeaderID` with the expected metadata and vertices.

## Verification
- Fixture sanity check: `cad_source/test/simpleleader.dxf` has 1 LEADER at DXF line 2098 with 7 vertices, dimstyle `ISO-25`, annotation handle `298`.
- `zcad.lpi` XML parses and has 182 `<Unit*>` entries matching `Units Count="182"`.
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff upstream/master..HEAD --check`
- `make -C cad_source/zengine/tests` could not run locally because `/home/box/lazarus/lazbuild` is not installed in this environment.

## CI
No GitHub Actions runs or PR checks are currently reported for branch `issue-1252-72ba2acebfb1`.



Fixes veb86/zcadvelecAI#1252