### PR TITLE
uzeentleader. Откорректировать команду создания выноски (возврат в предыдущее меню после выбора формата)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T07:46:40.348Z for PR creation at branch issue-1270-7471be4029db for issue https://github.com/veb86/zcadvelecAI/issues/1270

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T07:46:40.348Z for PR creation at branch issue-1270-7471be4029db for issue https://github.com/veb86/zcadvelecAI/issues/1270

--- a/cad_source/zcad/commands/uzccommand_leader.pas
+++ b/cad_source/zcad/commands/uzccommand_leader.pas
@@ -45,10 +45,14 @@
        - Format (F) — подменю настройки формата выноски:
            Specify parameter for leader format
              [Spline Segments Arrow Nothing] <Exit>:
-           Spline   (S) — сплайновая выноска (PathType=1);
-           Segments (G) — выноска отрезками (PathType=0);
-           Arrow    (A) — со стрелкой (ArrowHeadFlag=1);
-           Nothing  (N) — без стрелки  (ArrowHeadFlag=0);
+           Spline   (S) — сплайновая выноска (PathType=1), затем возврат
+                          в предыдущее меню;
+           Segments (G) — выноска отрезками (PathType=0), затем возврат
+                          в предыдущее меню;
+           Arrow    (A) — со стрелкой (ArrowHeadFlag=1), затем возврат
+                          в предыдущее меню;
+           Nothing  (N) — без стрелки  (ArrowHeadFlag=0), затем возврат
+                          в предыдущее меню;
            Exit     (X) / пустой Enter — вернуться в предыдущее меню;
        - Undo (U) — отменить последнюю введённую точку.
     5. ESC отменяет команду без каких-либо изменений в чертеже.
@@ -309,18 +313,26 @@ begin
                   LeaderIdSpline:begin
                     interactiveData.PLeader^.PathType:=1;
                     RefreshLeaderPreview(interactiveData);
+                    // После выбора формата возвращаемся в предыдущее меню
+                    SetLeaderCmdMode(LCMWaitNext);
                   end;
                   LeaderIdSegments:begin
                     interactiveData.PLeader^.PathType:=0;
                     RefreshLeaderPreview(interactiveData);
+                    // После выбора формата возвращаемся в предыдущее меню
+                    SetLeaderCmdMode(LCMWaitNext);
                   end;
                   LeaderIdArrow:begin
                     interactiveData.PLeader^.ArrowHeadFlag:=1;
                     RefreshLeaderPreview(interactiveData);
+                    // После выбора формата возвращаемся в предыдущее меню
+                    SetLeaderCmdMode(LCMWaitNext);
                   end;
                   LeaderIdNothing:begin
                     interactiveData.PLeader^.ArrowHeadFlag:=0;
                     RefreshLeaderPreview(interactiveData);
+                    // После выбора формата возвращаемся в предыдущее меню
+                    SetLeaderCmdMode(LCMWaitNext);
                   end;
                   LeaderIdExit:
                     SetLeaderCmdMode(LCMWaitNext);


### PR DESCRIPTION
## Описание

Решает veb86/zcadvelecAI#1270.

После выполнения задачи #1268 в команде `LEADER` подменю **Формат** оставалось активным после нажатия любой из кнопок:

- **Сплайн** — перевод выноски в сплайновую (`PathType=1`)
- **Отрезки** — перевод выноски в линейную (`PathType=0`)
- **Стрелка** — выноска со стрелкой (`ArrowHeadFlag=1`)
- **Ничего** — выноска без стрелки (`ArrowHeadFlag=0`)

Это неправильно: после выбора параметра формата необходимо возвращаться в предыдущее меню (`Next point ...`).

## Изменения

В `cad_source/zcad/commands/uzccommand_leader.pas` после применения каждого из пунктов подменю формата (Spline / Segments / Arrow / Nothing) добавлен вызов `SetLeaderCmdMode(LCMWaitNext)` — переключение обратно в предыдущее меню. Поведение пункта **Выход** (`Exit`) не изменилось.

## Как проверить

1. Запустить команду `LEADER`.
2. Указать первую и вторую точки.
3. В меню `Next point ...` выбрать **Формат**.
4. Нажать любую из кнопок: Сплайн / Отрезки / Стрелка / Ничего.
5. Убедиться, что произошёл возврат в предыдущее меню `Next point ...`, а не повторное отображение подменю формата.



Fixes veb86/zcadvelecAI#1270