### PR TITLE
Fix uzvfspellchecker result type compilation

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-04T20:02:19.744Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-04T20:02:19.744Z

--- a/cad_source/zcad/velec/uzvfspellchecker/README.md
+++ b/cad_source/zcad/velec/uzvfspellchecker/README.md
@@ -91,7 +91,7 @@
 - **SpellChecker** (из uzcSpeller.pas) - глобальный объект проверки орфографии
 - **TSpeller** (из uSpeller.pas) - класс для работы с Hunspell
 - **Методы TSpeller:**
-  - SpellTextSimple(Text: string; var Details: string; Opts: TSpellOpts): TSpellResult
+  - SpellTextSimple(Text: string; var Details: string; Opts: TSpellOpts): TLangHandle
   - SpellWord(Word: string): boolean
   - GetSuggestions(Word: string): TStringList (предполагаемый метод)
 

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspelllogic.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspelllogic.pas
@@ -117,7 +117,7 @@ end;
 function CheckWord(const AWord: string; var ErrorDetails: string): boolean;
 var
   spellOpts: TSpeller.TSpellOpts;
-  spellResult: TSpeller.TSpellResult;
+  spellResult: TSpeller.TLangHandle;
 begin
   Result := False;
 

--- a/test_issue1284_spellchecker_result_type.py
+++ b/test_issue1284_spellchecker_result_type.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1284 spellchecker result type usage.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SPELL_LOGIC = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvfspellchecker"
+    / "uzvfspelllogic.pas"
+)
+SPELL_README = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvfspellchecker"
+    / "README.md"
+)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_spellchecker_logic_uses_existing_speller_result_type():
+    logic_pas = read_text(SPELL_LOGIC)
+
+    assert "TSpeller.TSpellResult" not in logic_pas
+    assert "spellResult: TSpeller.TLangHandle;" in logic_pas
+    assert "SpellTextSimple(AWord, ErrorDetails, spellOpts)" in logic_pas
+    assert "spellResult = TSpeller.WrongLang" in logic_pas
+
+
+def test_spellchecker_readme_documents_actual_result_type():
+    readme_md = read_text(SPELL_README)
+    actual_signature = (
+        "SpellTextSimple(Text: string; var Details: string; Opts: TSpellOpts): "
+        "TLangHandle"
+    )
+    invalid_signature = (
+        "SpellTextSimple(Text: string; var Details: string; Opts: TSpellOpts): "
+        "TSpellResult"
+    )
+
+    assert actual_signature in readme_md
+    assert invalid_signature not in readme_md
+
+
+if __name__ == "__main__":
+    test_spellchecker_logic_uses_existing_speller_result_type()
+    test_spellchecker_readme_documents_actual_result_type()
+    print("issue 1284 spellchecker result type checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1284

## Summary
- Replaces the nonexistent `TSpeller.TSpellResult` declaration in `uzvfspelllogic.pas` with the actual `TSpeller.TLangHandle` return type used by `uSpeller.SpellTextSimple`.
- Updates the spellchecker README so the documented `SpellTextSimple` signature no longer points to the invalid result type.
- Adds a focused regression check for the spellchecker result type and README signature.

## Reproduction
Before this change, compiling `uzvfspelllogic.pas` failed at line 120 because `TSpeller` has no nested `TSpellResult` member. The `fphunspell` `uSpeller` unit defines `TLangHandle` and returns it from `SpellTextSimple`.

## Tests
- `python3 test_issue1284_spellchecker_result_type.py`
- `python3 test_issue1282_spellchecker_registration.py`
- `git diff --check upstream/master...HEAD`

Full `make tests` was attempted locally, but this workspace cannot run it: `cad_source/components/zcontainers/tests` is missing and Lazarus/FPC tools such as `/usr/bin/lazbuild` and `fpc` are not installed.