### PR TITLE
Fix uzvfspellchecker suggestion parsing

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-08T07:54:54.306Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-08T07:54:54.306Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspelllogic.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspelllogic.pas
@@ -207,10 +207,37 @@ begin
     [Result], LM_Info);
 end;
 
+// Извлечь список вариантов из строки вида "слово[вариант1, вариант2]"
+function ExtractSuggestionListText(const ADetails: string): string;
+var
+  openBracketPos: integer;
+  closeBracketPos: integer;
+begin
+  Result := Trim(ADetails);
+  openBracketPos := Pos('[', ADetails);
+
+  if openBracketPos = 0 then
+    Exit;
+
+  closeBracketPos := Length(ADetails);
+  while (closeBracketPos > openBracketPos) and
+        (ADetails[closeBracketPos] <> ']') do
+    Dec(closeBracketPos);
+
+  if closeBracketPos <= openBracketPos then begin
+    Result := '';
+    Exit;
+  end;
+
+  Result := Trim(Copy(ADetails, openBracketPos + 1,
+    closeBracketPos - openBracketPos - 1));
+end;
+
 // Получить варианты исправления
 function GetSuggestions(const AWord: string): TStringList;
 var
   errorDetails: string;
+  suggestionDetails: string;
   i: integer;
 begin
   Result := TStringList.Create;
@@ -223,17 +250,19 @@ begin
     TSpeller.CSpellOptDetail);
 
   // Разобрать варианты из errorDetails
-  // Примечание: формат зависит от реализации TSpeller
-  // Здесь используется простой парсинг
-  if Length(errorDetails) > 0 then begin
+  suggestionDetails := ExtractSuggestionListText(errorDetails);
+  if Length(suggestionDetails) > 0 then begin
     // Попытка извлечь варианты, разделенные запятой
     Result.Delimiter := ',';
     Result.StrictDelimiter := True;
-    Result.DelimitedText := errorDetails;
+    Result.DelimitedText := suggestionDetails;
 
     // Очистить варианты от лишних пробелов
-    for i := 0 to Result.Count - 1 do
+    for i := Result.Count - 1 downto 0 do begin
       Result[i] := Trim(Result[i]);
+      if Length(Result[i]) = 0 then
+        Result.Delete(i);
+    end;
   end;
 
   programlog.LogOutFormatStr('GetSuggestions: word="%s", count=%d',

--- a/test_issue1290_spellchecker_suggestions.py
+++ b/test_issue1290_spellchecker_suggestions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1290 spellchecker suggestion parsing.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SPELL_LOGIC = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvfspellchecker"
+    / "uzvfspelllogic.pas"
+)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def extract_routine(source: str, routine_name: str) -> str:
+    markers = [f"procedure {routine_name}", f"function {routine_name}"]
+    implementation = source.find("\nimplementation")
+    search_from = implementation if implementation != -1 else 0
+    starts = [source.find(marker, search_from) for marker in markers]
+    starts = [start for start in starts if start != -1]
+    assert starts, f"{routine_name} not found"
+    start = min(starts)
+    candidates = [
+        position
+        for position in (
+            source.find("\nprocedure ", start + 1),
+            source.find("\nfunction ", start + 1),
+        )
+        if position != -1
+    ]
+    end = min(candidates) if candidates else len(source)
+    return source[start:end]
+
+
+def test_bracketed_speller_details_are_parsed_as_suggestion_list():
+    logic_pas = read_text(SPELL_LOGIC)
+    helper = extract_routine(logic_pas, "ExtractSuggestionListText")
+    helper_one_line = " ".join(helper.split())
+
+    assert "openBracketPos := Pos('[', ADetails)" in helper
+    assert "while (closeBracketPos > openBracketPos) and" in helper
+    assert "(ADetails[closeBracketPos] <> ']')" in helper
+    assert (
+        "Copy(ADetails, openBracketPos + 1, "
+        "closeBracketPos - openBracketPos - 1)"
+    ) in helper_one_line
+
+
+def test_get_suggestions_splits_only_clean_suggestion_payload():
+    logic_pas = read_text(SPELL_LOGIC)
+    get_suggestions = extract_routine(logic_pas, "GetSuggestions")
+
+    assert "suggestionDetails := ExtractSuggestionListText(errorDetails)" in get_suggestions
+    assert "Result.DelimitedText := suggestionDetails" in get_suggestions
+    assert "Result.DelimitedText := errorDetails" not in get_suggestions
+
+
+if __name__ == "__main__":
+    test_bracketed_speller_details_are_parsed_as_suggestion_list()
+    test_get_suggestions_splits_only_clean_suggestion_payload()
+    print("issue 1290 spellchecker suggestion parsing checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1290

## Reproduction
- Open `uzvfspellchecker` on text like `Расщчетная схема щита ЩАО1`.
- Before this change, `GetSuggestions` split the full spellchecker detail string, for example `Расщчетная[Расчетная, Рассветная, Растраченная]`.
- The first suggestion row therefore included the misspelled word and opening bracket, and the last suggestion row included the closing bracket.

## Changes
- Adds `ExtractSuggestionListText` to strip the `слово[...]` wrapper from spellchecker details before splitting suggestions.
- Keeps `GetSuggestions` passing only the cleaned suggestion payload to `TStringList.DelimitedText`.
- Trims suggestions and removes empty entries after splitting.
- Adds a focused regression check for issue 1290.

## Verification
- `python3 test_issue1290_spellchecker_suggestions.py`
- `for t in test_*.py; do python3 "$t" || exit $?; done`
- `git diff --check`

Lazarus/FPC compilation was not run locally because this environment does not have `fpc` or `lazbuild` installed.
