### PR TITLE
loaderDWG: fix DimStyleEditForm crash after DWG load

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-03T19:04:22.166Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-03T19:04:22.166Z

--- a/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
+++ b/cad_source/zengine/fileformats/dwg/uzedwgimport.pas
@@ -1147,6 +1147,8 @@ begin
       ApplyDWGCurrentLineType(ZContext);
       ApplyDWGCurrentTextStyle(ZContext);
       ApplyDWGCurrentDimStyle(ZContext);
+      ZContext.PDrawing^.DimStyleTable.ResolveLineTypes(
+        ZContext.PDrawing^.LTypeStyleTable);
       ApplyDWGHeaderEntityProps(ZContext);
       ApplyDWGViewState(ZContext);
     finally

--- a/cad_source/zengine/tests/testzengine.lpr
+++ b/cad_source/zengine/tests/testzengine.lpr
@@ -5,7 +5,7 @@ program testzengine;
 uses
   //MemCheck,
   Classes, consoletestrunner,
-  Logtest,BoundaryPathSimpletest,
+  Logtest,BoundaryPathSimpletest, uzctdwgdimstylelinetype,
   uzctEntityArc, uzctmtextwrap, uzctenttextjustify, uzctacadtable, uzctentproxy,
   uzctentpolyfacemesh, uzctentleader, uzctdwgblockreserve, uzctdwgentleader,
   uzctenttextnilstyle,

--- a/cad_source/zengine/tests/uzctdwgdimstylelinetype.pas
+++ b/cad_source/zengine/tests/uzctdwgdimstylelinetype.pas
@@ -1,0 +1,80 @@
+unit uzctdwgdimstylelinetype;
+
+{ Issue #1280 regression: DWG-loaded dimension styles are initialized with nil
+  line-type pointers. The DXF loader normalizes those fields to ByBlock after
+  reading tables; DWG import must do the same before DimStyleEditForm can open. }
+
+{$mode objfpc}{$H+}
+{$modeswitch advancedrecords}
+
+interface
+
+uses
+  fpcunit,
+  testregistry;
+
+type
+  TDWGDimStyleLineTypeTest = class(TTestCase)
+  published
+    procedure EndImportAssignsFallbackLineTypes;
+  end;
+
+implementation
+
+uses
+  uzeTypes,
+  uzedrawingsimple,
+  uzeffmanager,
+  uzgldrawcontext,
+  uzestylesdim,
+  uzestyleslinetypes,
+  uzedwgimport;
+
+procedure TDWGDimStyleLineTypeTest.EndImportAssignsFallbackLineTypes;
+var
+  Drawing: TSimpleDrawing;
+  DC: TDrawContext;
+  ZDC: TZDrawingContext;
+  DimStyle: PGDBDimStyle;
+  ByBlockLT: PGDBLtypeProp;
+begin
+  Drawing.init(nil);
+  try
+    DC := Drawing.CreateDrawingRC;
+    ZDC.CreateRec(Drawing, Drawing.pObjRoot^, TLOLoad, DC);
+
+    BeginDWGImport(ZDC, 'issue-1280-test.dwg');
+    try
+      DimStyle := PGDBDimStyle(Drawing.DimStyleTable.MergeItem('DWG_STYLE',
+        TLOLoad));
+      AssertNotNull('test dimstyle must be created', DimStyle);
+      DimStyle^.init('DWG_STYLE');
+      DimStyle^.SetDefaultValues;
+
+      AssertNull('DWG mapper starts with nil DIMLTYPE',
+        DimStyle^.Lines.DIMLTYPE);
+      AssertNull('DWG mapper starts with nil DIMLTEX1',
+        DimStyle^.Lines.DIMLTEX1);
+      AssertNull('DWG mapper starts with nil DIMLTEX2',
+        DimStyle^.Lines.DIMLTEX2);
+    finally
+      EndDWGImport(ZDC);
+    end;
+
+    ByBlockLT := Drawing.LTypeStyleTable.GetSystemLT(TLTByBlock);
+    AssertNotNull('ByBlock line type must exist', ByBlockLT);
+    AssertTrue('DIMLTYPE must fall back to ByBlock',
+      ByBlockLT = DimStyle^.Lines.DIMLTYPE);
+    AssertTrue('DIMLTEX1 must fall back to ByBlock',
+      ByBlockLT = DimStyle^.Lines.DIMLTEX1);
+    AssertTrue('DIMLTEX2 must fall back to ByBlock',
+      ByBlockLT = DimStyle^.Lines.DIMLTEX2);
+  finally
+    Drawing.done;
+  end;
+end;
+
+initialization
+  RegisterTest(TDWGDimStyleLineTypeTest);
+
+end.


### PR DESCRIPTION
Fixes #1280

## Summary
- Resolve DWG-imported dimension style linetype references during `EndDWGImport`, matching the DXF loader normalization path.
- Add a zengine regression test that starts with DWG-style nil `DIMLTYPE`, `DIMLTEX1`, and `DIMLTEX2` fields and verifies they fall back to `ByBlock`.
- Restore the branch bootstrap `.gitkeep` change so it does not appear in the PR diff.

## Verification
- `git diff --check`
- Focused temporary nogui runner for `TDWGDimStyleLineTypeTest.EndImportAssignsFallbackLineTypes`: 1 test, 0 errors, 0 failures.
- `make -C cad_source/zengine/tests LP=/usr/bin PCP=~/.lazarus clean all` compiles `uzctdwgdimstylelinetype.pas`, then stops at an existing unrelated suite compile error: `cad_source/zengine/tests/uzctmtextwrap.pas:29:7 Error: Argument cannot be assigned to`.
