### PR TITLE
Fix uzvfspellchecker drawing scan

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-08T06:06:10.020Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-08T06:06:10.020Z

--- a/cad_source/zcad/register/uzcregspellchecker.pas
+++ b/cad_source/zcad/register/uzcregspellchecker.pas
@@ -24,9 +24,26 @@ uses
 
 implementation
 
-procedure uzvfspellcheckerSetupProc({%H-}Form: TControl);
+uses
+  uzclog;
+
+procedure uzvfspellcheckerSetupProc(Form: TControl);
 begin
-  // Reserved for future spellchecker form setup.
+  programlog.LogOutFormatStr('uzvfspellcheckerSetupProc: setup started',
+    [], LM_Info);
+
+  if Form = nil then begin
+    programlog.LogOutFormatStr('uzvfspellcheckerSetupProc: nil form',
+      [], LM_Info);
+    Exit;
+  end;
+
+  if Form is TSpellCheckerForm then
+    TSpellCheckerForm(Form).CheckCurrentDrawing
+  else
+    programlog.LogOutFormatStr(
+      'uzvfspellcheckerSetupProc: unexpected form class "%s"',
+      [Form.ClassName], LM_Info);
 end;
 
 initialization

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas
@@ -75,12 +75,18 @@ type
     // Очистить дерево вариантов
     procedure ClearSuggestionsTree;
 
+    // Очистить результаты и показать сообщение
+    procedure ResetResultsWithMessage(const MessageText: string);
+
   public
     constructor Create(AOwner: TComponent); override;
     destructor Destroy; override;
 
     // Проверить текст на ошибки
     procedure CheckText(const AText: string);
+
+    // Проверить текстовые примитивы текущего чертежа
+    procedure CheckCurrentDrawing;
   end;
 
 var
@@ -88,15 +94,106 @@ var
 
 implementation
 
+uses
+  gzctnrVectorTypes,
+  uzcdrawings, uzeconsts, uzeentity, uzeenttext;
+
 {$R *.lfm}
 
 const
+  // Разделитель текста между разными примитивами чертежа
+  DRAWING_TEXT_SEPARATOR = #10;
   // Индекс колонки с текстом ошибки
   COL_ERROR_WORD = 0;
   // Индекс колонки с количеством вхождений
   COL_ERROR_COUNT = 1;
   // Индекс колонки с вариантом исправления
   COL_SUGGESTION = 0;
+  // Сообщение по умолчанию для метки предложения
+  STR_SELECT_ERROR = 'Выберите слово из списка ошибок';
+  // Сообщение при отсутствии активного чертежа
+  STR_NO_DRAWING = 'Нет активного чертежа';
+  // Сообщение при отсутствии текстовых примитивов
+  STR_NO_TEXT_ENTITIES = 'В чертеже нет примитивов TEXT/MTEXT';
+  // Сообщение при отсутствии текста в найденных примитивах
+  STR_NO_TEXT_CONTENT = 'В текстовых примитивах нет текста';
+
+function IsSpellTextEntity(EntityPtr: PGDBObjEntity): boolean;
+begin
+  Result := False;
+
+  if not Assigned(EntityPtr) then
+    Exit;
+
+  case EntityPtr^.GetObjType of
+    GDBTextID, GDBMTextID:
+      Result := True;
+  end;
+end;
+
+function GetSpellTextContent(EntityPtr: PGDBObjEntity): string;
+begin
+  Result := '';
+
+  if not IsSpellTextEntity(EntityPtr) then
+    Exit;
+
+  Result := string(PGDBObjText(EntityPtr)^.Content);
+  if Result = '' then begin
+    Result := string(PGDBObjText(EntityPtr)^.Template);
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.GetSpellTextContent: content empty, template length=%d',
+      [Length(Result)], LM_Info);
+  end;
+end;
+
+procedure AppendDrawingText(var DrawingText: string; const EntityText: string);
+begin
+  if EntityText = '' then
+    Exit;
+
+  if DrawingText <> '' then
+    DrawingText := DrawingText + DRAWING_TEXT_SEPARATOR;
+
+  DrawingText := DrawingText + EntityText;
+end;
+
+function LoadCurrentDrawingText(out TextEntityCount, SkippedTextCount,
+  EntityCount: integer): string;
+var
+  EntityPtr: PGDBObjEntity;
+  Iterator: itrec;
+  EntityText: string;
+begin
+  Result := '';
+  TextEntityCount := 0;
+  SkippedTextCount := 0;
+  EntityCount := 0;
+
+  EntityPtr := drawings.GetCurrentDWG^.GetCurrentROOT^.ObjArray.beginiterate(
+    Iterator);
+  if EntityPtr <> nil then
+    repeat
+      Inc(EntityCount);
+      if IsSpellTextEntity(EntityPtr) then begin
+        Inc(TextEntityCount);
+        EntityText := Trim(GetSpellTextContent(EntityPtr));
+
+        if EntityText = '' then
+          Inc(SkippedTextCount)
+        else
+          AppendDrawingText(Result, EntityText);
+
+        programlog.LogOutFormatStr(
+          'TSpellCheckerForm.LoadCurrentDrawingText: text entity type=%d, ' +
+          'text length=%d',
+          [EntityPtr^.GetObjType, Length(EntityText)], LM_Info);
+      end;
+
+      EntityPtr := drawings.GetCurrentDWG^.GetCurrentROOT^.ObjArray.iterate(
+        Iterator);
+    until EntityPtr = nil;
+end;
 
 { TSpellCheckerForm }
 
@@ -138,16 +235,67 @@ var
 begin
   FCurrentText := AText;
 
+  programlog.LogOutFormatStr('TSpellCheckerForm.CheckText: text length=%d',
+    [Length(AText)], LM_Info);
+
   // Найти все ошибки
   errorCount := FindAllErrors(FCurrentText, FErrorManager);
 
   // Обновить отображение
   UpdateErrorsTree;
   ClearSuggestionsTree;
-  SentenceLabel.Caption := 'Выберите слово из списка ошибок';
+  SentenceLabel.Caption := STR_SELECT_ERROR;
 
   programlog.LogOutFormatStr('TSpellCheckerForm.CheckText: found %d errors',
     [errorCount], LM_Info);
+end;
+
+// Проверить текстовые примитивы текущего чертежа
+procedure TSpellCheckerForm.CheckCurrentDrawing;
+var
+  DrawingText: string;
+  TextEntityCount: integer;
+  SkippedTextCount: integer;
+  EntityCount: integer;
+begin
+  programlog.LogOutFormatStr('TSpellCheckerForm.CheckCurrentDrawing: start',
+    [], LM_Info);
+
+  if drawings.GetCurrentDWG = nil then begin
+    ResetResultsWithMessage(STR_NO_DRAWING);
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.CheckCurrentDrawing: no current drawing', [],
+      LM_Info);
+    Exit;
+  end;
+
+  if drawings.GetCurrentDWG^.GetCurrentROOT = nil then begin
+    ResetResultsWithMessage(STR_NO_DRAWING);
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.CheckCurrentDrawing: no current root', [], LM_Info);
+    Exit;
+  end;
+
+  DrawingText := LoadCurrentDrawingText(TextEntityCount, SkippedTextCount,
+    EntityCount);
+
+  programlog.LogOutFormatStr(
+    'TSpellCheckerForm.CheckCurrentDrawing: scanned entities=%d, ' +
+    'text entities=%d, empty text=%d, text length=%d',
+    [EntityCount, TextEntityCount, SkippedTextCount, Length(DrawingText)],
+    LM_Info);
+
+  if TextEntityCount = 0 then begin
+    ResetResultsWithMessage(STR_NO_TEXT_ENTITIES);
+    Exit;
+  end;
+
+  if DrawingText = '' then begin
+    ResetResultsWithMessage(STR_NO_TEXT_CONTENT);
+    Exit;
+  end;
+
+  CheckText(DrawingText);
 end;
 
 // Обновить дерево ошибок
@@ -182,6 +330,7 @@ var
   i: integer;
   node: PVirtualNode;
   nodeData: PSuggestionNodeData;
+  suggestions: TStringList;
 begin
   if not Assigned(ErrorPtr) then begin
     ClearSuggestionsTree;
@@ -189,8 +338,9 @@ begin
   end;
 
   // Получить варианты исправления
-  FCurrentSuggestions.Clear;
-  FCurrentSuggestions := GetSuggestions(ErrorPtr^.ErrorWord);
+  suggestions := GetSuggestions(ErrorPtr^.ErrorWord);
+  FCurrentSuggestions.Free;
+  FCurrentSuggestions := suggestions;
 
   SuggestionsTree.BeginUpdate;
   try
@@ -216,6 +366,20 @@ procedure TSpellCheckerForm.ClearSuggestionsTree;
 begin
   SuggestionsTree.Clear;
   FCurrentSuggestions.Clear;
+end;
+
+// Очистить результаты и показать сообщение
+procedure TSpellCheckerForm.ResetResultsWithMessage(const MessageText: string);
+begin
+  FCurrentText := '';
+  FErrorManager.ClearErrors;
+  UpdateErrorsTree;
+  ClearSuggestionsTree;
+  SentenceLabel.Caption := MessageText;
+
+  programlog.LogOutFormatStr(
+    'TSpellCheckerForm.ResetResultsWithMessage: "%s"', [MessageText],
+    LM_Info);
 end;
 
 // Получить текст для ячейки дерева ошибок
@@ -271,7 +435,7 @@ var
 begin
   if not Assigned(Node) then begin
     ClearSuggestionsTree;
-    SentenceLabel.Caption := 'Выберите слово из списка ошибок';
+    SentenceLabel.Caption := STR_SELECT_ERROR;
     Exit;
   end;
 
@@ -299,11 +463,10 @@ end;
 // Обработчик действия "Обновить"
 procedure TSpellCheckerForm.RefreshActionExecute(Sender: TObject);
 begin
-  if Length(FCurrentText) > 0 then begin
-    CheckText(FCurrentText);
-    programlog.LogOutFormatStr('TSpellCheckerForm.RefreshActionExecute: OK',
-      [], LM_Info);
-  end;
+  programlog.LogOutFormatStr(
+    'TSpellCheckerForm.RefreshActionExecute: refresh requested', [],
+    LM_Info);
+  CheckCurrentDrawing;
 end;
 
 end.

--- a/test_issue1286_spellchecker_drawing_scan.py
+++ b/test_issue1286_spellchecker_drawing_scan.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1286 spellchecker drawing scan.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SPELL_FORM = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvfspellchecker"
+    / "uzvfspellform.pas"
+)
+SPELL_REGISTER = ROOT / "cad_source" / "zcad" / "register" / "uzcregspellchecker.pas"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_procedure(source: str, procedure_name: str) -> str:
+    marker = f"procedure {procedure_name}"
+    start = source.index(marker)
+    candidates = [
+        position
+        for position in (
+            source.find("\nprocedure ", start + len(marker)),
+            source.find("\nfunction ", start + len(marker)),
+        )
+        if position != -1
+    ]
+    end = min(candidates) if candidates else len(source)
+    return source[start:end]
+
+
+def test_spellchecker_form_exposes_current_drawing_scan():
+    form_pas = read_text(SPELL_FORM)
+
+    assert "procedure CheckCurrentDrawing;" in form_pas
+    assert "uzcdrawings" in form_pas
+    assert "uzeentity" in form_pas
+    assert "uzeenttext" in form_pas
+    assert "uzeconsts" in form_pas
+    assert "gzctnrVectorTypes" in form_pas
+
+
+def test_refresh_action_scans_drawing_and_logs_even_without_loaded_text():
+    form_pas = read_text(SPELL_FORM)
+    refresh_proc = extract_procedure(
+        form_pas, "TSpellCheckerForm.RefreshActionExecute"
+    )
+
+    assert "CheckCurrentDrawing;" in refresh_proc
+    assert "Length(FCurrentText) > 0" not in refresh_proc
+    assert "TSpellCheckerForm.RefreshActionExecute: refresh requested" in refresh_proc
+
+
+def test_current_drawing_scan_extracts_text_and_mtext_content():
+    form_pas = read_text(SPELL_FORM)
+
+    assert "GetCurrentDWG^.GetCurrentROOT^.ObjArray.beginiterate" in form_pas
+    assert "GetCurrentDWG^.GetCurrentROOT^.ObjArray.iterate" in form_pas
+    assert "GDBTextID" in form_pas
+    assert "GDBMTextID" in form_pas
+    assert "PGDBObjText(EntityPtr)^.Content" in form_pas
+    assert "PGDBObjText(EntityPtr)^.Template" in form_pas
+
+
+def test_current_drawing_scan_writes_diagnostic_log_entries():
+    form_pas = read_text(SPELL_FORM)
+
+    assert "TSpellCheckerForm.CheckCurrentDrawing: start" in form_pas
+    assert (
+        "TSpellCheckerForm.CheckCurrentDrawing: scanned entities=%d, "
+        in form_pas
+    )
+    assert (
+        "TSpellCheckerForm.LoadCurrentDrawingText: text entity type=%d, "
+        in form_pas
+    )
+    assert "TSpellCheckerForm.ResetResultsWithMessage:" in form_pas
+
+
+def test_registered_form_setup_runs_initial_drawing_scan():
+    register_pas = read_text(SPELL_REGISTER)
+
+    assert "uzclog" in register_pas
+    assert "TSpellCheckerForm(Form).CheckCurrentDrawing" in register_pas
+    assert "uzvfspellcheckerSetupProc: setup started" in register_pas
+
+
+if __name__ == "__main__":
+    test_spellchecker_form_exposes_current_drawing_scan()
+    test_refresh_action_scans_drawing_and_logs_even_without_loaded_text()
+    test_current_drawing_scan_extracts_text_and_mtext_content()
+    test_current_drawing_scan_writes_diagnostic_log_entries()
+    test_registered_form_setup_runs_initial_drawing_scan()
+    print("issue 1286 spellchecker drawing scan checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1286

## Reproduction
- Open `uzvfspellchecker` on a drawing that contains spelling errors in `TEXT` or `MTEXT` primitives.
- Press refresh.
- Before this change, refresh only rechecked `FCurrentText` when it was already non-empty, so a newly opened form did not scan the drawing and wrote no useful diagnostics.

## Changes
- Added `TSpellCheckerForm.CheckCurrentDrawing` to scan the active drawing root for `TEXT` and `MTEXT` primitives.
- Collects primitive `Content` with `Template` fallback, then runs the existing spell error search over the collected text.
- Wires both form setup and the refresh action to the drawing scan path.
- Adds `uzclog` diagnostics for setup, refresh, scan counts, text primitive lengths, missing drawing/root, and empty scan states.
- Clears the UI with explicit messages when there is no active drawing or no text content to scan.
- Fixes suggestion-list ownership so repeated suggestion updates do not leak the previous `TStringList`.

## Verification
- `python3 test_issue1286_spellchecker_drawing_scan.py`
- `python3 test_issue1284_spellchecker_result_type.py`
- `python3 test_issue1282_spellchecker_registration.py`
- `python3 test_parsing_logic.py`
- `python3 test_polyfacemesh_parsing.py`
- `git diff --check`
- `fpc -h` could not be run in this environment because `fpc` is not installed.
