### PR TITLE
Object inspector: add LEADER dropdown editors

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T12:41:27.277Z for PR creation at branch issue-1254-cbcd1133c915 for issue https://github.com/veb86/zcadvelecAI/issues/1254

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T12:41:27.277Z for PR creation at branch issue-1254-cbcd1133c915 for issue https://github.com/veb86/zcadvelecAI/issues/1254

--- a/cad_source/zcad/register/uzcregleader.pas
+++ b/cad_source/zcad/register/uzcregleader.pas
@@ -25,9 +25,14 @@ implementation
 
 uses
   uzcoimultiproperties,uzcoimultipropertiesutil,
-  uzeentleader,uzeconsts,uzegeometrytypes,
+  uzeentleader,uzeconsts,uzegeometrytypes,uzestylesdim,
   uzsbVarmanDef,Varman,uzbUnits,gzctnrVectorTypes,
-  UGDBPoint3DArray,uzcLog;
+  UGDBPoint3DArray,uzcLog,uzcdrawing,uzcdrawings,
+  zUndoCmdChgTypes,zUndoCmdChgVariable;
+
+var
+  ptdInteger:PUserTypeDescriptor=nil;
+  ptdString:PUserTypeDescriptor=nil;
 
 procedure LeaderLengthEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
   mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
@@ -95,6 +100,184 @@ begin
     name,username,sysunit^.TypeName2PTD('Integer'),
     MPCMisc,GDBLeaderID,nil,getoffset,setoffset,
     OneVarDataMIPD,OneVarDataEIPD);
+end;
+
+function GetLeaderTypeData(mp:TMultiProperty;pu:PTEntityUnit):Pointer;
+const
+  LeaderTypeNames:array[0..3] of string=(
+    'Линейная без стрелки',
+    'Сплайн без стрелки',
+    'Линейная со стрелкой',
+    'Сплайн со стрелкой');
+var
+  PVD:pvardesk;
+  t:PTEnumData;
+  i:integer;
+begin
+  result:=GetTEnumData(mp,pu);
+  PVD:=PTOneVarData(result).VDAddr.Instance;
+  if PVD<>nil then begin
+    t:=PVD^.data.Addr.Instance;
+    for i:=low(LeaderTypeNames) to high(LeaderTypeNames) do
+      t^.Enums.PushBackData(LeaderTypeNames[i]);
+    t^.Selected:=LeaderTypeIndexLinearWithArrow;
+  end;
+end;
+
+procedure LeaderTypeEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
+  mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
+  const f:TzeUnitsFormat);
+var
+  PVD:pvardesk;
+  enumindex:integer;
+begin
+  PVD:=PTOneVarData(pdata).VDAddr.Instance;
+  if @ecp=nil then
+    ProcessVariableAttributes(PVD.attrib,vda_RO,0);
+  enumindex:=LeaderTypeToEnumIndex(PGDBObjLeader(ChangedData.PEntity)^);
+  if fistrun then
+    PTEnumData(PVD.data.Addr.Instance)^.Selected:=enumindex
+  else
+    if PTEnumData(PVD.data.Addr.Instance)^.Selected<>enumindex then
+      ProcessVariableAttributes(PVD.attrib,vda_different,0);
+end;
+
+procedure LeaderTypeEntChangeProc(var UMPlaced:boolean;pu:PTEntityUnit;
+  pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  cp:UCmdChgField;
+  NewArrowHeadFlag,NewPathType:integer;
+  OldTypeIndex,NewTypeIndex:integer;
+begin
+  OldTypeIndex:=LeaderTypeToEnumIndex(PGDBObjLeader(ChangedData.PEntity)^);
+  NewTypeIndex:=PTEnumData(pvardesk(pdata)^.data.Addr.Instance)^.Selected;
+  if OldTypeIndex=NewTypeIndex then
+    exit;
+
+  NewArrowHeadFlag:=PGDBObjLeader(ChangedData.PEntity)^.ArrowHeadFlag;
+  NewPathType:=PGDBObjLeader(ChangedData.PEntity)^.PathType;
+  case NewTypeIndex of
+    LeaderTypeIndexLinearNoArrow:begin
+      NewArrowHeadFlag:=0;
+      NewPathType:=0;
+    end;
+    LeaderTypeIndexSplineNoArrow:begin
+      NewArrowHeadFlag:=0;
+      NewPathType:=1;
+    end;
+    LeaderTypeIndexSplineWithArrow:begin
+      NewArrowHeadFlag:=1;
+      NewPathType:=1;
+    end;
+  else
+    NewArrowHeadFlag:=1;
+    NewPathType:=0;
+  end;
+
+  if ptdInteger=nil then
+    ptdInteger:=SysUnit^.TypeName2PTD('Integer');
+  if ptdInteger=nil then
+    exit;
+
+  if PGDBObjLeader(ChangedData.PEntity)^.ArrowHeadFlag<>NewArrowHeadFlag then begin
+    PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+    cp:=UCmdChgField.CreateAndPush(
+      PTZCADDrawing(drawings.GetCurrentDWG)^.UndoStack,
+      TChangedFieldDesc.CreateRec(
+        ptdInteger,
+        @PGDBObjLeader(ChangedData.PEntity)^.ArrowHeadFlag,
+        @PGDBObjLeader(ChangedData.PEntity)^.ArrowHeadFlag),
+      TSharedPEntityData.CreateRec(ChangedData.PEntity),
+      TAfterChangePDrawing.CreateRec(drawings.GetCurrentDWG));
+    ptdInteger^.CopyValueToInstance(
+      @NewArrowHeadFlag,@PGDBObjLeader(ChangedData.PEntity)^.ArrowHeadFlag);
+  end;
+
+  if PGDBObjLeader(ChangedData.PEntity)^.PathType<>NewPathType then begin
+    PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+    cp:=UCmdChgField.CreateAndPush(
+      PTZCADDrawing(drawings.GetCurrentDWG)^.UndoStack,
+      TChangedFieldDesc.CreateRec(
+        ptdInteger,
+        @PGDBObjLeader(ChangedData.PEntity)^.PathType,
+        @PGDBObjLeader(ChangedData.PEntity)^.PathType),
+      TSharedPEntityData.CreateRec(ChangedData.PEntity),
+      TAfterChangePDrawing.CreateRec(drawings.GetCurrentDWG));
+    ptdInteger^.CopyValueToInstance(
+      @NewPathType,@PGDBObjLeader(ChangedData.PEntity)^.PathType);
+  end;
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
+end;
+
+function GetLeaderDimStyle(const Leader:PGDBObjLeader):PGDBDimStyle;
+begin
+  result:=nil;
+  if drawings.GetCurrentDWG=nil then
+    exit;
+  if (Leader<>nil)and(Leader^.DimStyleName<>'') then
+    result:=PGDBDimStyle(
+      drawings.GetCurrentDWG.DimStyleTable.getAddres(Leader^.DimStyleName));
+end;
+
+procedure LeaderDimStyleEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
+  mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
+  const f:TzeUnitsFormat);
+var
+  PVD:pvardesk;
+  CurrentStyle:PGDBDimStyle;
+  Leader:PGDBObjLeader;
+begin
+  PVD:=PTOneVarData(pdata).VDAddr.Instance;
+  Leader:=PGDBObjLeader(ChangedData.PEntity);
+  CurrentStyle:=GetLeaderDimStyle(Leader);
+
+  if @ecp=nil then
+    ProcessVariableAttributes(PVD.attrib,vda_RO,0);
+  if fistrun then begin
+    PTOneVarData(pdata)^.StrValue:=Leader^.DimStyleName;
+    PPGDBDimStyleObjInsp(PVD.data.Addr.Instance)^:=CurrentStyle;
+  end else
+    if (PTOneVarData(pdata)^.StrValue<>Leader^.DimStyleName)or
+       (PPGDBDimStyleObjInsp(PVD.data.Addr.Instance)^<>CurrentStyle) then
+      ProcessVariableAttributes(PVD.attrib,vda_different,0);
+end;
+
+procedure LeaderDimStyleEntChangeProc(var UMPlaced:boolean;pu:PTEntityUnit;
+  pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  cp:UCmdChgField;
+  NewDimStyle:PGDBDimStyle;
+  NewDimStyleName:string;
+begin
+  NewDimStyle:=PGDBDimStyle(
+    PPGDBDimStyleObjInsp(pvardesk(pdata)^.data.Addr.Instance)^);
+  if NewDimStyle=nil then
+    exit;
+
+  NewDimStyleName:=NewDimStyle^.Name;
+  if PGDBObjLeader(ChangedData.PEntity)^.DimStyleName=NewDimStyleName then
+    exit;
+
+  if ptdString=nil then
+    ptdString:=SysUnit^.TypeName2PTD('String');
+  if ptdString=nil then
+    exit;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  cp:=UCmdChgField.CreateAndPush(
+    PTZCADDrawing(drawings.GetCurrentDWG)^.UndoStack,
+    TChangedFieldDesc.CreateRec(
+      ptdString,
+      @PGDBObjLeader(ChangedData.PEntity)^.DimStyleName,
+      @PGDBObjLeader(ChangedData.PEntity)^.DimStyleName),
+    TSharedPEntityData.CreateRec(ChangedData.PEntity),
+    TAfterChangePDrawing.CreateRec(drawings.GetCurrentDWG));
+  ptdString^.CopyValueToInstance(
+    @NewDimStyleName,@PGDBObjLeader(ChangedData.PEntity)^.DimStyleName);
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
 end;
 
 procedure RegisterLeaderProperties;
@@ -166,16 +349,18 @@ begin
     PtrInt(@pleader^.AnnotationOffset.z),PtrInt(@pleader^.AnnotationOffset.z));
 
   MultiPropertiesManager.RegisterPhysMultiproperty(
-    'LeaderDimStyleName','Style',sysunit^.TypeName2PTD('String'),
-    MPCMisc,GDBLeaderID,nil,
-    PtrInt(@pleader^.DimStyleName),PtrInt(@pleader^.DimStyleName),
-    OneVarDataMIPD,OneVarDataEIPD);
-  RegisterLeaderIntegerProperty(
-    'LeaderArrowHeadFlag','Arrow head flag',
-    PtrInt(@pleader^.ArrowHeadFlag),PtrInt(@pleader^.ArrowHeadFlag));
-  RegisterLeaderIntegerProperty(
-    'LeaderPathType','Path type',
-    PtrInt(@pleader^.PathType),PtrInt(@pleader^.PathType));
+    'LeaderDimStyle','Style',sysunit^.TypeName2PTD('PGDBDimStyleObjInsp'),
+    MPCMisc,GDBLeaderID,nil,0,0,
+    OneVarDataMIPD,
+    TEntIterateProcsData.Create(
+      nil,@LeaderDimStyleEntIterateProc,@LeaderDimStyleEntChangeProc));
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'LeaderType','Type',sysunit^.TypeName2PTD('TEnumData'),
+    MPCMisc,GDBLeaderID,nil,0,0,
+    TMainIterateProcsData.Create(@GetLeaderTypeData,@FreeTEnumData),
+    TEntIterateProcsData.Create(
+      nil,@LeaderTypeEntIterateProc,@LeaderTypeEntChangeProc),
+    MPUM_AtLeastOneEntMatched);
   RegisterLeaderIntegerProperty(
     'LeaderAnnotationType','Annotation type',
     PtrInt(@pleader^.AnnotationType),PtrInt(@pleader^.AnnotationType));

--- a/cad_source/zengine/core/entities/uzeentleader.pas
+++ b/cad_source/zengine/core/entities/uzeentleader.pas
@@ -64,7 +64,15 @@ type
     class function CreateInstance:PGDBObjLeader;static;
   end;
 
+const
+  LeaderTypeIndexLinearNoArrow=0;
+  LeaderTypeIndexSplineNoArrow=1;
+  LeaderTypeIndexLinearWithArrow=2;
+  LeaderTypeIndexSplineWithArrow=3;
+
   function AllocAndInitLeader(owner:PGDBObjGenericWithSubordinated):PGDBObjLeader;
+  function LeaderTypeToEnumIndex(const Leader:GDBObjLeader):integer;
+  procedure ApplyLeaderTypeEnumIndex(var Leader:GDBObjLeader;EnumIndex:integer);
 
 implementation
 
@@ -93,6 +101,42 @@ end;
 function IsSameVertex(const Left,Right:TzePoint3d):boolean;
 begin
   Result:=(Left.x=Right.x)and(Left.y=Right.y)and(Left.z=Right.z);
+end;
+
+function LeaderTypeToEnumIndex(const Leader:GDBObjLeader):integer;
+begin
+  if Leader.PathType=1 then begin
+    if Leader.ArrowHeadFlag=0 then
+      Result:=LeaderTypeIndexSplineNoArrow
+    else
+      Result:=LeaderTypeIndexSplineWithArrow;
+  end else begin
+    if Leader.ArrowHeadFlag=0 then
+      Result:=LeaderTypeIndexLinearNoArrow
+    else
+      Result:=LeaderTypeIndexLinearWithArrow;
+  end;
+end;
+
+procedure ApplyLeaderTypeEnumIndex(var Leader:GDBObjLeader;EnumIndex:integer);
+begin
+  case EnumIndex of
+    LeaderTypeIndexLinearNoArrow:begin
+      Leader.ArrowHeadFlag:=0;
+      Leader.PathType:=0;
+    end;
+    LeaderTypeIndexSplineNoArrow:begin
+      Leader.ArrowHeadFlag:=0;
+      Leader.PathType:=1;
+    end;
+    LeaderTypeIndexSplineWithArrow:begin
+      Leader.ArrowHeadFlag:=1;
+      Leader.PathType:=1;
+    end;
+  else
+    Leader.ArrowHeadFlag:=1;
+    Leader.PathType:=0;
+  end;
 end;
 
 constructor GDBObjLeader.init(own:Pointer;layeraddres:PGDBLayerProp;LW:smallint);

--- a/cad_source/zengine/tests/uzctentleader.pas
+++ b/cad_source/zengine/tests/uzctentleader.pas
@@ -26,6 +26,8 @@ type
   published
     procedure RegistersDXFEntity;
     procedure MinimalDXFLoadsLeaderEntity;
+    procedure LeaderTypeIndexCombinesPathAndArrowFlag;
+    procedure LeaderTypeIndexAppliesInspectorSelection;
     procedure CloneCopiesVerticesAndMetadata;
   end;
 
@@ -125,6 +127,7 @@ begin
 
     Leader:=PGDBObjLeader(Entity);
     CheckEquals('ISO-25',Leader^.DimStyleName);
+    CheckEquals(LeaderTypeIndexLinearWithArrow,LeaderTypeToEnumIndex(Leader^));
     CheckEquals(0,Leader^.AnnotationType);
     CheckEquals(0,Leader^.HookLineDirectionFlag);
     CheckEquals(1,Leader^.HookLineFlag);
@@ -141,6 +144,64 @@ begin
     CheckEquals(30.6637564603418,Leader^.AnnotationOffset.y,1e-9);
   finally
     Drawing.done;
+  end;
+end;
+
+procedure TLeaderEntityTest.LeaderTypeIndexCombinesPathAndArrowFlag;
+var
+  Leader:PGDBObjLeader;
+begin
+  Leader:=AllocAndInitLeader(nil);
+  try
+    Leader^.ArrowHeadFlag:=0;
+    Leader^.PathType:=0;
+    CheckEquals(LeaderTypeIndexLinearNoArrow,LeaderTypeToEnumIndex(Leader^));
+
+    Leader^.ArrowHeadFlag:=0;
+    Leader^.PathType:=1;
+    CheckEquals(LeaderTypeIndexSplineNoArrow,LeaderTypeToEnumIndex(Leader^));
+
+    Leader^.ArrowHeadFlag:=1;
+    Leader^.PathType:=0;
+    CheckEquals(LeaderTypeIndexLinearWithArrow,LeaderTypeToEnumIndex(Leader^));
+
+    Leader^.ArrowHeadFlag:=1;
+    Leader^.PathType:=1;
+    CheckEquals(LeaderTypeIndexSplineWithArrow,LeaderTypeToEnumIndex(Leader^));
+
+    Leader^.ArrowHeadFlag:=2;
+    Leader^.PathType:=2;
+    CheckEquals(LeaderTypeIndexLinearWithArrow,LeaderTypeToEnumIndex(Leader^));
+  finally
+    Leader^.done;
+    FreeMem(Pointer(Leader));
+  end;
+end;
+
+procedure TLeaderEntityTest.LeaderTypeIndexAppliesInspectorSelection;
+var
+  Leader:PGDBObjLeader;
+begin
+  Leader:=AllocAndInitLeader(nil);
+  try
+    ApplyLeaderTypeEnumIndex(Leader^,LeaderTypeIndexLinearNoArrow);
+    CheckEquals(0,Leader^.ArrowHeadFlag);
+    CheckEquals(0,Leader^.PathType);
+
+    ApplyLeaderTypeEnumIndex(Leader^,LeaderTypeIndexSplineNoArrow);
+    CheckEquals(0,Leader^.ArrowHeadFlag);
+    CheckEquals(1,Leader^.PathType);
+
+    ApplyLeaderTypeEnumIndex(Leader^,LeaderTypeIndexLinearWithArrow);
+    CheckEquals(1,Leader^.ArrowHeadFlag);
+    CheckEquals(0,Leader^.PathType);
+
+    ApplyLeaderTypeEnumIndex(Leader^,LeaderTypeIndexSplineWithArrow);
+    CheckEquals(1,Leader^.ArrowHeadFlag);
+    CheckEquals(1,Leader^.PathType);
+  finally
+    Leader^.done;
+    FreeMem(Pointer(Leader));
   end;
 end;
 

--- a/experiments/test_leader_inspector_registration.py
+++ b/experiments/test_leader_inspector_registration.py
@@ -26,9 +26,8 @@ def test_leader_registration_unit() -> None:
         "VertexCount",
         "Vertex3DControl_",
         "Length",
-        "LeaderDimStyleName",
-        "LeaderArrowHeadFlag",
-        "LeaderPathType",
+        "LeaderDimStyle",
+        "LeaderType",
         "LeaderAnnotationType",
         "LeaderHookLineDirectionFlag",
         "LeaderHookLineFlag",
@@ -48,6 +47,32 @@ def test_leader_registration_unit() -> None:
         raise AssertionError("expected leader misc properties")
     if len(re.findall(r"MPCSummary,GDBLeaderID", source)) < 2:
         raise AssertionError("expected leader summary properties")
+    for raw_property_name in (
+        "LeaderDimStyleName",
+        "LeaderArrowHeadFlag",
+        "LeaderPathType",
+    ):
+        if f"'{raw_property_name}'" in source:
+            raise AssertionError(
+                f"leader registration should expose editor-backed property instead of {raw_property_name}"
+            )
+    assert_contains(
+        source,
+        "sysunit^.TypeName2PTD('PGDBDimStyleObjInsp')",
+        "leader dim style editor",
+    )
+    assert_contains(
+        source,
+        "sysunit^.TypeName2PTD('TEnumData')",
+        "leader type editor",
+    )
+    for enum_label in (
+        "Линейная без стрелки",
+        "Сплайн без стрелки",
+        "Линейная со стрелкой",
+        "Сплайн со стрелкой",
+    ):
+        assert_contains(source, enum_label, "leader type enum")
 
 
 def test_leader_vertex_change_proc_uses_pointer_dereference() -> None:


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1254

## Summary
- Registered LEADER dim style as `PGDBDimStyleObjInsp`, so the Object Inspector reuses the existing dimension-style selector and nested arrow/line/text properties, including the existing arrow dropdown/index.
- Replaced raw `ArrowHeadFlag` and `PathType` inspector fields with a `TEnumData` LEADER type dropdown: `Линейная без стрелки`, `Сплайн без стрелки`, `Линейная со стрелкой`, `Сплайн со стрелкой`.
- Added shared LEADER type mapping helpers and regression coverage for DXF-loaded/default and inspector-selected type values.
- Updated the static Leader inspector registration experiment to assert editor-backed properties instead of raw DXF fields.

## Reproduction
Before this change, `uzcregleader.pas` exposed `DimStyleName` as a plain string and `ArrowHeadFlag`/`PathType` as integers. A LEADER loaded from DXF could not select the requested static type dropdown, and the inspector did not reuse the existing dimension-style arrow selector. The zengine LEADER test fixture now asserts that a DXF LEADER with the default path/arrow flags maps to `LeaderTypeIndexLinearWithArrow`.

## Verification
- `python3 experiments/test_leader_inspector_registration.py`
- `git diff --check`
- `make -C cad_source/zengine/tests` could not run locally because `/home/box/lazarus/lazbuild` is not installed in this environment; it exits before compiling with Error 127.

## Screenshots
No local screenshot is included because this environment cannot build/run the Lazarus UI without `lazbuild`.
