### PR TITLE
Fix arrow style combo preview compilation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-03T13:05:17.176Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-03T13:05:17.176Z

--- a/cad_source/zcad/gui/odjectinspector/uzcoidecorations.pas
+++ b/cad_source/zcad/gui/odjectinspector/uzcoidecorations.pas
@@ -25,7 +25,7 @@ uses
   SysUtils,Graphics,LCLType,Themes,Forms,ColorBox,
   uzOIUI,uzOIDecorations,uzccommandsabstract,uzepalette,
   uzOIEditors,UEnumDescriptor,uzObjectInspector,uzcinfoform,
-  uzestyleslinetypes,uzctreenode,uzcfsnapeditor,
+  uzestyleslinetypes,uzestylesdim,uzctreenode,uzcfsnapeditor,
   uzeconsts,UGDBNamedObjectsArray,uzctnrvectorstrings,
   uzsbVarmanDef,Varman,uzcfcolors,uzestyleslayers,uzeTypes,uzcflineweights,
   usupportgui,uzccommandsmanager,

--- a/cad_source/zcad/gui/uzcgui2arrows.pas
+++ b/cad_source/zcad/gui/uzcgui2arrows.pas
@@ -32,7 +32,7 @@ interface
 
 uses
   Classes, Controls, StdCtrls, Graphics, Types,
-  usupportgui, uzestylesdim, uzsbVarmanDef;
+  usupportgui, uzestylesdim, uzsbVarmanDef, uzctnrVectorStrings;
 
 type
   PTArrowStyle=^TArrowStyle;


### PR DESCRIPTION
## Summary
Fixes the compile errors introduced by the arrow-style combo preview support.

Root cause: the new arrow preview helper declared `TArrowStyleData = type TEnumData` without importing the unit that provides `TEnumData`. After that was fixed, the object-inspector decoration unit also needed the `TArrowStyle` enum's defining unit because it now references `TArrowStyle` directly in arrow preview decorators.

## Changes
- Added `uzctnrVectorStrings` to `uzcgui2arrows.pas` so `TEnumData` is visible.
- Added `uzestylesdim` to `uzcoidecorations.pas` so `TArrowStyle` is visible.

## Verification
- Ran `git diff --check` successfully.
- Ran `make zcadenv LP=/usr/bin PCP=$HOME/.lazarus` successfully.
- Ran `make zcad LP=/usr/bin PCP=$HOME/.lazarus`; confirmed `uzcgui2arrows.pas` and `uzcoidecorations.pas` compile past the reported errors. The full Linux build later stops at an unrelated existing platform issue: `cad_source/zcad/velec/connectmanager/gui/velectrnav.pas(9,42) Fatal: Can't find unit Windows used by VElectrNav`.

Fixes veb86/zcadvelecAI#1278
