### PR TITLE
Render LEADER as complex entity with arrow block

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-30T13:46:44.689Z for PR creation at branch issue-1259-0d2aea12c8a0 for issue https://github.com/veb86/zcadvelecAI/issues/1259

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-30T13:46:44.689Z for PR creation at branch issue-1259-0d2aea12c8a0 for issue https://github.com/veb86/zcadvelecAI/issues/1259

--- a/cad_source/zengine/core/entities/uzeentleader.pas
+++ b/cad_source/zengine/core/entities/uzeentleader.pas
@@ -22,14 +22,19 @@ interface
 uses
   uzeentityfactory,uzgldrawcontext,uzedrawingdef,uzecamera,UGDBVectorSnapArray,
   uzestyleslayers,uzeentsubordinated,uzeentcurve,UGDBSelectedObjArray,
+  uzeentcomplex,uzeentline,uzeentblockinsert,uzeentitiesmanager,
   uzeentity,uzctnrVectorBytesStream,uzeTypes,uzeconsts,uzglviewareadata,
-  uzegeometrytypes,uzegeometry,uzeffdxfsupport,SysUtils,uzesnap,
+  uzegeometrytypes,uzegeometry,uzeffdxfsupport,SysUtils,Math,uzesnap,
+  uzepalette,uzestylesdim,uzestyleslinetypes,uzedimblocksregister,UGDBPoint3DArray,
   uzMVReader,uzCtnrVectorpBaseEntity;
 
 type
   PGDBObjLeader=^GDBObjLeader;
 
-  GDBObjLeader=object(GDBObjCurve)
+  GDBObjLeader=object(GDBObjComplex)
+    VertexArrayInOCS:GDBPoint3dArray;
+    VertexArrayInWCS:GDBPoint3dArray;
+    length:double;
     DimStyleName:string;
     ArrowHeadFlag:integer;
     PathType:integer;
@@ -54,6 +59,8 @@ type
       var drawing:TDrawingDef;var IODXFContext:TIODXFSaveContext);virtual;
     procedure FormatEntity(var drawing:TDrawingDef;
       var DC:TDrawContext;Stage:TEFStages=EFAllStages);virtual;
+    procedure FormatWithoutSnapArray;virtual;
+    procedure BuildComplexGeometry(var drawing:TDrawingDef;var DC:TDrawContext);virtual;
     procedure DrawGeometry(lw:integer;var DC:TDrawContext;
       const inFrustumState:TInBoundingVolume);virtual;
     function Clone(own:Pointer):PGDBObjEntity;virtual;
@@ -61,6 +68,25 @@ type
     function GetObjType:TObjID;virtual;
     function CalcTrueInFrustum(
       const frustum:TzeFrustum):TInBoundingVolume;virtual;
+    procedure AddVertex(const Vertex:TzePoint3d);virtual;
+    function GetLength:double;virtual;
+    procedure transform(const t_matrix:TzeTypedMatrix4d);virtual;
+    procedure TransformAt(p:PGDBObjEntity;t_matrix:PzeTypedMatrix4d);virtual;
+    procedure rtsave(refp:Pointer);virtual;
+    function onmouse(var popa:TZctnrVectorPGDBaseEntity;
+      const MF:TzeFrustum;InSubEntry:boolean):boolean;virtual;
+    function onpoint(var objects:TZctnrVectorPGDBaseEntity;
+      const point:TzePoint3d):boolean;virtual;
+    procedure rtmodifyonepoint(const rtmod:TRTModifyData);virtual;
+    procedure remaponecontrolpoint(pdesc:pcontrolpointdesc;
+      ProjectProc:GDBProjectProc);virtual;
+    procedure addcontrolpoints(tdesc:Pointer);virtual;
+    procedure AddOnTrackAxis(var posr:os_record;
+      const processaxis:taddotrac);virtual;
+    function getsnap(var osp:os_record;var pdata:Pointer;
+      const param:OGLWndtype;ProjectProc:GDBProjectProc;SnapMode:TGDBOSMode):boolean;virtual;
+    procedure startsnap(out osp:os_record;out pdata:Pointer);virtual;
+    procedure endsnap(out osp:os_record;var pdata:Pointer);virtual;
     class function CreateInstance:PGDBObjLeader;static;
   end;
 
@@ -91,6 +117,56 @@ begin
   Leader.HorizontalDirection:=CreateVertex(1,0,0);
   Leader.BlockOffset:=NulVertex;
   Leader.AnnotationOffset:=NulVertex;
+end;
+
+function ResolveLeaderDimStyle(const Leader:GDBObjLeader;
+  var drawing:TDrawingDef):PGDBDimStyle;
+var
+  DimStyles:PGDBDimStyleArray;
+begin
+  Result:=nil;
+  DimStyles:=drawing.GetDimStyleTable;
+  if DimStyles=nil then
+    exit;
+  if Leader.DimStyleName<>'' then
+    Result:=PGDBDimStyle(DimStyles^.getAddres(Leader.DimStyleName));
+  if (Result=nil)and(DimStyles^.Count>0) then
+    Result:=PGDBDimStyle(DimStyles^.getDataMutable(0));
+end;
+
+function GetLeaderDimScale(PDimStyle:PGDBDimStyle):double;
+begin
+  if (PDimStyle<>nil)and(PDimStyle^.Units.DIMSCALE>0) then
+    Result:=PDimStyle^.Units.DIMSCALE
+  else
+    Result:=1;
+end;
+
+function LeaderArrowLineWeight(const Leader:GDBObjLeader;
+  PDimStyle:PGDBDimStyle):TGDBLineWeight;
+begin
+  if PDimStyle<>nil then
+    Result:=PDimStyle^.Lines.DIMLWD
+  else
+    Result:=Leader.vp.LineWeight;
+end;
+
+function LeaderArrowColor(const Leader:GDBObjLeader;
+  PDimStyle:PGDBDimStyle):TGDBPaletteColor;
+begin
+  if PDimStyle<>nil then
+    Result:=PDimStyle^.Lines.DIMCLRD
+  else
+    Result:=Leader.vp.Color;
+end;
+
+function LeaderArrowLineType(const Leader:GDBObjLeader;
+  PDimStyle:PGDBDimStyle):PGDBLtypeProp;
+begin
+  if (PDimStyle<>nil)and(PDimStyle^.Lines.DIMLTYPE<>nil) then
+    Result:=PDimStyle^.Lines.DIMLTYPE
+  else
+    Result:=Leader.vp.LineType;
 end;
 
 function IsZeroVertex(const Vertex:TzePoint3d):boolean;
@@ -142,18 +218,24 @@ end;
 constructor GDBObjLeader.init(own:Pointer;layeraddres:PGDBLayerProp;LW:smallint);
 begin
   inherited init(own,layeraddres,lw);
+  VertexArrayInWCS.init(10);
+  VertexArrayInOCS.init(10);
   InitLeaderDefaults(self);
 end;
 
 constructor GDBObjLeader.initnul(owner:PGDBObjGenericWithSubordinated);
 begin
-  inherited initnul(owner);
+  inherited initnul;
   bp.ListPos.Owner:=owner;
+  VertexArrayInWCS.init(10);
+  VertexArrayInOCS.init(10);
   InitLeaderDefaults(self);
 end;
 
 destructor GDBObjLeader.done;
 begin
+  VertexArrayInWCS.done;
+  VertexArrayInOCS.done;
   DimStyleName:='';
   inherited;
 end;
@@ -183,7 +265,8 @@ begin
 
   DXFGroupCode:=rdr.ParseInteger;
   while DXFGroupCode<>0 do begin
-    if not LoadFromDXFObjShared(rdr,DXFGroupCode,ptu,drawing,context) then
+    if dxfLoadGroupCodeVertex(rdr,210,DXFGroupCode,NormalVector) then
+    else if not LoadFromDXFObjShared(rdr,DXFGroupCode,ptu,drawing,context) then
       if dxfLoadGroupCodeString(rdr,3,DXFGroupCode,DimStyleName,context.Header) then
       else if dxfLoadGroupCodeInteger(rdr,71,DXFGroupCode,ArrowHeadFlag) then
       else if dxfLoadGroupCodeInteger(rdr,72,DXFGroupCode,PathType) then
@@ -193,7 +276,6 @@ begin
       else if dxfLoadGroupCodeInteger(rdr,76,DXFGroupCode,VertexCount) then
       else if dxfLoadGroupCodeDouble(rdr,40,DXFGroupCode,TextHeight) then
       else if dxfLoadGroupCodeDouble(rdr,41,DXFGroupCode,TextWidth) then
-      else if dxfLoadGroupCodeVertex(rdr,210,DXFGroupCode,NormalVector) then
       else if dxfLoadGroupCodeVertex(rdr,211,DXFGroupCode,HorizontalDirection) then
       else if dxfLoadGroupCodeVertex(rdr,212,DXFGroupCode,BlockOffset) then
       else if dxfLoadGroupCodeVertex(rdr,213,DXFGroupCode,AnnotationOffset) then
@@ -266,27 +348,99 @@ begin
   if assigned(EntExtensions) then
     EntExtensions.RunOnBeforeEntityFormat(@self,drawing,DC);
 
-  if (Stage=EFAllStages)or(EFCalcEntityCS in Stage) then begin
-    FormatWithoutSnapArray;
-    calcbb(dc);
-    CalcActualVisible(dc.DrawingContext.VActuality);
-  end;
-
-  if ((Stage=EFAllStages)or(EFDraw in Stage))and
-     (not (ESTemp in State))and(DCODrawable in DC.Options) then begin
-    Representation.Clear;
-    if VertexArrayInWCS.Count>1 then
-      Representation.DrawPolyLineWithLT(dc,VertexArrayInWCS,vp,False,False);
-  end;
+  FormatWithoutSnapArray;
+  BuildComplexGeometry(drawing,DC);
+  inherited FormatEntity(drawing,DC,Stage);
 
   if assigned(EntExtensions) then
     EntExtensions.RunOnAfterEntityFormat(@self,drawing,DC);
 end;
 
+procedure GDBObjLeader.FormatWithoutSnapArray;
+var
+  ptv:PzePoint3d;
+  tv:TzePoint3d;
+  ir:itrec;
+  OwnerMatrix:TzeTypedMatrix4d;
+begin
+  VertexArrayInWCS.Clear;
+  VertexArrayInWCS.SetSize(VertexArrayInOCS.Count);
+  if bp.ListPos.Owner<>nil then
+    OwnerMatrix:=bp.ListPos.Owner^.GetMatrix^
+  else
+    OwnerMatrix:=OneMatrix;
+  ptv:=VertexArrayInOCS.beginiterate(ir);
+  if ptv<>nil then
+    repeat
+      tv:=VectorTransform3D(ptv^,OwnerMatrix);
+      VertexArrayInWCS.PushBackData(tv);
+      ptv:=VertexArrayInOCS.iterate(ir);
+    until ptv=nil;
+
+  VertexArrayInOCS.Shrink;
+  VertexArrayInWCS.Shrink;
+  length:=GetLength;
+end;
+
+procedure GDBObjLeader.BuildComplexGeometry(var drawing:TDrawingDef;
+  var DC:TDrawContext);
+var
+  i:integer;
+  p1,p2:PzePoint3d;
+  PDimStyle:PGDBDimStyle;
+  ArrowParam:TDimArrowBlockParam;
+  ArrowScale:double;
+  ArrowAngle:double;
+  pl:PGDBObjLine;
+  pv:PGDBObjBlockInsert;
+begin
+  ConstObjArray.Free;
+  if VertexArrayInOCS.Count<2 then
+    exit;
+
+  for i:=0 to VertexArrayInOCS.Count-2 do begin
+    p1:=VertexArrayInOCS.getDataMutable(i);
+    p2:=VertexArrayInOCS.getDataMutable(i+1);
+    pl:=pointer(ConstObjArray.CreateInitObj(GDBlineID,@self));
+    CopyVPto(pl^);
+    pl^.CoordInOCS.lBegin:=p1^;
+    pl^.CoordInOCS.lEnd:=p2^;
+    pl^.FormatEntity(drawing,DC);
+  end;
+
+  if ArrowHeadFlag<>0 then begin
+    PDimStyle:=ResolveLeaderDimStyle(self,drawing);
+    if PDimStyle<>nil then begin
+      ArrowParam:=PDimStyle^.GetDimBlockParam(-1);
+      ArrowScale:=PDimStyle^.Arrows.DIMASZ*GetLeaderDimScale(PDimStyle);
+    end else begin
+      ArrowParam:=DimArrows[TSClosedFilled];
+      ArrowScale:=1;
+    end;
+
+    if (ArrowParam.Name<>'')and(ArrowScale<>0) then begin
+      p1:=VertexArrayInOCS.getDataMutable(0);
+      p2:=VertexArrayInOCS.getDataMutable(1);
+      drawing.CreateBlockDef(ArrowParam.Name);
+      ArrowAngle:=VertexAngle(CreateVertex2D(p1^.x,p1^.y),
+        CreateVertex2D(p2^.x,p2^.y))-pi;
+      pointer(pv):=ENTF_CreateBlockInsert(@self,@self.ConstObjArray,
+        vp.Layer,LeaderArrowLineType(self,PDimStyle),
+        LeaderArrowLineWeight(self,PDimStyle),
+        LeaderArrowColor(self,PDimStyle),
+        ArrowParam.Name,p1^,ArrowScale,ArrowAngle);
+      if pv<>nil then begin
+        pv^.BuildGeometry(drawing);
+        pv^.FormatEntity(drawing,DC);
+      end;
+    end;
+  end;
+end;
+
 procedure GDBObjLeader.DrawGeometry(lw:integer;var DC:TDrawContext;
   const inFrustumState:TInBoundingVolume);
 begin
-  Representation.DrawGeometry(DC,VP.BoundingBox,inFrustumState);
+  inherited DrawGeometry(lw,DC,inFrustumState);
 end;
 
 function GDBObjLeader.Clone(own:Pointer):PGDBObjEntity;
@@ -307,6 +461,8 @@ begin
   Leader^.HorizontalDirection:=HorizontalDirection;
   Leader^.BlockOffset:=BlockOffset;
   Leader^.AnnotationOffset:=AnnotationOffset;
+  Leader^.Local:=Local;
+  Leader^.P_insert_in_WCS:=P_insert_in_WCS;
   CopyVPto(Leader^);
   CopyExtensionsTo(Leader^);
   Leader^.VertexArrayInOCS.SetSize(VertexArrayInOCS.Count);
@@ -328,7 +484,155 @@ end;
 function GDBObjLeader.CalcTrueInFrustum(
   const frustum:TzeFrustum):TInBoundingVolume;
 begin
-  Result:=VertexArrayInWCS.CalcTrueInFrustum(frustum,False);
+  Result:=inherited CalcTrueInFrustum(frustum);
+end;
+
+procedure GDBObjLeader.AddVertex(const Vertex:TzePoint3d);
+begin
+  VertexArrayInOCS.PushBackData(Vertex);
+end;
+
+function GDBObjLeader.GetLength:double;
+var
+  ptv,ptvprev:PzePoint3d;
+  ir:itrec;
+begin
+  Result:=0;
+  ptvprev:=VertexArrayInWCS.beginiterate(ir);
+  ptv:=VertexArrayInWCS.iterate(ir);
+  if ptv<>nil then
+    repeat
+      Result:=Result+uzegeometry.Vertexlength(ptv^,ptvprev^);
+      ptvprev:=ptv;
+      ptv:=VertexArrayInWCS.iterate(ir);
+    until ptv=nil;
+end;
+
+procedure GDBObjLeader.TransformAt(p:PGDBObjEntity;t_matrix:PzeTypedMatrix4d);
+var
+  ptv,ptv2:PzePoint3d;
+  ir,ir2:itrec;
+begin
+  ptv:=VertexArrayInOCS.beginiterate(ir);
+  ptv2:=PGDBObjLeader(p)^.VertexArrayInOCS.beginiterate(ir2);
+  if (ptv<>nil)and(ptv2<>nil) then
+    repeat
+      ptv^:=VectorTransform3D(ptv2^,t_matrix^);
+      ptv:=VertexArrayInOCS.iterate(ir);
+      ptv2:=PGDBObjLeader(p)^.VertexArrayInOCS.iterate(ir2);
+    until (ptv=nil)or(ptv2=nil);
+end;
+
+procedure GDBObjLeader.transform(const t_matrix:TzeTypedMatrix4d);
+var
+  ptv:PzePoint3d;
+  ir:itrec;
+begin
+  ptv:=VertexArrayInOCS.beginiterate(ir);
+  if ptv<>nil then
+    repeat
+      ptv^:=VectorTransform3D(ptv^,t_matrix);
+      ptv:=VertexArrayInOCS.iterate(ir);
+    until ptv=nil;
+end;
+
+procedure GDBObjLeader.rtsave(refp:Pointer);
+var
+  p,pold:PzePoint3d;
+  i:integer;
+begin
+  p:=VertexArrayInOCS.GetParrayAsPointer;
+  pold:=PGDBObjLeader(refp)^.VertexArrayInOCS.GetParrayAsPointer;
+  for i:=0 to VertexArrayInOCS.Count-1 do begin
+    pold^:=p^;
+    Inc(pold);
+    Inc(p);
+  end;
+end;
+
+function GDBObjLeader.onmouse(var popa:TZctnrVectorPGDBaseEntity;
+  const MF:TzeFrustum;InSubEntry:boolean):boolean;
+begin
+  Result:=inherited onmouse(popa,MF,InSubEntry);
+end;
+
+function GDBObjLeader.onpoint(var objects:TZctnrVectorPGDBaseEntity;
+  const point:TzePoint3d):boolean;
+begin
+  Result:=inherited onpoint(objects,point);
+end;
+
+procedure GDBObjLeader.rtmodifyonepoint(const rtmod:TRTModifyData);
+var
+  VertexNumber:integer;
+begin
+  VertexNumber:=rtmod.point.vertexnum;
+  GDBPoint3dArray.PTArr(VertexArrayInOCS.parray)^[VertexNumber]:=
+    VertexAdd(rtmod.point.worldcoord,rtmod.dist);
+end;
+
+procedure GDBObjLeader.remaponecontrolpoint(pdesc:pcontrolpointdesc;
+  ProjectProc:GDBProjectProc);
+var
+  VertexNumber:integer;
+  tv:TzePoint3d;
+begin
+  VertexNumber:=pdesc^.vertexnum;
+  pdesc^.worldcoord:=
+    GDBPoint3dArray.PTArr(VertexArrayInWCS.parray)^[VertexNumber];
+  ProjectProc(pdesc^.worldcoord,tv);
+  pdesc^.dispcoord:=ToTzePoint2i(tv);
+end;
+
+procedure GDBObjLeader.addcontrolpoints(tdesc:Pointer);
+var
+  pdesc:controlpointdesc;
+  i:integer;
+  pv:PzePoint3d;
+begin
+  PSelectedObjDesc(tdesc)^.pcontrolpoint^.init(VertexArrayInWCS.Count);
+  pv:=VertexArrayInWCS.GetParrayAsPointer;
+  pdesc.selected:=False;
+  pdesc.PDrawable:=nil;
+
+  for i:=0 to VertexArrayInWCS.Count-1 do begin
+    pdesc.vertexnum:=i;
+    pdesc.attr:=[CPA_Strech];
+    pdesc.worldcoord:=pv^;
+    PSelectedObjDesc(tdesc)^.pcontrolpoint^.PushBackData(pdesc);
+    Inc(pv);
+  end;
+end;
+
+procedure GDBObjLeader.AddOnTrackAxis(var posr:os_record;
+  const processaxis:taddotrac);
+begin
+  GDBPoint3dArrayAddOnTrackAxis(VertexArrayInWCS,posr,processaxis,False);
+end;
+
+procedure GDBObjLeader.startsnap(out osp:os_record;out pdata:Pointer);
+begin
+  inherited;
+  Getmem(pdata,sizeof(GDBVectorSnapArray));
+  PGDBVectorSnapArray(pdata)^.init(VertexArrayInWCS.Max);
+  BuildSnapArray(VertexArrayInWCS,PGDBVectorSnapArray(pdata)^,False);
+end;
+
+procedure GDBObjLeader.endsnap(out osp:os_record;var pdata:Pointer);
+begin
+  if pdata<>nil then begin
+    PGDBVectorSnapArray(pdata)^.Done;
+    Freemem(pdata);
+  end;
+  inherited;
+end;
+
+function GDBObjLeader.getsnap(var osp:os_record;var pdata:Pointer;
+  const param:OGLWndtype;ProjectProc:GDBProjectProc;
+  SnapMode:TGDBOSMode):boolean;
+begin
+  Result:=GDBPoint3dArraygetsnapWOPProjPoint(VertexArrayInWCS,
+    PGDBVectorSnapArray(pdata)^,osp,False,param,ProjectProc,SnapMode);
 end;
 
 function AllocLeader:PGDBObjLeader;

--- a/cad_source/zengine/tests/uzctentleader.pas
+++ b/cad_source/zengine/tests/uzctentleader.pas
@@ -6,12 +6,15 @@ interface
 
 uses
   SysUtils,
+  Math,
   Interfaces,
   fpcunit,
   testregistry,
   uzeconsts,
   uzeentity,
+  uzeentblockinsert,
   uzeentityfactory,
+  uzeentline,
   uzeentleader,
   uzeffdxf,
   uzeffmanager,
@@ -19,6 +22,8 @@ uses
   uzegeometrytypes,
   uzedrawingsimple,
   uzgldrawcontext,
+  uzestylesdim,
+  uzestyleslinetypes,
   uzeTypes;
 
 type
@@ -26,6 +31,7 @@ type
   published
     procedure RegistersDXFEntity;
     procedure MinimalDXFLoadsLeaderEntity;
+    procedure FormatBuildsLeaderPathAndArrowBlock;
     procedure LeaderTypeIndexCombinesPathAndArrowFlag;
     procedure LeaderTypeIndexAppliesInspectorSelection;
     procedure CloneCopiesVerticesAndMetadata;
@@ -142,6 +148,55 @@ begin
     CheckEquals(0.0,Vertex^.z,1e-9);
     CheckEquals(5.609187033556736,Leader^.AnnotationOffset.x,1e-9);
     CheckEquals(30.6637564603418,Leader^.AnnotationOffset.y,1e-9);
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TLeaderEntityTest.FormatBuildsLeaderPathAndArrowBlock;
+var
+  Drawing:TSimpleDrawing;
+  Entity:PGDBObjEntity;
+  EntityCount:integer;
+  Leader:PGDBObjLeader;
+  DimStyle:PGDBDimStyle;
+  DC:TDrawContext;
+  Child:PGDBObjEntity;
+  Arrow:PGDBObjBlockInsert;
+begin
+  EntityCount:=LoadLeaderDXFContent(DXF_LEADER_ENTITY_CONTENT,Drawing);
+  try
+    CheckEquals(1,EntityCount,'DXF LEADER must load as one entity');
+    Entity:=PGDBObjEntity(Drawing.pObjRoot^.ObjArray.GetData(0));
+    Leader:=PGDBObjLeader(Entity);
+
+    DimStyle:=PGDBDimStyle(Drawing.DimStyleTable.MergeItem('ISO-25',TLOLoad));
+    DimStyle^.init('ISO-25');
+    DimStyle^.Arrows.DIMLDRBLK:=TSOblique;
+    DimStyle^.Arrows.DIMASZ:=2.0;
+    DimStyle^.Units.DIMSCALE:=3.0;
+    DimStyle^.Lines.DIMLTYPE:=Drawing.LTypeStyleTable.GetSystemLT(TLTByBlock);
+
+    DC:=Drawing.CreateDrawingRC;
+    Leader^.FormatEntity(Drawing,DC);
+
+    CheckEquals(3,Leader^.ConstObjArray.Count,
+      'leader must be a complex object with 2 path segments and 1 arrow block');
+
+    Child:=PGDBObjEntity(Leader^.ConstObjArray.GetData(0));
+    CheckEquals(GDBlineID,Child^.GetObjType,'first leader child must be a path line');
+    Child:=PGDBObjEntity(Leader^.ConstObjArray.GetData(1));
+    CheckEquals(GDBlineID,Child^.GetObjType,'second leader child must be a path line');
+
+    Arrow:=PGDBObjBlockInsert(Leader^.ConstObjArray.GetData(2));
+    CheckEquals(GDBBlockInsertID,Arrow^.GetObjType,'leader head must be a block insert');
+    CheckEquals('_Oblique',Arrow^.Name);
+    CheckEquals(1.0,Arrow^.Local.P_insert.x,1e-9);
+    CheckEquals(2.0,Arrow^.Local.P_insert.y,1e-9);
+    CheckEquals(6.0,Arrow^.scale.x,1e-9);
+    CheckEquals(
+      VertexAngle(CreateVertex2D(1,2),CreateVertex2D(3,4))-pi,
+      Arrow^.rotate,1e-9);
   finally
     Drawing.done;
   end;

--- a/experiments/test_leader_complex_geometry.py
+++ b/experiments/test_leader_complex_geometry.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parents[1]
+LEADER_UNIT = ROOT / "cad_source" / "zengine" / "core" / "entities" / "uzeentleader.pas"
+LEADER_TEST = ROOT / "cad_source" / "zengine" / "tests" / "uzctentleader.pas"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(text: str, needle: str, context: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{context}: missing {needle!r}")
+
+
+def test_leader_is_complex_entity() -> None:
+    source = read(LEADER_UNIT)
+    assert_contains(source, "uzeentcomplex", "leader unit uses")
+    assert_contains(source, "GDBObjLeader=object(GDBObjComplex)", "leader type")
+
+
+def test_leader_builds_arrow_from_dimstyle() -> None:
+    source = read(LEADER_UNIT)
+    assert_contains(source, "ConstObjArray.CreateInitObj(GDBlineID,@self)", "leader path")
+    assert_contains(source, "ENTF_CreateBlockInsert(@self,@self.ConstObjArray", "leader arrow block")
+    assert_contains(source, "GetDimBlockParam(-1)", "leader dimstyle arrow")
+    assert_contains(source, "Arrows.DIMASZ", "leader arrow scale")
+    if not re.search(r"ArrowHeadFlag\s*<>\s*0", source):
+        raise AssertionError("leader arrow block must be controlled by ArrowHeadFlag")
+
+
+def test_pascal_regression_covers_complex_geometry() -> None:
+    source = read(LEADER_TEST)
+    assert_contains(source, "FormatBuildsLeaderPathAndArrowBlock", "leader regression")
+    assert_contains(source, "Leader^.ConstObjArray.Count", "leader regression")
+    assert_contains(source, "TSOblique", "leader regression")
+    assert_contains(source, "GDBBlockInsertID", "leader regression")
+
+
+if __name__ == "__main__":
+    test_leader_is_complex_entity()
+    test_leader_builds_arrow_from_dimstyle()
+    test_pascal_regression_covers_complex_geometry()

--- a/experiments/test_leader_inspector_registration.py
+++ b/experiments/test_leader_inspector_registration.py
@@ -93,9 +93,14 @@ def test_leader_vertex_change_proc_uses_pointer_dereference() -> None:
         "pdata^.name=mp.MPName+'x'",
         "pdata^.name=mp.MPName+'y'",
         "pdata^.name=mp.MPName+'z'",
-        "mp.MPType.CopyValueToInstance(pdata^.data.Addr.Instance,@Vertex3DControl)",
     ):
         assert_contains(proc_source, expected, "leader vertex change proc")
+    if not re.search(
+        r"mp\.MPType\^?\.CopyValueToInstance"
+        r"\(pdata\^\.data\.Addr\.Instance,@Vertex3DControl\)",
+        proc_source,
+    ):
+        raise AssertionError("leader vertex change proc: missing MPType CopyValueToInstance")
 
 
 def test_leader_registration_is_wired() -> None:


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1259

## Summary
- Make DXF `LEADER` inherit from `GDBObjComplex` and keep its vertex/snap/edit behavior explicitly on the entity.
- Build LEADER geometry as complex children: line segments for the path plus an arrow block insert at the first vertex.
- Resolve the arrow block from the leader dimension style (`DIMLDRBLK`) and scale it with `DIMASZ * DIMSCALE`.
- Preserve the existing selected-object inspector behavior for leader style and combined leader type, with regression coverage for the pointer-dereference form used in current code.

## Reproduce
Load a DXF containing a `LEADER` with style `ISO-25`, arrow flag enabled, and multiple vertices. Before this change the leader drew only as a curve/polyline representation and had no leader-head block at the start.

## Tests
- `PYTHONDONTWRITEBYTECODE=1 python3 experiments/test_leader_complex_geometry.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 experiments/test_leader_inspector_registration.py`
- `git diff --check`

The Pascal test target was attempted but this runner does not include Lazarus/FPC:

```text
make -C cad_source/zengine/tests
/bin/sh: 1: /home/box/lazarus/lazbuild: not found
```

## Screenshots
Not applicable: this is entity geometry/rendering logic, not a visual UI change.
