### PR TITLE
uzeentleader. Корректировка работы выноски

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T05:27:20.540Z for PR creation at branch issue-1265-dc3e728b2902 for issue https://github.com/veb86/zcadvelecAI/issues/1265

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T05:27:20.540Z for PR creation at branch issue-1265-dc3e728b2902 for issue https://github.com/veb86/zcadvelecAI/issues/1265

--- a/cad_source/zengine/core/entities/uzeentleader.pas
+++ b/cad_source/zengine/core/entities/uzeentleader.pas
@@ -260,33 +260,6 @@ begin
     Leader.VertexArrayInOCS.Count-2),LeaderArrowSize);
 end;
 
-function LeaderPathStartPoint(const Leader:GDBObjLeader;LeaderArrowSize:double;
-  ArrowEnabled:boolean):TzePoint3d;
-var
-  p1,p2:PzePoint3d;
-  FirstSegmentLength,Offset:double;
-  Direction:TzePoint3d;
-begin
-  Result:=NulVertex;
-  if Leader.VertexArrayInOCS.Count=0 then
-    exit;
-  p1:=Leader.VertexArrayInOCS.getDataMutable(0);
-  Result:=p1^;
-
-  if (not ArrowEnabled)or(LeaderArrowSize<=0)or(Leader.VertexArrayInOCS.Count<2) then
-    exit;
-
-  FirstSegmentLength:=LeaderSegmentLength(Leader,0);
-  if (FirstSegmentLength<=LeaderGeometryEpsilon)or
-     (FirstSegmentLength>=LeaderArrowSize*2) then
-    exit;
-
-  p2:=Leader.VertexArrayInOCS.getDataMutable(1);
-  Offset:=FirstSegmentLength/2;
-  Direction:=NormalizeVertex(VertexSub(p2^,p1^));
-  Result:=VertexAdd(p1^,VertexMulOnSc(Direction,Offset));
-end;
-
 function LeaderArrowAngleFromDirection(const Direction,FallbackStart,
   FallbackEnd:TzePoint3d):double;
 begin
@@ -395,7 +368,7 @@ end;
 // Создаёт сплайновую часть через заданные точки.
 function CreateLeaderSplinePath(Leader:PGDBObjLeader;var drawing:TDrawingDef;
   var DC:TDrawContext;PDimStyle:PGDBDimStyle;
-  const FirstPathPoint:TzePoint3d;SplinePointCount:integer):PGDBObjSpline;
+  SplinePointCount:integer):PGDBObjSpline;
 var
   i:integer;
   FitPoints:array of TzePoint3d;
@@ -415,8 +388,7 @@ begin
   Result^.Degree:=ClampLeaderSplineDegree(SplinePointCount);
 
   SetLength(FitPoints,SplinePointCount);
-  FitPoints[0]:=FirstPathPoint;
-  for i:=1 to SplinePointCount-1 do
+  for i:=0 to SplinePointCount-1 do
     FitPoints[i]:=Leader^.VertexArrayInOCS.getDataMutable(i)^;
 
   if Result^.Degree=1 then begin
@@ -669,7 +641,6 @@ var
   LeaderArrowSize:double;
   ArrowAngle:double;
   ArrowDirection:TzePoint3d;
-  PathStartPoint,SegmentStart:TzePoint3d;
   SplinePath:PGDBObjSpline;
   SplinePointCount:integer;
   HasTextTail,ArrowEnabled:boolean;
@@ -682,9 +653,12 @@ begin
   PDimStyle:=ResolveLeaderDimStyle(self,drawing);
   LeaderArrowSize:=ResolveLeaderArrowSize(self,PDimStyle);
   ArrowParam:=DimArrows[TArrowStyle(ResolveLeaderArrowStyleIndex(self,PDimStyle))];
+  // Стрелка (ArrowStyle) отображается только тогда, когда длина первого
+  // участка выноски не меньше удвоенного размера стрелки (пункт 2 задачи):
+  // на более коротком участке стрелка не помещается и не строится.
   ArrowEnabled:=(ArrowHeadFlag<>0)and(ArrowParam.Name<>'')and
-    (LeaderArrowSize<>0);
-  PathStartPoint:=LeaderPathStartPoint(self,LeaderArrowSize,ArrowEnabled);
+    (LeaderArrowSize<>0)and
+    (LeaderSegmentLength(self,0)>=LeaderArrowSize*2);
   SplinePath:=nil;
 
   if (PathType=1)and(VertexArrayInOCS.Count>2) then begin
@@ -694,7 +668,7 @@ begin
       Dec(SplinePointCount);
 
     SplinePath:=CreateLeaderSplinePath(@self,drawing,DC,PDimStyle,
-      PathStartPoint,SplinePointCount);
+      SplinePointCount);
     if HasTextTail then begin
       p1:=VertexArrayInOCS.getDataMutable(VertexArrayInOCS.Count-2);
       p2:=VertexArrayInOCS.getDataMutable(VertexArrayInOCS.Count-1);
@@ -704,11 +678,7 @@ begin
     for i:=0 to VertexArrayInOCS.Count-2 do begin
       p1:=VertexArrayInOCS.getDataMutable(i);
       p2:=VertexArrayInOCS.getDataMutable(i+1);
-      if i=0 then
-        SegmentStart:=PathStartPoint
-      else
-        SegmentStart:=p1^;
-      CreateLeaderLineSegment(@self,drawing,DC,PDimStyle,SegmentStart,p2^);
+      CreateLeaderLineSegment(@self,drawing,DC,PDimStyle,p1^,p2^);
     end;
   end;
 

--- a/cad_source/zengine/tests/uzctentleader.pas
+++ b/cad_source/zengine/tests/uzctentleader.pas
@@ -35,7 +35,8 @@ type
     procedure FormatBuildsLeaderPathAndArrowBlock;
     procedure FormatBuildsSplinePathAndStraightLastSegment;
     procedure FormatBuildsWholeSplinePathWithoutTextTail;
-    procedure FormatKeepsLeaderArrowVisibleOnShortFirstSegment;
+    procedure FormatHidesLeaderArrowOnShortFirstSegment;
+    procedure FormatShowsLeaderArrowOnLongFirstSegment;
     procedure SplineLeaderArrowUsesSplineTangent;
     procedure LeaderTypeIndexCombinesPathAndArrowFlag;
     procedure LeaderTypeIndexAppliesInspectorSelection;
@@ -181,11 +182,14 @@ begin
     Entity:=PGDBObjEntity(Drawing.pObjRoot^.ObjArray.GetData(0));
     Leader:=PGDBObjLeader(Entity);
 
+    // Первый участок выноски (1,2)->(3,4) имеет длину ~2.83, поэтому размер
+    // стрелки выбран так, чтобы её удвоенное значение (2*1=2) не превышало
+    // длину участка и стрелка отображалась (пункт 2 задачи).
     DimStyle:=PGDBDimStyle(Drawing.DimStyleTable.MergeItem('ISO-25',TLOLoad));
     DimStyle^.init('ISO-25');
     DimStyle^.Arrows.DIMLDRBLK:=TSOblique;
-    DimStyle^.Arrows.DIMASZ:=2.0;
-    DimStyle^.Units.DIMSCALE:=3.0;
+    DimStyle^.Arrows.DIMASZ:=0.5;
+    DimStyle^.Units.DIMSCALE:=2.0;
     DimStyle^.Lines.DIMLTYPE:=Drawing.LTypeStyleTable.GetSystemLT(TLTByBlock);
 
     DC:=Drawing.CreateDrawingRC;
@@ -204,7 +208,7 @@ begin
     CheckEquals('_Oblique',Arrow^.Name);
     CheckEquals(1.0,Arrow^.Local.P_insert.x,1e-9);
     CheckEquals(2.0,Arrow^.Local.P_insert.y,1e-9);
-    CheckEquals(6.0,Arrow^.scale.x,1e-9);
+    CheckEquals(1.0,Arrow^.scale.x,1e-9);
     CheckEquals(
       VertexAngle(CreateVertex2D(1,2),CreateVertex2D(3,4))-pi,
       Arrow^.rotate,1e-9);
@@ -224,13 +228,16 @@ begin
   Drawing.init(nil);
   Leader:=AllocAndInitLeader(nil);
   try
+    // Первый участок (0,0)->(4,3) длиной 5 не короче 2*ArrowSize(=4),
+    // поэтому стрелка отображается. Последний участок (6,1)->(8,1) длиной 2
+    // равен ArrowSize, значит он считается участком текста и остаётся прямым.
     Leader^.ArrowHeadFlag:=1;
     Leader^.PathType:=1;
     Leader^.ArrowSize:=2.0;
     Leader^.AddVertex(CreateVertex(0,0,0));
-    Leader^.AddVertex(CreateVertex(2,3,0));
-    Leader^.AddVertex(CreateVertex(4,1,0));
+    Leader^.AddVertex(CreateVertex(4,3,0));
     Leader^.AddVertex(CreateVertex(6,1,0));
+    Leader^.AddVertex(CreateVertex(8,1,0));
 
     DC:=Drawing.CreateDrawingRC;
     Leader^.FormatEntity(Drawing,DC);
@@ -247,9 +254,9 @@ begin
       'text tail segment length equal to arrow size must remain straight');
 
     LastSegment:=PGDBObjLine(Child);
-    CheckEquals(4.0,LastSegment^.CoordInOCS.lBegin.x,1e-9);
+    CheckEquals(6.0,LastSegment^.CoordInOCS.lBegin.x,1e-9);
     CheckEquals(1.0,LastSegment^.CoordInOCS.lBegin.y,1e-9);
-    CheckEquals(6.0,LastSegment^.CoordInOCS.lEnd.x,1e-9);
+    CheckEquals(8.0,LastSegment^.CoordInOCS.lEnd.x,1e-9);
     CheckEquals(1.0,LastSegment^.CoordInOCS.lEnd.y,1e-9);
 
     Child:=PGDBObjEntity(Leader^.ConstObjArray.GetData(2));
@@ -307,7 +314,53 @@ begin
   end;
 end;
 
-procedure TLeaderEntityTest.FormatKeepsLeaderArrowVisibleOnShortFirstSegment;
+procedure TLeaderEntityTest.FormatHidesLeaderArrowOnShortFirstSegment;
+var
+  Drawing:TSimpleDrawing;
+  Leader:PGDBObjLeader;
+  DC:TDrawContext;
+  Child:PGDBObjEntity;
+  FirstSegment:PGDBObjLine;
+  i:integer;
+begin
+  Drawing.init(nil);
+  Leader:=AllocAndInitLeader(nil);
+  try
+    // Первый участок (0,0)->(6,0) длиной 6 короче 2*ArrowSize(=8),
+    // поэтому стрелка не строится (пункт 2 задачи).
+    Leader^.ArrowHeadFlag:=1;
+    Leader^.PathType:=0;
+    Leader^.ArrowSize:=4.0;
+    Leader^.AddVertex(CreateVertex(0,0,0));
+    Leader^.AddVertex(CreateVertex(6,0,0));
+    Leader^.AddVertex(CreateVertex(10,0,0));
+
+    DC:=Drawing.CreateDrawingRC;
+    Leader^.FormatEntity(Drawing,DC);
+
+    CheckEquals(2,Leader^.ConstObjArray.Count,
+      'short first segment leader must keep path segments without an arrow');
+
+    for i:=0 to Leader^.ConstObjArray.Count-1 do begin
+      Child:=PGDBObjEntity(Leader^.ConstObjArray.GetData(i));
+      CheckEquals(GDBlineID,Child^.GetObjType,
+        'short first segment leader must not contain an arrow block');
+    end;
+
+    Child:=PGDBObjEntity(Leader^.ConstObjArray.GetData(0));
+    FirstSegment:=PGDBObjLine(Child);
+    CheckEquals(0.0,FirstSegment^.CoordInOCS.lBegin.x,1e-9);
+    CheckEquals(0.0,FirstSegment^.CoordInOCS.lBegin.y,1e-9);
+    CheckEquals(6.0,FirstSegment^.CoordInOCS.lEnd.x,1e-9);
+    CheckEquals(0.0,FirstSegment^.CoordInOCS.lEnd.y,1e-9);
+  finally
+    Leader^.done;
+    FreeMem(Pointer(Leader));
+    Drawing.done;
+  end;
+end;
+
+procedure TLeaderEntityTest.FormatShowsLeaderArrowOnLongFirstSegment;
 var
   Drawing:TSimpleDrawing;
   Leader:PGDBObjLeader;
@@ -319,31 +372,33 @@ begin
   Drawing.init(nil);
   Leader:=AllocAndInitLeader(nil);
   try
+    // Первый участок (0,0)->(10,0) длиной 10 не короче 2*ArrowSize(=8),
+    // поэтому стрелка отображается (пункт 2 задачи).
     Leader^.ArrowHeadFlag:=1;
     Leader^.PathType:=0;
     Leader^.ArrowSize:=4.0;
     Leader^.AddVertex(CreateVertex(0,0,0));
-    Leader^.AddVertex(CreateVertex(6,0,0));
     Leader^.AddVertex(CreateVertex(10,0,0));
+    Leader^.AddVertex(CreateVertex(14,0,0));
 
     DC:=Drawing.CreateDrawingRC;
     Leader^.FormatEntity(Drawing,DC);
 
     CheckEquals(3,Leader^.ConstObjArray.Count,
-      'short first segment leader must keep path segments and arrow');
+      'long first segment leader must keep path segments and arrow');
 
     Child:=PGDBObjEntity(Leader^.ConstObjArray.GetData(0));
     CheckEquals(GDBlineID,Child^.GetObjType,
       'first leader child must remain a line segment');
     FirstSegment:=PGDBObjLine(Child);
-    CheckEquals(3.0,FirstSegment^.CoordInOCS.lBegin.x,1e-9);
+    CheckEquals(0.0,FirstSegment^.CoordInOCS.lBegin.x,1e-9);
     CheckEquals(0.0,FirstSegment^.CoordInOCS.lBegin.y,1e-9);
-    CheckEquals(6.0,FirstSegment^.CoordInOCS.lEnd.x,1e-9);
+    CheckEquals(10.0,FirstSegment^.CoordInOCS.lEnd.x,1e-9);
     CheckEquals(0.0,FirstSegment^.CoordInOCS.lEnd.y,1e-9);
 
     Arrow:=PGDBObjBlockInsert(Leader^.ConstObjArray.GetData(2));
     CheckEquals(GDBBlockInsertID,Arrow^.GetObjType,
-      'arrow head must be present when first segment is shorter than 2 arrow sizes');
+      'arrow head must be present when first segment is at least 2 arrow sizes');
     CheckEquals('_ClosedFilled',Arrow^.Name);
     CheckEquals(4.0,Arrow^.scale.x,1e-9);
   finally


### PR DESCRIPTION
## Что исправлено

Issue #1265 описывает три проблемы выноски (leader). Пункты 1 и 3 были исправлены ранее (PR #1266, влит в эту ветку). Этот PR закрывает оставшийся **пункт 2**.

### Пункт 2 — отображение стрелки (ArrowStyle) по длине первого участка

**Проблема (из комментария к issue):** «Пункт 2 неисправлен. ArrowStyle отображается всегда, независимо от длины `LeaderArrowSize * 2`».

**Требование:** если длина первого участка выноски меньше `LeaderArrowSize * 2`, стрелка не должна строиться; если не меньше — строится.

**Исправление** (`uzeentleader.pas`):
- В `BuildComplexGeometry` условие `ArrowEnabled` дополнено проверкой
  `LeaderSegmentLength(self,0) >= LeaderArrowSize*2`. Стрелка (и её блок-вставка) строится только при выполнении этого условия.
- Удалена ранее добавленная функция `LeaderPathStartPoint` и связанная с ней логика смещения (`FirstPathPoint` у `CreateLeaderSplinePath`, `PathStartPoint`/`SegmentStart`), которая на коротком участке смещала путь и **оставляла стрелку видимой** — то есть реализовывала противоположное требованию поведение.

## Как воспроизвести

Создать выноску, у которой длина первого участка меньше удвоенного размера стрелки (`DIMASZ * DIMSCALE`). До исправления стрелка рисовалась всегда; после — на коротком участке стрелка отсутствует.

## Тесты (`uzctentleader.pas`)

- `FormatHidesLeaderArrowOnShortFirstSegment` — первый участок (0,0)→(6,0) длиной 6 < `2*ArrowSize`(=8): проверяет, что блок стрелки **не** создан (только линейные участки).
- `FormatShowsLeaderArrowOnLongFirstSegment` — первый участок (0,0)→(10,0) длиной 10 ≥ `2*ArrowSize`(=8): проверяет, что блок стрелки `_ClosedFilled` создан, `scale.x = ArrowSize`.
- Существующие тесты пути/сплайна (`FormatBuildsLeaderPathAndArrowBlock`, `FormatBuildsSplinePathAndStraightLastSegment`) скорректированы по данным размеров так, чтобы условие видимости стрелки выполнялось там, где стрелка ожидается. Тесты пунктов 1 и 3 (`FormatBuildsWholeSplinePathWithoutTextTail`, `SplineLeaderArrowUsesSplineTangent`) сохранены без регрессий.

> Примечание: в репозитории CI собирает только документацию, код/тесты автоматически не компилируются. Изменения проверены ручным разбором геометрии каждого теста; локальная полная компиляция невозможна из-за отсутствующих внешних зависимостей (`gzctnrVector` и LCL).



Fixes veb86/zcadvelecAI#1265