### PR TITLE
Добавить предпросмотр и читаемые имена стрелок в редактор размерных стилей

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-03T10:38:57.191Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-03T10:38:57.191Z

--- a/cad_source/zcad/gui/forms/uzcfdimedit.pas
+++ b/cad_source/zcad/gui/forms/uzcfdimedit.pas
@@ -336,19 +336,12 @@ begin
 end;
 
 procedure TDimStyleEditForm.ArrowsComboBoxCreate(Sender: TObject;var arrowsBox:TComboBox;arrowsIndex:TArrowStyle);
-var
-    i:integer;
-    D: PTypeData;
-    //i : integer;
-  begin
-    arrowsBox.Clear;
-    D := GetTypeData(TypeInfo(TArrowStyle));
-    for i := D^.MinValue to D^.MaxValue do
-      arrowsBox.AddItem(GetEnumName(TypeInfo(TArrowStyle), i),Sender);
-    arrowsBox.ItemIndex := Ord(arrowsIndex);
-    {Items are added in TArrowStyle enum order, so owner-draw can map each
-     item index directly to its arrow style and draw a mini preview.}
-    TSupportArrowStyleCombo.Setup(arrowsBox);
+begin
+  TSupportArrowStyleCombo.FillItems(arrowsBox, Sender);
+  arrowsBox.ItemIndex := Ord(arrowsIndex);
+  {Items are added in TArrowStyle enum order, so owner-draw can map each
+   item index directly to its arrow style and draw a mini preview.}
+  TSupportArrowStyleCombo.Setup(arrowsBox);
 end;
 
 

--- a/cad_source/zcad/gui/uzcgui2arrows.pas
+++ b/cad_source/zcad/gui/uzcgui2arrows.pas
@@ -40,17 +40,91 @@ type
                                 TArrowStyle enum order (Index=Ord(style)). }
                               class procedure ArrowBoxDrawItem(Control: TWinControl; Index: Integer; ARect: TRect;
                                                                State: StdCtrls.TOwnerDrawState);
+                              { Fills cb with localized arrow style names in
+                                TArrowStyle enum order. }
+                              class procedure FillItems(cb: TComboBox; ItemObject: TObject);
                               { Turns cb into an owner-draw arrow picker. }
                               class procedure Setup(cb: TComboBox);
                             end;
 
 { Draws the arrow preview followed by the text s inside ARect. }
 procedure drawArrow(canvas: TCanvas; ARect: TRect; const s: string; arrowStyle: TArrowStyle);
+function GetArrowStyleName(arrowStyle: TArrowStyle): string;
 
 implementation
 
 const
   COneSixth = 1.0/6.0;
+
+resourcestring
+  rsArrowStyleClosedFilled = 'Closed filled';
+  rsArrowStyleClosedBlank = 'Closed blank';
+  rsArrowStyleClosed = 'Closed';
+  rsArrowStyleDot = 'Dot';
+  rsArrowStyleArchitecturalTick = 'Architectural tick';
+  rsArrowStyleOblique = 'Oblique';
+  rsArrowStyleOpen = 'Open';
+  rsArrowStyleOriginIndicator = 'Origin indicator';
+  rsArrowStyleOriginIndicator2 = 'Origin indicator 2';
+  rsArrowStyleRightAngle = 'Right angle';
+  rsArrowStyleOpen30 = 'Open 30';
+  rsArrowStyleDotSmall = 'Dot small';
+  rsArrowStyleDotBlank = 'Dot blank';
+  rsArrowStyleDotSmallBlank = 'Dot small blank';
+  rsArrowStyleBox = 'Box';
+  rsArrowStyleBoxFilled = 'Box filled';
+  rsArrowStyleDatumTriangle = 'Datum triangle';
+  rsArrowStyleDatumTriangleFilled = 'Datum triangle filled';
+  rsArrowStyleIntegral = 'Integral';
+  rsArrowStyleUserArrow = 'User Arrow...';
+
+function GetArrowStyleName(arrowStyle: TArrowStyle): string;
+begin
+  case arrowStyle of
+    TSClosedFilled:
+      Result := rsArrowStyleClosedFilled;
+    TSClosedBlank:
+      Result := rsArrowStyleClosedBlank;
+    TSClosed:
+      Result := rsArrowStyleClosed;
+    TSDot:
+      Result := rsArrowStyleDot;
+    TSArchitecturalTick:
+      Result := rsArrowStyleArchitecturalTick;
+    TSOblique:
+      Result := rsArrowStyleOblique;
+    TSOpen:
+      Result := rsArrowStyleOpen;
+    TSOriginIndicator:
+      Result := rsArrowStyleOriginIndicator;
+    TSOriginIndicator2:
+      Result := rsArrowStyleOriginIndicator2;
+    TSRightAngle:
+      Result := rsArrowStyleRightAngle;
+    TSOpen30:
+      Result := rsArrowStyleOpen30;
+    TSDotSmall:
+      Result := rsArrowStyleDotSmall;
+    TSDotBlank:
+      Result := rsArrowStyleDotBlank;
+    TSDotSmallBlank:
+      Result := rsArrowStyleDotSmallBlank;
+    TSBox:
+      Result := rsArrowStyleBox;
+    TSBoxFilled:
+      Result := rsArrowStyleBoxFilled;
+    TSDatumTriangle:
+      Result := rsArrowStyleDatumTriangle;
+    TSDatumtTriangleFilled:
+      Result := rsArrowStyleDatumTriangleFilled;
+    TSIntegral:
+      Result := rsArrowStyleIntegral;
+    TSUserDef:
+      Result := rsArrowStyleUserArrow;
+  else
+    Result := '';
+  end;
+end;
 
 { Draws a mini representation of arrowStyle in the left part of ARect and
   the text s in the remaining space. The block coordinate system has the
@@ -248,6 +322,15 @@ begin
   s := TComboBox(Control).Items[Index];
   ARect.Left := ARect.Left + 2;
   drawArrow(TComboBox(Control).Canvas, ARect, s, TArrowStyle(Index));
+end;
+
+class procedure TSupportArrowStyleCombo.FillItems(cb: TComboBox; ItemObject: TObject);
+var
+  arrowStyle: TArrowStyle;
+begin
+  cb.Clear;
+  for arrowStyle := Low(TArrowStyle) to High(TArrowStyle) do
+    cb.AddItem(GetArrowStyleName(arrowStyle), ItemObject);
 end;
 
 class procedure TSupportArrowStyleCombo.Setup(cb: TComboBox);

--- a/cad_source/zcad/gui/uzcui_dimstyleedit.pas
+++ b/cad_source/zcad/gui/uzcui_dimstyleedit.pas
@@ -39,6 +39,7 @@ uses
   uzedrawingsimple,
   uzcsysvars,
   uzcinterface,
+  uzcgui2arrows,
   uzepalette,
   uzestylestexts,
   uzeTypes,
@@ -77,30 +78,6 @@ const
   { Текст заглушки предпросмотра }
   CPreviewStubText = 'Предпросмотр недоступен';
   CPreviewFontSize = 10;
-
-  { Отображаемые имена стилей стрелок }
-  CArrowNames: array[TArrowStyle] of string = (
-    'Заполненная замкнутая',
-    'Замкнутая незаполненная',
-    'Замкнутая',
-    'Точка',
-    'Архитектурная засечка',
-    'Наклонная',
-    'Открытая',
-    'Указатель начала координат',
-    'Указатель начала координат 2',
-    'Прямой угол',
-    'Открытая 30',
-    'Точка малая',
-    'Точка незаполненная',
-    'Точка малая незаполненная',
-    'Прямоугольник',
-    'Прямоугольник заполненный',
-    'Треугольник базы',
-    'Треугольник базы заполненный',
-    'Интеграл',
-    'Пользовательский'
-  );
 
   { Отображаемые имена вертикального размещения текста }
   CTextVertNames: array[TDimTextVertPosition] of string = (
@@ -609,7 +586,6 @@ end;
 { Загружает значения из структуры стиля в элементы управления }
 procedure TDimStyleEditDialog.LoadFromStyle;
 var
-  ArrowIdx: TArrowStyle;
   VertIdx: TDimTextVertPosition;
   UnitIdx: TDimUnit;
   SepIdx: TDimDSep;

--- a/cad_source/zcad/gui/uzcui_dimstyleedit_tab_arrows.inc
+++ b/cad_source/zcad/gui/uzcui_dimstyleedit_tab_arrows.inc
@@ -10,7 +10,6 @@ var
   GroupArrows: TGroupBox;
   GroupCenter: TGroupBox;
   Preview: TPaintBox;
-  ArrowIdx: TArrowStyle;
   RowTop: Integer;
   LeftCol, RightCol: Integer;
 begin
@@ -41,24 +40,24 @@ begin
   CreateLabel(GroupArrows, 'Первая:', LeftCol, RowTop);
   FComboArrow1 := CreateCombo(
     GroupArrows, LeftCol, RowTop + 18, 250);
-  for ArrowIdx := Low(TArrowStyle) to High(TArrowStyle) do
-    FComboArrow1.Items.Add(CArrowNames[ArrowIdx]);
+  TSupportArrowStyleCombo.FillItems(FComboArrow1, Self);
+  TSupportArrowStyleCombo.Setup(FComboArrow1);
   RowTop := RowTop + CControlStep + 18;
 
   { Вторая стрелка }
   CreateLabel(GroupArrows, 'Вторая:', LeftCol, RowTop);
   FComboArrow2 := CreateCombo(
     GroupArrows, LeftCol, RowTop + 18, 250);
-  for ArrowIdx := Low(TArrowStyle) to High(TArrowStyle) do
-    FComboArrow2.Items.Add(CArrowNames[ArrowIdx]);
+  TSupportArrowStyleCombo.FillItems(FComboArrow2, Self);
+  TSupportArrowStyleCombo.Setup(FComboArrow2);
   RowTop := RowTop + CControlStep + 18;
 
   { Выноска }
   CreateLabel(GroupArrows, 'Выноска:', LeftCol, RowTop);
   FComboArrowLeader := CreateCombo(
     GroupArrows, LeftCol, RowTop + 18, 250);
-  for ArrowIdx := Low(TArrowStyle) to High(TArrowStyle) do
-    FComboArrowLeader.Items.Add(CArrowNames[ArrowIdx]);
+  TSupportArrowStyleCombo.FillItems(FComboArrowLeader, Self);
+  TSupportArrowStyleCombo.Setup(FComboArrowLeader);
   RowTop := RowTop + CControlStep + 18;
 
   { Размер стрелки }

--- a/cad_source/zcad/register/uzcregleader.pas
+++ b/cad_source/zcad/register/uzcregleader.pas
@@ -28,31 +28,8 @@ uses
   uzeentleader,uzeconsts,uzegeometrytypes,uzestylesdim,
   uzsbVarmanDef,Varman,uzbUnits,gzctnrVectorTypes,
   UGDBPoint3DArray,uzcLog,uzcdrawing,uzcdrawings,uzetypes,uzepalette,
-  zUndoCmdChgTypes,zUndoCmdChgVariable,uzctnrVectorStrings;
-
-const
-  // Названия стрелок выноски (соответствуют порядку TArrowStyle)
-  CArrowLeaderNames:array[TArrowStyle] of string=(
-    'Заполненная замкнутая',
-    'Замкнутая незаполненная',
-    'Замкнутая',
-    'Точка',
-    'Архитектурная засечка',
-    'Наклонная',
-    'Открытая',
-    'Указатель начала координат',
-    'Указатель начала координат 2',
-    'Прямой угол',
-    'Открытая 30',
-    'Точка малая',
-    'Точка незаполненная',
-    'Точка малая незаполненная',
-    'Прямоугольник',
-    'Прямоугольник заполненный',
-    'Треугольник базы',
-    'Треугольник базы заполненный',
-    'Интеграл',
-    'Пользовательский');
+  zUndoCmdChgTypes,zUndoCmdChgVariable,uzctnrVectorStrings,
+  uzcgui2arrows;
 
 var
   ptdInteger:PUserTypeDescriptor=nil;
@@ -330,7 +307,7 @@ begin
   if PVD<>nil then begin
     t:=PVD^.data.Addr.Instance;
     for ias:=low(TArrowStyle) to high(TArrowStyle) do
-      t^.Enums.PushBackData(CArrowLeaderNames[ias]);
+      t^.Enums.PushBackData(GetArrowStyleName(ias));
     t^.Selected:=0;
   end;
 end;

--- a/cad_source/zcad/register/uzcregzscript.pas
+++ b/cad_source/zcad/register/uzcregzscript.pas
@@ -36,7 +36,7 @@ uses
   uzgldrawerogl,uzgldrawergdi,
   uzcSysParams,
   uzcdevicebaseabstract,uzcdevicebase,uzcRegSysVars,Graphics,
-  URecordDescriptor,uzcTypeDescriprors,uzcTypes;
+  URecordDescriptor,uzcTypeDescriprors,uzcTypes,uzcgui2arrows;
 
 implementation
 
@@ -848,7 +848,27 @@ begin
                             'TSRightAngle','TSOpen30','TSDotSmall','TSDotBlank',
                             'TSDotSmallBlank','TSBox','TSBoxFilled',
                             'TSDatumTriangle','TSDatumtTriangleFilled',
-                            'TSIntegral','TSUserDef'],[FNProgram,FNUser]);
+                            'TSIntegral','TSUserDef'],[FNProgram]);
+    ptsu^.SetTypeDesk2(utd,[GetArrowStyleName(TSClosedFilled),
+                            GetArrowStyleName(TSClosedBlank),
+                            GetArrowStyleName(TSClosed),
+                            GetArrowStyleName(TSDot),
+                            GetArrowStyleName(TSArchitecturalTick),
+                            GetArrowStyleName(TSOblique),
+                            GetArrowStyleName(TSOpen),
+                            GetArrowStyleName(TSOriginIndicator),
+                            GetArrowStyleName(TSOriginIndicator2),
+                            GetArrowStyleName(TSRightAngle),
+                            GetArrowStyleName(TSOpen30),
+                            GetArrowStyleName(TSDotSmall),
+                            GetArrowStyleName(TSDotBlank),
+                            GetArrowStyleName(TSDotSmallBlank),
+                            GetArrowStyleName(TSBox),
+                            GetArrowStyleName(TSBoxFilled),
+                            GetArrowStyleName(TSDatumTriangle),
+                            GetArrowStyleName(TSDatumtTriangleFilled),
+                            GetArrowStyleName(TSIntegral),
+                            GetArrowStyleName(TSUserDef)],[FNUser]);
   end;
   utd:=ptsu^.RegisterType(TypeInfo(TDimTextVertPosition),
                                   'TDimTextVertPosition');

--- a/experiments/issue_1274_arrow_combo_names_check.py
+++ b/experiments/issue_1274_arrow_combo_names_check.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Static regression check for issue #1274 arrow-style combo names."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def read_repo(path: str) -> str:
+    return (ROOT / path).read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> None:
+    arrows = read_repo("cad_source/zcad/gui/uzcgui2arrows.pas")
+    dimedit = read_repo("cad_source/zcad/gui/forms/uzcfdimedit.pas")
+    tab_arrows = read_repo("cad_source/zcad/gui/uzcui_dimstyleedit_tab_arrows.inc")
+    reg_leader = read_repo("cad_source/zcad/register/uzcregleader.pas")
+    reg_zscript = read_repo("cad_source/zcad/register/uzcregzscript.pas")
+
+    for expected in [
+        "Closed filled",
+        "Closed blank",
+        "Closed",
+        "Dot",
+        "Architectural tick",
+        "Oblique",
+        "Open",
+        "Origin indicator",
+        "Origin indicator 2",
+        "Right angle",
+        "Open 30",
+        "Dot small",
+        "Dot blank",
+        "Dot small blank",
+        "Box",
+        "Box filled",
+        "Datum triangle",
+        "Datum triangle filled",
+        "Integral",
+        "User Arrow...",
+    ]:
+        require(expected in arrows, f"missing arrow display name: {expected}")
+
+    require("resourcestring" in arrows, "arrow display names must be resourcestrings")
+    require("GetArrowStyleName" in arrows, "missing reusable arrow-style name helper")
+    require("FillItems" in arrows, "missing reusable arrow combo fill helper")
+
+    require(
+        "GetEnumName(TypeInfo(TArrowStyle)" not in dimedit,
+        "dimension edit form still exposes raw TArrowStyle enum identifiers",
+    )
+
+    require(
+        tab_arrows.count("TSupportArrowStyleCombo.FillItems") == 3,
+        "programmatic dimension-style dialog must fill all three arrow combos via the helper",
+    )
+    require(
+        tab_arrows.count("TSupportArrowStyleCombo.Setup") == 3,
+        "programmatic dimension-style dialog must owner-draw all three arrow combos",
+    )
+    require(
+        "CArrowLeaderNames" not in reg_leader,
+        "leader registration still uses a duplicate hardcoded arrow-name list",
+    )
+    require(
+        "GetArrowStyleName(ias)" in reg_leader,
+        "leader registration must reuse resource-string-backed arrow names",
+    )
+    require(
+        "uzcgui2arrows" in reg_zscript,
+        "TArrowStyle descriptor registration must import the arrow-name helper",
+    )
+    require(
+        "TSUserDef'],[FNProgram]" in reg_zscript,
+        "TArrowStyle program names must stay separate from user-facing names",
+    )
+    require(
+        reg_zscript.count("GetArrowStyleName(TS") == 20,
+        "TArrowStyle user names must be populated from the resource-string helper",
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1274

## Summary
- Reused the owner-draw arrow combo helper for the dimension style editor comboboxes so the arrow preview is shown consistently.
- Centralized the displayed arrow style names in `uzcgui2arrows.pas` `resourcestring`s and reused them from the form-based editor, programmatic dimension style editor, leader registration, and `TArrowStyle` user descriptors.
- Kept the existing 20 `TArrowStyle` enum values intact and preserved raw enum names for programmatic descriptor names while switching user-facing names to readable labels.
- Added `experiments/issue_1274_arrow_combo_names_check.py` as a focused regression check for this wiring.

## Reproduction
Before this change, the affected arrow style combo boxes could be populated from raw enum names such as `TSClosedFilled` or duplicated hardcoded names, and the programmatic dimension style editor did not use the owner-draw preview helper for these three combos.

After this change, the current `TArrowStyle` values are populated with readable names such as `Closed filled`, `Architectural tick`, and `User Arrow...`, and the affected combos are configured through `TSupportArrowStyleCombo` for preview rendering. I did not add a `None` enum item because the current Pascal enum does not contain a `None` value; adding one would change the persisted enum/DXF-facing value set.

## Tests
- Passed: `python3 experiments/issue_1274_arrow_combo_names_check.py`
- Passed: `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
- Partial build: `make zcad PCP=$HOME/.lazarus` compiled the changed units, then failed later on an existing Linux build issue: `cad_source/zcad/velec/connectmanager/gui/velectrnav.pas(9,42) Fatal: Can't find unit Windows used by VElectrNav`.
- Existing test target issue: `make tests` fails because `cad_source/components/zcontainers/tests` is missing.
- Existing zengine test issue: `make -C cad_source/zengine/tests LP=/usr/bin PCP=$HOME/.lazarus clean all` fails in `cad_source/zengine/tests/uzctmtextwrap.pas(29,7)` with `Error: Argument cannot be assigned to`.

No GUI screenshot is included because the repository does not complete a local Linux GUI build in this environment before hitting the unrelated `VElectrNav` Windows unit failure.
