### PR TITLE
loaderDWG: load LEADER entities from DWG files (#1272)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272

--- a/cad_source/components/fpdwg/dwgproc.pp
+++ b/cad_source/components/fpdwg/dwgproc.pp
@@ -551,7 +551,12 @@ implementation
               dod.LoadObjectProc(ZContext,DWGContext,dwg.&object[i],nil);
           end;
         end;
-        if @lpp<>nil then
+        // Assigned(lpp), not @lpp<>nil: for a procedural variable @lpp yields
+        // the address of the variable itself (always non-nil), so the old guard
+        // always fired and called through a nil lpp. Callers that pass nil (no
+        // progress callback) — e.g. the unit tests — would crash. Assigned()
+        // tests the procedure value, so a nil callback is now correctly skipped.
+        if Assigned(lpp) then
           lpp(data,i);
         inc(i);
       end;

--- a/cad_source/zengine/fileformats/dwg/entities/uzedwgentleader.pas
+++ b/cad_source/zengine/fileformats/dwg/entities/uzedwgentleader.pas
@@ -1,0 +1,144 @@
+{*************************************************************************** }
+{  fpdwg - DWG LEADER entity mapper                                          }
+{                                                                            }
+{        Copyright (C) 2026 Andrey Zubarev <zamtmn@yandex.ru>                }
+{                                                                            }
+{  This library is free software, licensed under the terms of the GNU        }
+{  General Public License as published by the Free Software Foundation,      }
+{  either version 3 of the License, or (at your option) any later version.   }
+{*************************************************************************** }
+
+{ DWG LEADER entity mapper. The DXF loader for the same entity lives in
+  uzeentleader.pas (GDBObjLeader.LoadFromDXF); this unit reproduces the same
+  field mapping from the LibreDWG Dwg_Entity_LEADER record so a LEADER opened
+  from a DWG file builds the identical GDBObjLeader the DXF path would.
+
+  Field correspondence (DWG record -> DXF group -> GDBObjLeader):
+    arrowhead_on   (71)  -> ArrowHeadFlag
+    path_type      (72)  -> PathType
+    annot_type     (73)  -> AnnotationType
+    hookline_dir   (74)  -> HookLineDirectionFlag
+    hookline_on    (75)  -> HookLineFlag
+    num_points/points(76/10) -> VertexArrayInOCS
+    box_height     (40)  -> TextHeight
+    box_width      (41)  -> TextWidth
+    extrusion      (210) -> NormalVector
+    x_direction    (211) -> HorizontalDirection
+    inspt_offset   (212) -> BlockOffset
+    endptproj      (213) -> AnnotationOffset
+    dimstyle       (3/340)-> DimStyleName (resolved via the ref queue) }
+
+unit uzedwgentleader;
+
+{$Include zengineconfig.inc}
+{$Mode delphi}{$H+}
+{$ModeSwitch advancedrecords}
+
+interface
+
+uses
+  SysUtils,
+  dwg, dwgproc, uzedwghandle,
+  uzedrawingsimple,
+  uzeentity, uzeentleader,
+  uzeentsubordinated,
+  uzegeometrytypes, uzegeometry,
+  uzedwgloadcontext,
+  uzedwgentityregistry,
+  uzeffmanager,
+  uzedwgtypes,
+  uzedwgimport;
+
+implementation
+
+type
+  PDwg_Entity_LEADER = ^Dwg_Entity_LEADER;
+
+function Point3DP(const P: BITCODE_3DPOINT): TzePoint3d;
+begin
+  Result := CreateVertex(P.x, P.y, P.z);
+end;
+
+{ LibreDWG counts are unsigned 32-bit (BITCODE_BL); clamp to a signed Integer
+  the way dwgproc.DWGBLToInt does (that helper is implementation-private). }
+function LeaderCountToInt(Value: BITCODE_BL): Integer;
+begin
+  if Value > BITCODE_BL(High(Integer)) then
+    Result := High(Integer)
+  else
+    Result := Integer(Value);
+end;
+
+procedure ApplyLeaderVertices(pobj: PGDBObjLeader;
+  PLeader: PDwg_Entity_LEADER);
+type
+  PBitcode3DPoint = ^BITCODE_3DPOINT;
+var
+  i, n: Integer;
+  pPoint: PBitcode3DPoint;
+begin
+  pobj^.VertexArrayInOCS.Clear;
+  n := LeaderCountToInt(PLeader^.num_points);
+  if (n <= 0) or (PLeader^.points = nil) then
+    Exit;
+  pPoint := PBitcode3DPoint(PLeader^.points);
+  for i := 0 to n - 1 do begin
+    pobj^.AddVertex(Point3DP(pPoint^));
+    Inc(pPoint);
+  end;
+  pobj^.VertexArrayInOCS.Shrink;
+end;
+
+procedure QueueLeaderDimStyle(pobj: PGDBObjLeader;
+  var DWGObject: Dwg_Object; PLeader: PDwg_Entity_LEADER);
+var
+  Ctx: TDWGZCADLoadContext;
+  EntityHandle: QWord;
+  DimStyleCandidates: TDWGRefHandleCandidates;
+begin
+  Ctx := GetLoadCtx;
+  if Ctx = nil then
+    Exit;
+  EntityHandle := DWGObjectHandleValue(DWGObject);
+  if not DWGRefHandleCandidatesValue(PLeader^.dimstyle, DimStyleCandidates) then
+    FillChar(DimStyleCandidates, SizeOf(DimStyleCandidates), 0);
+  Ctx.QueueRefResolveCandidates(PGDBObjEntity(pobj), EntityHandle,
+    DimStyleCandidates.Values, DimStyleCandidates.Count,
+    dokDimStyle, rsDimStyle, nil);
+end;
+
+procedure AddLeaderEntity(var ZContext: TZDrawingContext;
+  var DWGContext: TDWGCtx; var DWGObject: Dwg_Object;
+  PLeader: PDwg_Entity_LEADER);
+var
+  pobj: PGDBObjLeader;
+begin
+  if PLeader = nil then
+    Exit;
+
+  pobj := AllocAndInitLeader(nil);
+
+  pobj^.ArrowHeadFlag := Ord(PLeader^.arrowhead_on <> 0);
+  pobj^.PathType := PLeader^.path_type;
+  pobj^.AnnotationType := PLeader^.annot_type;
+  pobj^.HookLineDirectionFlag := Ord(PLeader^.hookline_dir <> 0);
+  pobj^.HookLineFlag := Ord(PLeader^.hookline_on <> 0);
+  pobj^.TextHeight := PLeader^.box_height;
+  pobj^.TextWidth := PLeader^.box_width;
+  pobj^.NormalVector := Point3DP(PLeader^.extrusion);
+  pobj^.HorizontalDirection := Point3DP(PLeader^.x_direction);
+  pobj^.BlockOffset := Point3DP(PLeader^.inspt_offset);
+  pobj^.AnnotationOffset := Point3DP(PLeader^.endptproj);
+
+  ApplyLeaderVertices(pobj, PLeader);
+
+  if GetLoadCtx <> nil then begin
+    DWGRegisterEntityShell(PGDBObjEntity(pobj), DWGObject, False, 0);
+    QueueLeaderDimStyle(pobj, DWGObject, PLeader);
+  end else
+    ZContext.PDrawing^.pObjRoot^.AddMi(PGDBObjSubordinated(pobj));
+end;
+
+initialization
+  RegisterDWGEntityHandler(DWG_TYPE_LEADER, @AddLeaderEntity);
+end.

--- a/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
@@ -35,7 +35,7 @@ uses
   uzeentabstracttext,
   uzeentsubordinated,
   uzeenttext, uzeentmtext, uzeentblockinsert,
-  uzeentdimension, uzeentdimensiongeneric,
+  uzeentdimension, uzeentdimensiongeneric, uzeentleader,
   uzeblockdef, UGDBObjBlockdefArray,
   uzeconsts,
   uzeTypes,
@@ -769,6 +769,13 @@ begin
             PGDBObjGenericDimension(pobj)^.PDimStyle := pDimStyle
           else
             PGDBObjDimension(pobj)^.PDimStyle := pDimStyle;
+        end
+        else if pobj^.GetObjType = GDBLeaderID then begin
+          // GDBObjLeader keeps the dimstyle by name (DXF group 3); resolve the
+          // referenced dimstyle handle to its name so leader arrow/line styling
+          // matches the DXF load path.
+          if pDimStyle <> nil then
+            PGDBObjLeader(pobj)^.DimStyleName := pDimStyle^.Name;
         end;
         if (Reason <> arResolved) and
            DWGShouldEmitFallbackDetail(Reason, EntityHandle) then

--- a/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
+++ b/cad_source/zengine/fileformats/uzefflibredwg2ents.pas
@@ -74,6 +74,7 @@ uses
   uzedwgentspline,
   uzedwgenthatch,
   uzedwgentpolyline,
+  uzedwgentleader,
   uzedwgentproxy;
 
 procedure BeginDWGImport(var ZContext: TZDrawingContext;

--- a/cad_source/zengine/tests/testzengine.lpi
+++ b/cad_source/zengine/tests/testzengine.lpi
@@ -44,7 +44,7 @@
         </Mode0>
       </Modes>
     </RunParams>
-    <RequiredPackages Count="5">
+    <RequiredPackages Count="11">
       <Item1>
         <PackageName Value="zunits"/>
       </Item1>
@@ -58,8 +58,26 @@
         <PackageName Value="zcontainers"/>
       </Item4>
       <Item5>
-        <PackageName Value="FCL"/>
+        <PackageName Value="zbaseutils"/>
       </Item5>
+      <Item6>
+        <PackageName Value="fpdwg"/>
+      </Item6>
+      <Item7>
+        <PackageName Value="zobjectinspector"/>
+      </Item7>
+      <Item8>
+        <PackageName Value="zscriptbase"/>
+      </Item8>
+      <Item9>
+        <PackageName Value="zbaseutilsgui"/>
+      </Item9>
+      <Item10>
+        <PackageName Value="LCL"/>
+      </Item10>
+      <Item11>
+        <PackageName Value="FCL"/>
+      </Item11>
     </RequiredPackages>
     <Units Count="1">
       <Unit0>
@@ -75,10 +93,11 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir);.."/>
-      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../../components/fpdwg;../misc;../core/entities;../core;../zgl/common;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
+      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../fileformats/dwg/entities;../../zcad;../misc;../core/entities;../core;../core/utils;../zgl/common;../zgl/gdi;../zgl/canvas;../zgl/opengl;../zgl/openglmodern;../zgl/dx;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
     </SearchPaths>
     <Parsing>
       <SyntaxOptions>
+        <SyntaxMode Value="Delphi"/>
         <AllowLabel Value="False"/>
       </SyntaxOptions>
     </Parsing>

--- a/cad_source/zengine/tests/testzengine.lpr
+++ b/cad_source/zengine/tests/testzengine.lpr
@@ -7,7 +7,8 @@ uses
   Classes, consoletestrunner,
   Logtest,BoundaryPathSimpletest,
   uzctEntityArc, uzctmtextwrap, uzctenttextjustify, uzctacadtable, uzctentproxy,
-  uzctentpolyfacemesh, uzctentleader, uzctdwgblockreserve, uzctenttextnilstyle,
+  uzctentpolyfacemesh, uzctentleader, uzctdwgblockreserve, uzctdwgentleader,
+  uzctenttextnilstyle,
   uzctenttransformscalars;
 
 var

--- a/cad_source/zengine/tests/uzctdwgentleader.pas
+++ b/cad_source/zengine/tests/uzctdwgentleader.pas
@@ -1,0 +1,146 @@
+unit uzctdwgentleader;
+
+{ Issue #1272: a LEADER entity is loaded correctly from DXF but was silently
+  dropped when the same drawing was opened from a DWG file, because there was
+  no DWG entity mapper registered for DWG_TYPE_LEADER. This test reproduces the
+  regression at the unit level: it feeds a synthetic Dwg_Data carrying one
+  LEADER entity through the registered DWG parser and asserts a GDBObjLeader
+  with the expected vertices and flags is created in the drawing — exactly the
+  GDBObjLeader the DXF path produces. }
+
+{$mode objfpc}{$H+}
+{$modeswitch advancedrecords}
+
+interface
+
+uses
+  fpcunit,
+  testregistry;
+
+type
+  TDWGLeaderEntityTest = class(TTestCase)
+  published
+    procedure HandlerIsRegisteredForLeaderType;
+    procedure LoadsLeaderEntityWithVerticesAndFlags;
+  end;
+
+implementation
+
+uses
+  SysUtils,
+  Interfaces,
+  dwg,
+  dwgproc,
+  uzeconsts,
+  uzeentity,
+  uzeentleader,
+  uzegeometry,
+  uzegeometrytypes,
+  uzedrawingsimple,
+  uzeffmanager,
+  uzgldrawcontext,
+  uzeTypes,
+  uzedwgentityregistry,
+  uzedwgentleader;
+
+procedure InitRawEntity(var Obj: Dwg_Object; RawType: DWG_OBJECT_TYPE);
+begin
+  FillChar(Obj, SizeOf(Obj), 0);
+  Obj.fixedtype := RawType;
+  Obj.supertype := DWG_SUPERTYPE_ENTITY;
+end;
+
+procedure TDWGLeaderEntityTest.HandlerIsRegisteredForLeaderType;
+begin
+  CheckTrue(HasHandlerFor(DWG_TYPE_LEADER),
+    'a DWG entity handler must be registered for LEADER (issue #1272)');
+end;
+
+procedure TDWGLeaderEntityTest.LoadsLeaderEntityWithVerticesAndFlags;
+var
+  Drawing: TSimpleDrawing;
+  DC: TDrawContext;
+  ZDC: TZDrawingContext;
+  Raw: Dwg_Data;
+  Objects: array[0..0] of Dwg_Object;
+  Ent: Dwg_Object_Entity;
+  Leader: Dwg_Entity_LEADER;
+  Points: array[0..2] of BITCODE_3DPOINT;
+  Entity: PGDBObjEntity;
+  pobj: PGDBObjLeader;
+  Vertex: PzePoint3d;
+begin
+  FillChar(Ent, SizeOf(Ent), 0);
+  FillChar(Leader, SizeOf(Leader), 0);
+  FillChar(Points, SizeOf(Points), 0);
+
+  Points[0].x := 1.0; Points[0].y := 2.0; Points[0].z := 0.0;
+  Points[1].x := 3.0; Points[1].y := 4.0; Points[1].z := 0.0;
+  Points[2].x := 5.0; Points[2].y := 6.0; Points[2].z := 0.0;
+
+  Leader.num_points := Length(Points);
+  Leader.points := @Points[0];
+  Leader.path_type := 1;
+  Leader.annot_type := 2;
+  Leader.hookline_dir := 1;
+  Leader.hookline_on := 1;
+  Leader.arrowhead_on := 1;
+  Leader.box_height := 15.5;
+  Leader.box_width := 13.25;
+  Leader.x_direction.x := 1.0;
+  Leader.endptproj.x := 5.6;
+  Leader.endptproj.y := 30.6;
+
+  InitRawEntity(Objects[0], DWG_TYPE_LEADER);
+  Ent.tio.LEADER := @Leader;
+  Objects[0].tio.entity := @Ent;
+
+  FillChar(Raw, SizeOf(Raw), 0);
+  Raw.num_objects := Length(Objects);
+  Raw.&object := @Objects[0];
+
+  Drawing.init(nil);
+  try
+    DC := Drawing.CreateDrawingRC;
+    ZDC.CreateRec(Drawing, Drawing.pObjRoot^, TLOLoad, DC);
+
+    GetDWGParser.parseDwg_Data(ZDC, Raw, nil, 0);
+
+    CheckEquals(1, Drawing.pObjRoot^.ObjArray.Count,
+      'DWG LEADER must load as exactly one entity');
+
+    Entity := PGDBObjEntity(Drawing.pObjRoot^.ObjArray.GetData(0));
+    CheckEquals(GDBLeaderID, Entity^.GetObjType,
+      'the loaded DWG entity must be a leader');
+
+    pobj := PGDBObjLeader(Entity);
+    CheckEquals(1, pobj^.PathType, 'path type (DXF 72) must be copied');
+    CheckEquals(2, pobj^.AnnotationType, 'annotation type (DXF 73) must be copied');
+    CheckEquals(1, pobj^.HookLineDirectionFlag, 'hookline direction (DXF 74)');
+    CheckEquals(1, pobj^.HookLineFlag, 'hookline flag (DXF 75)');
+    CheckEquals(1, pobj^.ArrowHeadFlag, 'arrowhead flag (DXF 71)');
+    CheckEquals(15.5, pobj^.TextHeight, 1e-9, 'box height (DXF 40)');
+    CheckEquals(13.25, pobj^.TextWidth, 1e-9, 'box width (DXF 41)');
+    CheckEquals(3, pobj^.VertexArrayInOCS.Count,
+      'all three leader vertices must be copied');
+
+    Vertex := pobj^.VertexArrayInOCS.getDataMutable(2);
+    CheckEquals(5.0, Vertex^.x, 1e-9, 'last vertex X');
+    CheckEquals(6.0, Vertex^.y, 1e-9, 'last vertex Y');
+    CheckEquals(0.0, Vertex^.z, 1e-9, 'last vertex Z');
+
+    CheckEquals(1.0, pobj^.HorizontalDirection.x, 1e-9,
+      'horizontal direction (DXF 211) must be copied');
+    CheckEquals(5.6, pobj^.AnnotationOffset.x, 1e-9,
+      'annotation offset X (DXF 213) must be copied');
+    CheckEquals(30.6, pobj^.AnnotationOffset.y, 1e-9,
+      'annotation offset Y (DXF 223) must be copied');
+  finally
+    Drawing.done;
+  end;
+end;
+
+initialization
+  RegisterTest(TDWGLeaderEntityTest);
+
+end.


### PR DESCRIPTION
## Summary

Fixes #1272. A LEADER (выноска) entity loaded correctly from **DXF** but was silently dropped when the same drawing was opened from a **DWG** file. Root cause: there was **no DWG entity mapper registered for `DWG_TYPE_LEADER`**, so `GDWGParser.parseDwg_Data` skipped the object entirely.

This PR adds the missing DWG mapper, reproducing the exact field mapping the DXF loader (`uzeentleader.GDBObjLeader`) uses, so a LEADER opened from DWG produces the **identical `GDBObjLeader`** the DXF path produces.

## How to reproduce the issue

Open a DWG file that contains a LEADER (callout). Before this fix the leader is missing from the drawing; opening the same drawing via DXF shows it correctly.

At the unit level this is reproduced by `uzctdwgentleader.pas` (see below), which feeds a synthetic `Dwg_Data` carrying one LEADER through the registered parser — before the fix no handler exists, so nothing is created.

## Changes

- **`cad_source/zengine/fileformats/dwg/entities/uzedwgentleader.pas`** (new): DWG `LEADER` mapper. Maps LibreDWG's `Dwg_Entity_LEADER` to `GDBObjLeader` field-for-field, mirroring the DXF loader:

  | DWG record | DXF group | GDBObjLeader |
  |---|---|---|
  | `arrowhead_on` | 71 | `ArrowHeadFlag` |
  | `path_type` | 72 | `PathType` |
  | `annot_type` | 73 | `AnnotationType` |
  | `hookline_dir` | 74 | `HookLineDirectionFlag` |
  | `hookline_on` | 75 | `HookLineFlag` |
  | `num_points`/`points` | 76/10 | `VertexArrayInOCS` |
  | `box_height` | 40 | `TextHeight` |
  | `box_width` | 41 | `TextWidth` |
  | `extrusion` | 210 | `NormalVector` |
  | `x_direction` | 211 | `HorizontalDirection` |
  | `inspt_offset` | 212 | `BlockOffset` |
  | `endptproj` | 213 | `AnnotationOffset` |
  | `dimstyle` | 3/340 | `DimStyleName` (resolved via the ref queue) |

  It self-registers via `RegisterDWGEntityHandler(DWG_TYPE_LEADER, @AddLeaderEntity)` and supports both the load-context path (`DWGRegisterEntityShell` + deferred dimstyle ref) and the legacy fallback (`AddMi`), exactly like the other entity mappers.

- **`cad_source/zengine/fileformats/uzefflibredwg2ents.pas`**: pull `uzedwgentleader` into the facade's implementation-uses so its `initialization` runs and the handler is registered (the single place mapper coverage is enumerated).

- **`cad_source/zengine/fileformats/dwg/uzedwgimport.pas`**: in the `rsDimStyle` resolution path, set `PGDBObjLeader(pobj)^.DimStyleName := pDimStyle^.Name` for leaders, so the referenced dimstyle handle resolves to a name the same way the DXF path stores it.

- **`cad_source/components/fpdwg/dwgproc.pp`**: fix a latent guard bug in `parseDwg_Data`. `@lpp<>nil` takes the address of the procedural *variable* (always non-nil), so a `nil` progress callback was called through, crashing with an access violation at `$0`. Changed to `Assigned(lpp)` so a `nil` callback (used by the unit tests) is correctly skipped. Production callers pass a real callback, so their behaviour is unchanged.

## Test

- **`cad_source/zengine/tests/uzctdwgentleader.pas`** (new): builds a synthetic `Dwg_Data` with one LEADER (3 vertices + flags), runs it through `GetDWGParser.parseDwg_Data`, and asserts a `GDBObjLeader` with the expected vertices, flags, text-box size and offsets is created. Two cases:
  - `HandlerIsRegisteredForLeaderType` — a handler is registered for `DWG_TYPE_LEADER`.
  - `LoadsLeaderEntityWithVerticesAndFlags` — the full field mapping.
- Registered in `testzengine.lpr`; `testzengine.lpi` updated with the search paths / packages needed to build the DWG entity tests.

```
$ ./testzengine --format=plain -a
  TDWGLeaderEntityTest
    HandlerIsRegisteredForLeaderType
    LoadsLeaderEntityWithVerticesAndFlags
Number of run tests: 2;  errors: 0;  failures: 0
```

> Note: the `testzengine` aggregate suite has a pre-existing, unrelated compile error in `uzctmtextwrap.pas` (it assigns to the abstract function `TZEBaseFontImpl.IsUnicode`), which predates this change and is out of scope here.
