### PR TITLE
Добавить превью стилей стрелок в комбобоксы

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-03T12:05:48.684Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-03T12:05:48.684Z

--- a/cad_source/zcad/gui/odjectinspector/uzcoidecorations.pas
+++ b/cad_source/zcad/gui/odjectinspector/uzcoidecorations.pas
@@ -31,7 +31,7 @@ uses
   usupportgui,uzccommandsmanager,
   StdCtrls,uzcdrawings,uzcstrconsts,Controls,Classes,uzcsysvars,
   uzcsysparams,gzctnrVectorTypes,uzcinterface,uzcoimultiobjects,
-  uzcgui2color,uzcgui2linewidth,uzcgui2linetypes,
+  uzcgui2color,uzcgui2linewidth,uzcgui2linetypes,uzcgui2arrows,
   uzccommand_layer,uzcuitypes,uzeNamedObject,uzccommandsimpl,
   uzcOI,uzcdrawing,uzbUnits,uzeBaseUtils,uzcTypes,uzObjectInspectorManager;
 type
@@ -363,6 +363,10 @@ function TGetterSetterTColorDecorator(PInstance:Pointer):String;
 begin
      result:=ColorToString(PTGetterSetterTColor(pinstance)^.Getter);
 end;
+function ArrowStyleDecorator(PInstance:Pointer):String;
+begin
+     result:=GetArrowStyleName(PTArrowStyle(PInstance)^);
+end;
 
 procedure drawLTProp(canvas:TCanvas;ARect:TRect;PInstance:Pointer);
 var
@@ -383,6 +387,88 @@ begin
 
          ARect.Left:=ARect.Left+2;
          drawLT(canvas,ARect,s,plt);
+end;
+procedure drawArrowStyleProp(canvas:TCanvas;ARect:TRect;PInstance:Pointer);
+var
+   arrowStyle:TArrowStyle;
+   s:String;
+begin
+     arrowStyle:=PTArrowStyle(PInstance)^;
+     s:=GetArrowStyleName(arrowStyle);
+     ARect.Left:=ARect.Left+2;
+     drawArrow(canvas,ARect,s,arrowStyle);
+end;
+function ArrowStyleDecoratorCreateEditor(TheOwner:TPropEditorOwner;rect:trect;pinstance:pointer;psa:PTZctnrVectorStrings;FreeOnLostFocus:boolean;PTD:PUserTypeDescriptor;f:TzeUnitsFormat):TEditorDesc;
+var
+   cbedit:TComboBox;
+   selected:integer;
+begin
+     CreateComboPropEditor(TheOwner,pinstance,FreeOnLostFocus,PTD,result.editor,cbedit,f);
+     result.editor.byObjects:=false;
+     SetComboSize(cbedit,sysvar.INTF.INTF_DefaultControlHeight^-6,CBReadOnly);
+     TSupportArrowStyleCombo.FillItems(cbedit,nil);
+     TSupportArrowStyleCombo.Setup(cbedit);
+
+     selected:=ord(PTArrowStyle(pinstance)^);
+     if (selected>=0)and(selected<cbedit.Items.Count) then
+       cbedit.ItemIndex:=selected
+     else
+       cbedit.ItemIndex:=0;
+     result.mode:=TEM_Integrate;
+end;
+function IsArrowStyleDataIndex(index:integer):boolean;
+begin
+     result:=(index>=ord(low(TArrowStyle)))and(index<=ord(high(TArrowStyle)));
+end;
+function GetArrowStyleDataName(PInstance:Pointer;index:integer):String;
+var
+   enumdata:PTEnumData;
+begin
+     enumdata:=PTEnumData(PInstance);
+     if (enumdata<>nil)and(index>=0)and(index<enumdata^.Enums.Count) then
+       result:=pstring(enumdata^.Enums.getDataMutable(index))^
+     else
+       if IsArrowStyleDataIndex(index) then
+         result:=GetArrowStyleName(TArrowStyle(index))
+       else
+         result:='';
+end;
+function ArrowStyleDataDecorator(PInstance:Pointer):String;
+begin
+     result:=GetArrowStyleDataName(PInstance,PTEnumData(PInstance)^.Selected);
+end;
+procedure drawArrowStyleDataProp(canvas:TCanvas;ARect:TRect;PInstance:Pointer);
+var
+   index:integer;
+   s:String;
+begin
+     index:=PTEnumData(PInstance)^.Selected;
+     if not IsArrowStyleDataIndex(index) then
+       exit;
+     s:=GetArrowStyleDataName(PInstance,index);
+     ARect.Left:=ARect.Left+2;
+     drawArrow(canvas,ARect,s,TArrowStyle(index));
+end;
+function ArrowStyleDataDecoratorCreateEditor(TheOwner:TPropEditorOwner;rect:trect;pinstance:pointer;psa:PTZctnrVectorStrings;FreeOnLostFocus:boolean;PTD:PUserTypeDescriptor;f:TzeUnitsFormat):TEditorDesc;
+var
+   cbedit:TComboBox;
+   arrowStyle:TArrowStyle;
+   selected:integer;
+begin
+     CreateComboPropEditor(TheOwner,pinstance,FreeOnLostFocus,PTD,result.editor,cbedit,f);
+     result.editor.byObjects:=false;
+     SetComboSize(cbedit,sysvar.INTF.INTF_DefaultControlHeight^-6,CBReadOnly);
+     TSupportArrowStyleCombo.Setup(cbedit);
+
+     for arrowStyle:=low(TArrowStyle) to high(TArrowStyle) do
+       cbedit.Items.Add(GetArrowStyleDataName(pinstance,ord(arrowStyle)));
+
+     selected:=PTEnumData(pinstance)^.Selected;
+     if (selected>=0)and(selected<cbedit.Items.Count) then
+       cbedit.ItemIndex:=selected
+     else
+       cbedit.ItemIndex:=0;
+     result.mode:=TEM_Integrate;
 end;
 procedure RunStringEditor(PInstance:Pointer);
 var
@@ -681,6 +767,8 @@ begin
     DecorateType(SysUnit.TypeName2PTD('PGDBDimStyleObjInsp'),NamedObjectsDecorator,DimStyleDecoratorCreateEditor,nil);
     DecorateType(SysUnit.TypeName2PTD('PGDBTableStyleObjInsp'),NamedObjectsDecorator,TableStyleDecoratorCreateEditor,nil);
     DecorateType(SysUnit.TypeName2PTD('TGDBPaletteColor'),PaletteColorDecorator,ColorDecoratorCreateEditor,drawIndexColorProp);
+    DecorateType(SysUnit.TypeName2PTD('TArrowStyle'),ArrowStyleDecorator,ArrowStyleDecoratorCreateEditor,drawArrowStyleProp);
+    DecorateType(SysUnit.TypeName2PTD('TArrowStyleData'),ArrowStyleDataDecorator,ArrowStyleDataDecoratorCreateEditor,drawArrowStyleDataProp);
     DecorateType(SysUnit.TypeName2PTD('TGDBOSMode'),nil,CreateEmptyEditor,nil);
     DecorateType(SysUnit.TypeName2PTD('TColor'),TColorDecorator,TColorDecoratorCreateEditor,nil);
     DecorateType(SysUnit.TypeName2PTD('TFString'),TFStringDecorator,nil,nil);

--- a/cad_source/zcad/gui/uzcgui2arrows.pas
+++ b/cad_source/zcad/gui/uzcgui2arrows.pas
@@ -32,9 +32,12 @@ interface
 
 uses
   Classes, Controls, StdCtrls, Graphics, Types,
-  usupportgui, uzestylesdim;
+  usupportgui, uzestylesdim, uzsbVarmanDef;
 
 type
+  PTArrowStyle=^TArrowStyle;
+  TArrowStyleData=type TEnumData;
+
   TSupportArrowStyleCombo = class
                               { OnDrawItem handler. Items must be in
                                 TArrowStyle enum order (Index=Ord(style)). }

--- a/cad_source/zcad/register/uzcregleader.pas
+++ b/cad_source/zcad/register/uzcregleader.pas
@@ -486,7 +486,7 @@ begin
     MPUM_AtLeastOneEntMatched);
 
   MultiPropertiesManager.RegisterPhysMultiproperty(
-    'LeaderArrowStyle','Arrow style',sysunit^.TypeName2PTD('TEnumData'),
+    'LeaderArrowStyle','Arrow style',sysunit^.TypeName2PTD('TArrowStyleData'),
     MPCMisc,GDBLeaderID,nil,0,0,
     TMainIterateProcsData.Create(@GetLeaderArrowStyleData,@FreeTEnumData),
     TEntIterateProcsData.Create(

--- a/cad_source/zcad/register/uzcregzscript.pas
+++ b/cad_source/zcad/register/uzcregzscript.pas
@@ -642,6 +642,9 @@ begin
   utd:=ptsu^.RegisterType(TypeInfo(PTEnumDataWithOtherPointers),
                                   'PTEnumDataWithOtherPointers');
 
+  utd:=ptsu^.RegisterType(TypeInfo(TArrowStyleData),'TArrowStyleData');
+  if utd<>nil then
+    registerRecTypeDescriptorOverrider(utd,@GDBEnumDataDescriptorObj);
 
   utd:=ptsu^.RegisterType(TypeInfo(TMSPrimitiveDetector),
                                   'TMSPrimitiveDetector');

--- a/experiments/issue_1274_arrow_combo_names_check.py
+++ b/experiments/issue_1274_arrow_combo_names_check.py
@@ -20,6 +20,7 @@ def main() -> None:
     arrows = read_repo("cad_source/zcad/gui/uzcgui2arrows.pas")
     dimedit = read_repo("cad_source/zcad/gui/forms/uzcfdimedit.pas")
     tab_arrows = read_repo("cad_source/zcad/gui/uzcui_dimstyleedit_tab_arrows.inc")
+    decorations = read_repo("cad_source/zcad/gui/odjectinspector/uzcoidecorations.pas")
     reg_leader = read_repo("cad_source/zcad/register/uzcregleader.pas")
     reg_zscript = read_repo("cad_source/zcad/register/uzcregzscript.pas")
 
@@ -50,6 +51,14 @@ def main() -> None:
     require("resourcestring" in arrows, "arrow display names must be resourcestrings")
     require("GetArrowStyleName" in arrows, "missing reusable arrow-style name helper")
     require("FillItems" in arrows, "missing reusable arrow combo fill helper")
+    require(
+        "TArrowStyleData=type TEnumData" in arrows,
+        "missing dedicated object-inspector enum data type for arrow styles",
+    )
+    require(
+        "PTArrowStyle=^TArrowStyle" in arrows,
+        "missing reusable TArrowStyle pointer type for decorated editors",
+    )
 
     require(
         "GetEnumName(TypeInfo(TArrowStyle)" not in dimedit,
@@ -73,8 +82,21 @@ def main() -> None:
         "leader registration must reuse resource-string-backed arrow names",
     )
     require(
+        "'LeaderArrowStyle','Arrow style',sysunit^.TypeName2PTD('TArrowStyleData')"
+        in reg_leader,
+        "leader arrow style must use the dedicated arrow-style enum-data type",
+    )
+    require(
         "uzcgui2arrows" in reg_zscript,
         "TArrowStyle descriptor registration must import the arrow-name helper",
+    )
+    require(
+        "RegisterType(TypeInfo(TArrowStyleData)" in reg_zscript,
+        "TArrowStyleData must be registered in the system unit",
+    )
+    require(
+        reg_zscript.count("registerRecTypeDescriptorOverrider(utd,@GDBEnumDataDescriptorObj)") >= 2,
+        "TArrowStyleData must use the enum-data descriptor",
     )
     require(
         "TSUserDef'],[FNProgram]" in reg_zscript,
@@ -83,6 +105,30 @@ def main() -> None:
     require(
         reg_zscript.count("GetArrowStyleName(TS") == 20,
         "TArrowStyle user names must be populated from the resource-string helper",
+    )
+    require(
+        "ArrowStyleDataDecoratorCreateEditor" in decorations,
+        "object inspector must provide an arrow-style combobox editor",
+    )
+    require(
+        "ArrowStyleDecoratorCreateEditor" in decorations,
+        "object inspector must provide a raw TArrowStyle combobox editor",
+    )
+    require(
+        "TSupportArrowStyleCombo.Setup(cbedit)" in decorations,
+        "object inspector arrow-style editor must enable owner draw",
+    )
+    require(
+        "drawArrowStyleDataProp" in decorations,
+        "object inspector must draw arrow previews in the collapsed property cell",
+    )
+    require(
+        "DecorateType(SysUnit.TypeName2PTD('TArrowStyleData')" in decorations,
+        "object inspector must decorate the dedicated arrow-style enum-data type",
+    )
+    require(
+        "DecorateType(SysUnit.TypeName2PTD('TArrowStyle')" in decorations,
+        "object inspector must decorate raw TArrowStyle values",
     )
 
 


### PR DESCRIPTION
## Что изменено

Fixes #1274

- Добавлен отдельный тип `TArrowStyleData` для object inspector, чтобы выбор стиля стрелки не использовал общий `TEnumData` без отрисовки.
- Для `TArrowStyle` и `TArrowStyleData` добавлены декораторы object inspector: отображение имени, owner-draw комбобокс и мини-превью стрелки в ячейке свойства.
- `LeaderArrowStyle` теперь регистрируется через `TArrowStyleData`, поэтому комбобокс выбора стрелки у лидеров использует тот же визуальный helper, что и редактор размерных стилей.
- Регрессионная проверка расширена на dim editor, leader registration, zscript registration и object-inspector decorators.

## Как воспроизвести

1. Открыть object inspector для leader entity.
2. Открыть свойство `Arrow style`.
3. До исправления список был обычным текстовым `TEnumData` без мини-превью стрелок.
4. После исправления используется owner-draw список со стилями стрелок и нормальными именами из `resourcestring`.

## Проверка

- `python3 experiments/issue_1274_arrow_combo_names_check.py`
- `python3 experiments/test_leader_inspector_registration.py`
- `git diff --check`
- `lazbuild cad_source/zcad.lpi` пробовал с локально созданными generated includes; локальная сборка останавливается до измененных units на отсутствующей зависимости: `uzcregmemprofiler.pas(23,3) Fatal: Can't find unit callstack_memprofiler used by uzcregMemProfiler`.

Скриншот after-state не приложен, потому что локальная Lazarus-сборка в этом окружении не доходит до запуска GUI из-за отсутствующей зависимости выше.
