### PR TITLE
Object inspector: register LEADER properties

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T06:56:36.233Z for PR creation at branch issue-1254-0922961e7f2c for issue https://github.com/veb86/zcadvelecAI/issues/1254

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T06:56:36.233Z for PR creation at branch issue-1254-0922961e7f2c for issue https://github.com/veb86/zcadvelecAI/issues/1254

--- a/cad_source/zcad.lpi
+++ b/cad_source/zcad.lpi
@@ -501,7 +501,7 @@
         <PackageName Value="LCL"/>
       </Item29>
     </RequiredPackages>
-    <Units Count="182">
+    <Units Count="183">
       <Unit0>
         <Filename Value="zcad.pas"/>
         <IsPartOfProject Value="True"/>
@@ -1301,6 +1301,10 @@
         <Filename Value="zengine/core/entities/uzeentleader.pas"/>
         <IsPartOfProject Value="True"/>
       </Unit181>
+      <Unit182>
+        <Filename Value="zcad/register/uzcregleader.pas"/>
+        <IsPartOfProject Value="True"/>
+      </Unit182>
     </Units>
   </ProjectOptions>
   <CompilerOptions>

--- a/cad_source/zcad.pas
+++ b/cad_source/zcad.pas
@@ -366,6 +366,7 @@ uses
   uzcregisterenitiesfeatures,
   uzcregisterenitiesextenders,
   uzcoiregistermultiproperties,
+  uzcregleader,
   uzclibraryblocksregister,
   {$IF not((DEFINED(WINDOWS))and(DEFINED(LCLQT5)))}uzglviewareaogl,uzglviewareaoglmodern,{$ENDIF}
   uzglviewareagdi,uzglviewareacanvas,

--- a/cad_source/zcad/register/uzcregleader.pas
+++ b/cad_source/zcad/register/uzcregleader.pas
@@ -1,0 +1,221 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+
+{$MODE OBJFPC}{$H+}
+unit uzcregleader;
+{$INCLUDE zengineconfig.inc}
+
+interface
+
+procedure RegisterLeaderProperties;
+
+implementation
+
+uses
+  uzcoimultiproperties,uzcoimultipropertiesutil,
+  uzeentleader,uzeconsts,uzegeometrytypes,
+  uzsbVarmanDef,Varman,uzbUnits,gzctnrVectorTypes,
+  UGDBPoint3DArray,uzcLog;
+
+procedure LeaderLengthEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
+  mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
+  const f:TzeUnitsFormat);
+var
+  l:Double;
+begin
+  l:=PGDBObjLeader(ChangedData.PEntity)^.GetLength;
+  ChangedData.PGetDataInEtity:=@l;
+  GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+procedure LeaderSumLengthEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
+  mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
+  const f:TzeUnitsFormat);
+var
+  l:Double;
+begin
+  l:=PGDBObjLeader(ChangedData.PEntity)^.GetLength;
+  ChangedData.PGetDataInEtity:=@l;
+  Double2SumEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+procedure LeaderVertex3DControlFromVarEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  tv:PzePoint3d;
+  v:TzePoint3d;
+  pindex:pTArrayIndex;
+  PGDBDTypeDesc:PUserTypeDescriptor;
+begin
+  if pvardesk(pdata).name=mp.MPName then
+    exit;
+
+  PGDBDTypeDesc:=SysUnit.TypeName2PTD('Double');
+  pindex:=pu^.FindValue(mp.MPName).data.Addr.Instance;
+  tv:=PGDBObjLeader(ChangedData.pentity).VertexArrayInWCS.getDataMutable(pindex^);
+  v:=tv^;
+
+  if pvardesk(pdata).name=mp.MPName+'x' then
+    PGDBDTypeDesc.CopyValueToInstance(pvardesk(pdata).data.Addr.Instance,@v.x);
+  if pvardesk(pdata).name=mp.MPName+'y' then
+    PGDBDTypeDesc.CopyValueToInstance(pvardesk(pdata).data.Addr.Instance,@v.y);
+  if pvardesk(pdata).name=mp.MPName+'z' then
+    PGDBDTypeDesc.CopyValueToInstance(pvardesk(pdata).data.Addr.Instance,@v.z);
+
+  tv:=PGDBPoint3dArray(ChangedData.PSetDataInEtity).getDataMutable(pindex^);
+  tv^:=v;
+end;
+
+procedure RegisterLeaderDoubleProperty(const name,username:string;
+  category:TMultiPropertyCategory;getoffset,setoffset:PtrInt);
+begin
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    name,username,sysunit^.TypeName2PTD('Double'),
+    category,GDBLeaderID,nil,getoffset,setoffset,
+    OneVarDataMIPD,OneVarDataEIPD);
+end;
+
+procedure RegisterLeaderIntegerProperty(const name,username:string;
+  getoffset,setoffset:PtrInt);
+begin
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    name,username,sysunit^.TypeName2PTD('Integer'),
+    MPCMisc,GDBLeaderID,nil,getoffset,setoffset,
+    OneVarDataMIPD,OneVarDataEIPD);
+end;
+
+procedure RegisterLeaderProperties;
+const
+  pleader:PGDBObjLeader=nil;
+begin
+  if sysunit=nil then
+    exit;
+
+  MultiPropertiesManager.RestartMultipropertySortID;
+
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'VertexCount','Vertex count',sysunit^.TypeName2PTD('TArrayIndex'),
+    MPCGeometry,GDBLeaderID,nil,
+    PtrInt(@pleader^.VertexArrayInOCS.Count),
+    PtrInt(@pleader^.VertexArrayInOCS.Count),
+    OneVarDataMIPD,OneVarRODataEIPD);
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'Vertex3DControl_','Vertex control',sysunit^.TypeName2PTD('TArrayIndex'),
+    MPCGeometry,GDBLeaderID,nil,
+    PtrInt(@pleader^.VertexArrayInWCS),
+    PtrInt(@pleader^.VertexArrayInOCS),
+    TMainIterateProcsData.Create(@GetVertex3DControlData,@FreeVertex3DControlData),
+    TEntIterateProcsData.Create(
+      @PolylineVertex3DControlBeforeEntIterateProc,
+      @PolylineVertex3DControlEntIterateProc,
+      @LeaderVertex3DControlFromVarEntChangeProc));
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'Length','Length',sysunit^.TypeName2PTD('Double'),
+    MPCGeometry,GDBLeaderID,nil,0,0,
+    OneVarDataMIPD,
+    TEntIterateProcsData.Create(nil,@LeaderLengthEntIterateProc,nil));
+
+  RegisterLeaderDoubleProperty(
+    'LeaderNormalX','Normal X',MPCGeometry,
+    PtrInt(@pleader^.NormalVector.x),PtrInt(@pleader^.NormalVector.x));
+  RegisterLeaderDoubleProperty(
+    'LeaderNormalY','Normal Y',MPCGeometry,
+    PtrInt(@pleader^.NormalVector.y),PtrInt(@pleader^.NormalVector.y));
+  RegisterLeaderDoubleProperty(
+    'LeaderNormalZ','Normal Z',MPCGeometry,
+    PtrInt(@pleader^.NormalVector.z),PtrInt(@pleader^.NormalVector.z));
+  RegisterLeaderDoubleProperty(
+    'LeaderHorizontalDirectionX','Horizontal direction X',MPCGeometry,
+    PtrInt(@pleader^.HorizontalDirection.x),PtrInt(@pleader^.HorizontalDirection.x));
+  RegisterLeaderDoubleProperty(
+    'LeaderHorizontalDirectionY','Horizontal direction Y',MPCGeometry,
+    PtrInt(@pleader^.HorizontalDirection.y),PtrInt(@pleader^.HorizontalDirection.y));
+  RegisterLeaderDoubleProperty(
+    'LeaderHorizontalDirectionZ','Horizontal direction Z',MPCGeometry,
+    PtrInt(@pleader^.HorizontalDirection.z),PtrInt(@pleader^.HorizontalDirection.z));
+  RegisterLeaderDoubleProperty(
+    'LeaderBlockOffsetX','Block offset X',MPCGeometry,
+    PtrInt(@pleader^.BlockOffset.x),PtrInt(@pleader^.BlockOffset.x));
+  RegisterLeaderDoubleProperty(
+    'LeaderBlockOffsetY','Block offset Y',MPCGeometry,
+    PtrInt(@pleader^.BlockOffset.y),PtrInt(@pleader^.BlockOffset.y));
+  RegisterLeaderDoubleProperty(
+    'LeaderBlockOffsetZ','Block offset Z',MPCGeometry,
+    PtrInt(@pleader^.BlockOffset.z),PtrInt(@pleader^.BlockOffset.z));
+  RegisterLeaderDoubleProperty(
+    'LeaderAnnotationOffsetX','Annotation offset X',MPCGeometry,
+    PtrInt(@pleader^.AnnotationOffset.x),PtrInt(@pleader^.AnnotationOffset.x));
+  RegisterLeaderDoubleProperty(
+    'LeaderAnnotationOffsetY','Annotation offset Y',MPCGeometry,
+    PtrInt(@pleader^.AnnotationOffset.y),PtrInt(@pleader^.AnnotationOffset.y));
+  RegisterLeaderDoubleProperty(
+    'LeaderAnnotationOffsetZ','Annotation offset Z',MPCGeometry,
+    PtrInt(@pleader^.AnnotationOffset.z),PtrInt(@pleader^.AnnotationOffset.z));
+
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'LeaderDimStyleName','Style',sysunit^.TypeName2PTD('String'),
+    MPCMisc,GDBLeaderID,nil,
+    PtrInt(@pleader^.DimStyleName),PtrInt(@pleader^.DimStyleName),
+    OneVarDataMIPD,OneVarDataEIPD);
+  RegisterLeaderIntegerProperty(
+    'LeaderArrowHeadFlag','Arrow head flag',
+    PtrInt(@pleader^.ArrowHeadFlag),PtrInt(@pleader^.ArrowHeadFlag));
+  RegisterLeaderIntegerProperty(
+    'LeaderPathType','Path type',
+    PtrInt(@pleader^.PathType),PtrInt(@pleader^.PathType));
+  RegisterLeaderIntegerProperty(
+    'LeaderAnnotationType','Annotation type',
+    PtrInt(@pleader^.AnnotationType),PtrInt(@pleader^.AnnotationType));
+  RegisterLeaderIntegerProperty(
+    'LeaderHookLineDirectionFlag','Hook line direction flag',
+    PtrInt(@pleader^.HookLineDirectionFlag),
+    PtrInt(@pleader^.HookLineDirectionFlag));
+  RegisterLeaderIntegerProperty(
+    'LeaderHookLineFlag','Hook line flag',
+    PtrInt(@pleader^.HookLineFlag),PtrInt(@pleader^.HookLineFlag));
+  RegisterLeaderDoubleProperty(
+    'LeaderTextHeight','Text height',MPCMisc,
+    PtrInt(@pleader^.TextHeight),PtrInt(@pleader^.TextHeight));
+  RegisterLeaderDoubleProperty(
+    'LeaderTextWidth','Text width',MPCMisc,
+    PtrInt(@pleader^.TextWidth),PtrInt(@pleader^.TextWidth));
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'LeaderAnnotationHandle','Annotation handle',sysunit^.TypeName2PTD('QWord'),
+    MPCMisc,GDBLeaderID,nil,
+    PtrInt(@pleader^.AnnotationHandle),PtrInt(@pleader^.AnnotationHandle),
+    OneVarDataMIPD,OneVarRODataEIPD);
+
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'TotalVertexCount','Total vertex count',sysunit^.TypeName2PTD('TArrayIndex'),
+    MPCSummary,GDBLeaderID,nil,
+    PtrInt(@pleader^.VertexArrayInOCS.Count),
+    PtrInt(@pleader^.VertexArrayInOCS.Count),
+    OneVarDataMIPD,
+    TEntIterateProcsData.Create(nil,@TArrayIndex2SumEntIterateProc,nil));
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'TotalLength','Total length',sysunit^.TypeName2PTD('Double'),
+    MPCSummary,GDBLeaderID,nil,0,0,
+    OneVarDataMIPD,
+    TEntIterateProcsData.Create(nil,@LeaderSumLengthEntIterateProc,nil));
+
+  MultiPropertiesManager.sort;
+end;
+
+initialization
+  RegisterLeaderProperties;
+finalization
+  ProgramLog.LogOutFormatStr('Unit "%s" finalization',[{$INCLUDE %FILE%}],
+    LM_Info,UnitsFinalizeLMId);
+end.

--- a/experiments/test_leader_inspector_registration.py
+++ b/experiments/test_leader_inspector_registration.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+import xml.etree.ElementTree as ET
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEADER_UNIT = ROOT / "cad_source" / "zcad" / "register" / "uzcregleader.pas"
+ZCAD_MAIN = ROOT / "cad_source" / "zcad.pas"
+ZCAD_LPI = ROOT / "cad_source" / "zcad.lpi"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(text: str, needle: str, context: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{context}: missing {needle!r}")
+
+
+def test_leader_registration_unit() -> None:
+    source = read(LEADER_UNIT)
+
+    for property_name in (
+        "VertexCount",
+        "Vertex3DControl_",
+        "Length",
+        "LeaderDimStyleName",
+        "LeaderArrowHeadFlag",
+        "LeaderPathType",
+        "LeaderAnnotationType",
+        "LeaderHookLineDirectionFlag",
+        "LeaderHookLineFlag",
+        "LeaderTextHeight",
+        "LeaderTextWidth",
+        "LeaderAnnotationHandle",
+        "TotalVertexCount",
+        "TotalLength",
+    ):
+        assert_contains(source, f"'{property_name}'", "leader multiproperty")
+
+    if source.count("GDBLeaderID") < 8:
+        raise AssertionError("expected leader registrations")
+    if source.count("MPCGeometry") < 3:
+        raise AssertionError("expected leader geometry properties")
+    if source.count("MPCMisc") < 3:
+        raise AssertionError("expected leader misc properties")
+    if len(re.findall(r"MPCSummary,GDBLeaderID", source)) < 2:
+        raise AssertionError("expected leader summary properties")
+
+
+def test_leader_registration_is_wired() -> None:
+    assert_contains(read(ZCAD_MAIN), "uzcregleader", "zcad.pas uses")
+
+    tree = ET.parse(ZCAD_LPI)
+    units = tree.findall(".//Units")[0]
+    declared_count = int(units.attrib["Count"])
+    unit_nodes = [child for child in units if re.fullmatch(r"Unit\d+", child.tag)]
+    filenames = [
+        filename.attrib["Value"]
+        for unit in unit_nodes
+        for filename in unit.findall("Filename")
+    ]
+
+    if declared_count != len(unit_nodes):
+        raise AssertionError(
+            f"zcad.lpi Units Count={declared_count}, actual Unit nodes={len(unit_nodes)}"
+        )
+    if "zcad/register/uzcregleader.pas" not in filenames:
+        raise AssertionError("zcad.lpi does not include uzcregleader.pas")
+
+
+if __name__ == "__main__":
+    test_leader_registration_unit()
+    test_leader_registration_is_wired()


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1254

## Summary
- Added `cad_source/zcad/register/uzcregleader.pas` to register object-inspector multiproperties for `GDBLeaderID`.
- Reused polyline-style vertex count, vertex control, length, and summary registrations for LEADER geometry.
- Added LEADER metadata fields for dim style name, flags, text size, annotation handle, normal/horizontal vectors, and block/annotation offsets.
- Wired the new registration unit into `zcad.pas` and `zcad.lpi`.

## Reproduction
Before this change, `GDBObjLeader` returned `GDBLeaderID`, but no object-inspector multiproperty registration targeted that entity id. The new `experiments/test_leader_inspector_registration.py` check fails on the base branch because `cad_source/zcad/register/uzcregleader.pas` is absent and the project is not wired to load it.

## Verification
- `python3 experiments/test_leader_inspector_registration.py`
- `python3 -m py_compile experiments/test_leader_inspector_registration.py`
- `git diff --check`
- `git diff --cached --check`
- `make -C cad_source/zengine/tests` could not run locally because `/home/box/lazarus/lazbuild` is not installed in this environment.

No screenshot is included because the change is object-inspector registration wiring and this environment cannot build/run the Lazarus UI.