### PR TITLE
uzvfspellchecker. Зум к слову с ошибкой

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-08T10:51:24.599Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-08T10:51:24.599Z

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.lfm
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.lfm
@@ -76,6 +76,7 @@ object SpellCheckerForm: TSpellCheckerForm
       TreeOptions.MiscOptions = [toFullRepaintOnResize, toInitOnSave, toToggleOnDblClick, toWheelPanning]
       TreeOptions.PaintOptions = [toShowButtons, toShowDropmark, toThemeAware, toUseBlendedImages]
       TreeOptions.SelectionOptions = [toFullRowSelect]
+      OnDblClick = ErrorsTreeDblClick
       OnFocusChanged = ErrorsTreeFocusChanged
       OnGetText = ErrorsTreeGetText
     end

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas
@@ -56,6 +56,7 @@ type
 
     procedure ErrorsTreeFocusChanged(Sender: TBaseVirtualTree;
       Node: PVirtualNode; Column: TColumnIndex);
+    procedure ErrorsTreeDblClick(Sender: TObject);
     procedure ErrorsTreeGetText(Sender: TBaseVirtualTree; Node: PVirtualNode;
       Column: TColumnIndex; TextType: TVSTTextType; var CellText: string);
     procedure ApplySuggestionActionExecute(Sender: TObject);
@@ -121,7 +122,7 @@ implementation
 uses
   gzctnrVectorTypes,
   uzcdrawing, uzcdrawings, uzcutils, uzeconsts, uzeentity, uzeenttext,
-  uzetypes, uzgldrawcontext, zUndoCmdSaveEntityState;
+  uzetypes, uzgldrawcontext, uzvfspellzoom, zUndoCmdSaveEntityState;
 
 {$R *.lfm}
 
@@ -677,6 +678,19 @@ begin
   programlog.LogOutFormatStr(
     'TSpellCheckerForm.ErrorsTreeFocusChanged: selected "%s"',
     [errorPtr^.ErrorWord], LM_Info);
+end;
+
+// Обработчик двойного щелчка по ошибке
+procedure TSpellCheckerForm.ErrorsTreeDblClick(Sender: TObject);
+begin
+  if ZoomToSpellError(GetFocusedError) then
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.ErrorsTreeDblClick: zoomed focused error',
+      [], LM_Info)
+  else
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.ErrorsTreeDblClick: no drawable error selected',
+      [], LM_Info);
 end;
 
 // Обработчик действия "Применить"

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellzoom.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellzoom.pas
@@ -1,0 +1,415 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+{
+@author(Vladimir Bobrov)
+}
+
+unit uzvfspellzoom;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  uzvfspelldata, uzegeometrytypes;
+
+function TryGetSpellErrorWordVolume(ErrorPtr: PSpellError;
+  out Volume: TBoundingBox): boolean;
+function ZoomToSpellEntity(ErrorPtr: PSpellError): boolean;
+function ZoomToSpellError(ErrorPtr: PSpellError): boolean;
+
+implementation
+
+uses
+  SysUtils, StrUtils, Math,
+  uzclog,
+  uzcdrawing, uzcdrawings,
+  uzeconsts, uzeentity, uzeenttext, uzeentmtext, uzegeometry, uzetypes,
+  uzefont, uzglgeometry, uzgldrawcontext;
+
+const
+  WORD_VOLUME_PADDING_FACTOR = 0.35;
+
+function IsZoomTextEntity(EntityPtr: PGDBObjEntity): boolean;
+begin
+  Result := False;
+
+  if not Assigned(EntityPtr) then
+    Exit;
+
+  case EntityPtr^.GetObjType of
+    GDBTextID, GDBMTextID:
+      Result := True;
+  end;
+end;
+
+function GetZoomTextContent(EntityPtr: PGDBObjEntity): string;
+begin
+  Result := '';
+
+  if not IsZoomTextEntity(EntityPtr) then
+    Exit;
+
+  Result := string(PGDBObjText(EntityPtr)^.Content);
+  if Result = '' then
+    Result := string(PGDBObjText(EntityPtr)^.Template);
+end;
+
+function ResolveErrorPosition(const EntityText: string;
+  ErrorPtr: PSpellError): integer;
+begin
+  Result := 0;
+
+  if not Assigned(ErrorPtr) or (ErrorPtr^.ErrorWord = '') then
+    Exit;
+
+  Result := ErrorPtr^.EntityPosition;
+  if (Result >= 1) and
+     (Copy(EntityText, Result, Length(ErrorPtr^.ErrorWord)) =
+       ErrorPtr^.ErrorWord) then
+    Exit;
+
+  Result := Pos(ErrorPtr^.ErrorWord, EntityText);
+end;
+
+function HasUsableFont(TextObj: PGDBObjText): boolean;
+begin
+  Result := Assigned(TextObj) and Assigned(TextObj^.TXTStyle) and
+    Assigned(TextObj^.TXTStyle^.pfont) and
+    Assigned(TextObj^.TXTStyle^.pfont^.font);
+end;
+
+function MeasureTextAdvance(TextObj: PGDBObjText;
+  const AText: TDXFEntsInternalStringType; AStart, ACount: integer): double;
+var
+  font: pgdbfont;
+  i: integer;
+  endPosition: integer;
+  symbolLength: integer;
+  symbol: word;
+begin
+  Result := 0;
+
+  if not HasUsableFont(TextObj) or (ACount <= 0) then
+    Exit;
+
+  if AStart < 1 then
+    AStart := 1;
+
+  font := TextObj^.TXTStyle^.pfont;
+  i := AStart;
+  endPosition := AStart + ACount - 1;
+  while (i <= Length(AText)) and (i <= endPosition) do begin
+    symbol := getsymbol_fromGDBText(AText, i, symbolLength,
+      font^.font.IsUnicode);
+    if symbolLength <= 0 then
+      symbolLength := 1;
+
+    if symbol <> 1 then
+      Result := Result + font^.GetOrReplaceSymbolInfo(symbol).NextSymX;
+
+    Inc(i, symbolLength);
+  end;
+end;
+
+procedure InitVolumeFromPoint(out Volume: TBoundingBox;
+  const Point: TzePoint3d);
+begin
+  Volume.LBN := Point;
+  Volume.RTF := Point;
+end;
+
+procedure AddPointToVolume(var Volume: TBoundingBox; const Point: TzePoint3d);
+begin
+  if Point.x < Volume.LBN.x then
+    Volume.LBN.x := Point.x;
+  if Point.y < Volume.LBN.y then
+    Volume.LBN.y := Point.y;
+  if Point.z < Volume.LBN.z then
+    Volume.LBN.z := Point.z;
+
+  if Point.x > Volume.RTF.x then
+    Volume.RTF.x := Point.x;
+  if Point.y > Volume.RTF.y then
+    Volume.RTF.y := Point.y;
+  if Point.z > Volume.RTF.z then
+    Volume.RTF.z := Point.z;
+end;
+
+procedure PadVolume(var Volume: TBoundingBox; Padding: double);
+begin
+  if Padding < eps then
+    Padding := 1;
+
+  Volume.LBN.x := Volume.LBN.x - Padding;
+  Volume.LBN.y := Volume.LBN.y - Padding;
+  Volume.LBN.z := Volume.LBN.z - Padding;
+  Volume.RTF.x := Volume.RTF.x + Padding;
+  Volume.RTF.y := Volume.RTF.y + Padding;
+  Volume.RTF.z := Volume.RTF.z + Padding;
+end;
+
+function TransformTextPoint(TextObj: PGDBObjText;
+  const TextMatrix: TzeTypedMatrix4d; X, Y: double): TzePoint3d;
+begin
+  Result := CreateVertex(X, Y, 0);
+  Result := VectorTransform3D(Result, TextMatrix);
+  Result := VectorTransform3D(Result, TextObj^.objmatrix);
+end;
+
+function BuildWordVolume(TextObj: PGDBObjText;
+  const TextMatrix: TzeTypedMatrix4d; WordLeft, WordRight: double;
+  out Volume: TBoundingBox): boolean;
+var
+  point: TzePoint3d;
+begin
+  Result := False;
+
+  if not Assigned(TextObj) or (WordRight <= WordLeft) then
+    Exit;
+
+  point := TransformTextPoint(TextObj, TextMatrix, WordLeft, 0);
+  InitVolumeFromPoint(Volume, point);
+
+  point := TransformTextPoint(TextObj, TextMatrix, WordRight, 0);
+  AddPointToVolume(Volume, point);
+  point := TransformTextPoint(TextObj, TextMatrix, WordRight, 1);
+  AddPointToVolume(Volume, point);
+  point := TransformTextPoint(TextObj, TextMatrix, WordLeft, 1);
+  AddPointToVolume(Volume, point);
+
+  PadVolume(Volume, TextObj^.textprop.size * WORD_VOLUME_PADDING_FACTOR);
+  Result := True;
+end;
+
+function TryGetTextWordVolume(TextObj: PGDBObjText; ErrorPtr: PSpellError;
+  out Volume: TBoundingBox): boolean;
+var
+  entityText: string;
+  wordStart: integer;
+  prefixWidth: double;
+  wordWidth: double;
+begin
+  Result := False;
+
+  if not Assigned(TextObj) or not Assigned(ErrorPtr) then
+    Exit;
+
+  entityText := GetZoomTextContent(PGDBObjEntity(TextObj));
+  wordStart := ResolveErrorPosition(entityText, ErrorPtr);
+  if wordStart < 1 then
+    Exit;
+
+  prefixWidth := MeasureTextAdvance(TextObj,
+    TDXFEntsInternalStringType(entityText), 1, wordStart - 1);
+  wordWidth := MeasureTextAdvance(TextObj,
+    TDXFEntsInternalStringType(entityText), wordStart,
+    Length(ErrorPtr^.ErrorWord));
+  if wordWidth < eps then
+    wordWidth := 1;
+
+  Result := BuildWordVolume(TextObj, TextObj^.DrawMatrix, prefixWidth,
+    prefixWidth + wordWidth, Volume);
+end;
+
+function BuildMTextLineMatrix(MTextObj: PGDBObjMText;
+  LinePtr: pGDBStrWithPoint): TzeTypedMatrix4d;
+var
+  lineTranslation: TzeTypedMatrix4d;
+  obliqueOffset: double;
+begin
+  Result := MTextObj^.DrawMatrix;
+
+  obliqueOffset := 0;
+  if Abs(MTextObj^.textprop.wfactor) > eps then
+    obliqueOffset := LinePtr^.y * cotan(Pi / 2 - MTextObj^.textprop.oblique) /
+      MTextObj^.textprop.wfactor;
+
+  lineTranslation := CreateTranslationMatrix(
+    CreateVertex(LinePtr^.x - obliqueOffset, LinePtr^.y, 0));
+  Result := MatrixMultiply(lineTranslation, Result);
+end;
+
+function TryFindMTextLineWord(MTextObj: PGDBObjMText;
+  ErrorPtr: PSpellError; out LinePtr: pGDBStrWithPoint;
+  out WordOffset: integer): boolean;
+var
+  entityText: string;
+  lineText: string;
+  wordStart: integer;
+  scanFrom: integer;
+  lineStart: integer;
+  lineEnd: integer;
+  iterator: itrec;
+begin
+  Result := False;
+  LinePtr := nil;
+  WordOffset := 0;
+
+  if not Assigned(MTextObj) or not Assigned(ErrorPtr) then
+    Exit;
+
+  entityText := GetZoomTextContent(PGDBObjEntity(MTextObj));
+  wordStart := ResolveErrorPosition(entityText, ErrorPtr);
+  if wordStart < 1 then
+    Exit;
+
+  scanFrom := 1;
+  LinePtr := MTextObj^.Text.beginiterate(iterator);
+  if LinePtr <> nil then
+    repeat
+      lineText := string(LinePtr^.str);
+      if lineText = '' then
+        lineStart := scanFrom
+      else
+        lineStart := PosEx(lineText, entityText, scanFrom);
+
+      if lineStart < 1 then
+        lineStart := scanFrom;
+
+      lineEnd := lineStart + Length(lineText) - 1;
+      if (wordStart >= lineStart) and
+         (wordStart + Length(ErrorPtr^.ErrorWord) - 1 <= lineEnd) then begin
+        WordOffset := wordStart - lineStart + 1;
+        Result := True;
+        Exit;
+      end;
+
+      scanFrom := lineEnd + 1;
+      LinePtr := MTextObj^.Text.iterate(iterator);
+    until LinePtr = nil;
+end;
+
+function TryGetMTextWordVolume(MTextObj: PGDBObjMText; ErrorPtr: PSpellError;
+  out Volume: TBoundingBox): boolean;
+var
+  linePtr: pGDBStrWithPoint;
+  wordOffset: integer;
+  prefixWidth: double;
+  wordWidth: double;
+  lineMatrix: TzeTypedMatrix4d;
+begin
+  Result := False;
+
+  if not TryFindMTextLineWord(MTextObj, ErrorPtr, linePtr, wordOffset) then
+    Exit;
+
+  prefixWidth := MeasureTextAdvance(PGDBObjText(MTextObj), linePtr^.str, 1,
+    wordOffset - 1);
+  wordWidth := MeasureTextAdvance(PGDBObjText(MTextObj), linePtr^.str,
+    wordOffset, Length(ErrorPtr^.ErrorWord));
+  if wordWidth < eps then
+    wordWidth := 1;
+
+  lineMatrix := BuildMTextLineMatrix(MTextObj, linePtr);
+  Result := BuildWordVolume(PGDBObjText(MTextObj), lineMatrix, prefixWidth,
+    prefixWidth + wordWidth, Volume);
+end;
+
+function FormatSpellEntity(EntityPtr: PGDBObjEntity): boolean;
+var
+  drawing: PTZCADDrawing;
+  drawContext: TDrawContext;
+begin
+  Result := False;
+
+  if not Assigned(EntityPtr) or (drawings.GetCurrentDWG = nil) then
+    Exit;
+
+  drawing := PTZCADDrawing(drawings.GetCurrentDWG);
+  drawContext := drawing^.CreateDrawingRC;
+  EntityPtr^.FormatEntity(drawing^, drawContext);
+  Result := True;
+end;
+
+function TryGetSpellErrorWordVolume(ErrorPtr: PSpellError;
+  out Volume: TBoundingBox): boolean;
+var
+  entityPtr: PGDBObjEntity;
+begin
+  Result := False;
+
+  if not Assigned(ErrorPtr) or not Assigned(ErrorPtr^.EntityPtr) then
+    Exit;
+
+  entityPtr := PGDBObjEntity(ErrorPtr^.EntityPtr);
+  if not IsZoomTextEntity(entityPtr) or not FormatSpellEntity(entityPtr) then
+    Exit;
+
+  case entityPtr^.GetObjType of
+    GDBMTextID:
+      Result := TryGetMTextWordVolume(PGDBObjMText(entityPtr), ErrorPtr,
+        Volume);
+    GDBTextID:
+      Result := TryGetTextWordVolume(PGDBObjText(entityPtr), ErrorPtr,
+        Volume);
+  end;
+end;
+
+function ZoomToSpellEntity(ErrorPtr: PSpellError): boolean;
+var
+  entityPtr: PGDBObjEntity;
+  drawing: PTZCADDrawing;
+  drawContext: TDrawContext;
+  volume: TBoundingBox;
+begin
+  Result := False;
+
+  if not Assigned(ErrorPtr) or not Assigned(ErrorPtr^.EntityPtr) or
+     (drawings.GetCurrentDWG = nil) then
+    Exit;
+
+  entityPtr := PGDBObjEntity(ErrorPtr^.EntityPtr);
+  if not FormatSpellEntity(entityPtr) then
+    Exit;
+
+  drawing := PTZCADDrawing(drawings.GetCurrentDWG);
+  drawContext := drawing^.CreateDrawingRC;
+  entityPtr^.getonlyoutbound(drawContext);
+  volume := entityPtr^.vp.BoundingBox;
+  drawings.GetCurrentDWG^.wa.ZoomToVolume(volume);
+  Result := True;
+end;
+
+function ZoomToSpellError(ErrorPtr: PSpellError): boolean;
+var
+  volume: TBoundingBox;
+begin
+  Result := False;
+
+  if not Assigned(ErrorPtr) then
+    Exit;
+
+  if TryGetSpellErrorWordVolume(ErrorPtr, volume) then begin
+    drawings.GetCurrentDWG^.wa.ZoomToVolume(volume);
+    programlog.LogOutFormatStr(
+      'ZoomToSpellError: zoomed word "%s" at entity position %d',
+      [ErrorPtr^.ErrorWord, ErrorPtr^.EntityPosition], LM_Info);
+    Result := True;
+    Exit;
+  end;
+
+  Result := ZoomToSpellEntity(ErrorPtr);
+  if Result then
+    programlog.LogOutFormatStr(
+      'ZoomToSpellError: zoomed entity for word "%s"',
+      [ErrorPtr^.ErrorWord], LM_Info)
+  else
+    programlog.LogOutFormatStr(
+      'ZoomToSpellError: unable to zoom word "%s"',
+      [ErrorPtr^.ErrorWord], LM_Info);
+end;
+
+end.

--- a/test_issue1292_spellchecker_error_zoom.py
+++ b/test_issue1292_spellchecker_error_zoom.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #1292 spellchecker error zoom behavior."""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parent
+SPELL_DIR = ROOT / "cad_source" / "zcad" / "velec" / "uzvfspellchecker"
+FORM_PAS = SPELL_DIR / "uzvfspellform.pas"
+FORM_LFM = SPELL_DIR / "uzvfspellform.lfm"
+ZOOM_PAS = SPELL_DIR / "uzvfspellzoom.pas"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def extract_routine(source: str, routine_name: str) -> str:
+    pattern = (
+        rf"procedure\s+{re.escape(routine_name)}\b.*?"
+        rf"(?=\nprocedure\s+|\nfunction\s+|\ninitialization|\nfinalization|\Z)"
+    )
+    match = re.search(pattern, source, flags=re.IGNORECASE | re.DOTALL)
+    assert match, f"{routine_name} routine is missing"
+    return match.group(0)
+
+
+def test_spellchecker_zoom_helper_is_separate_unit() -> None:
+    assert ZOOM_PAS.exists(), "spell error zoom logic must live in a separate unit"
+
+    zoom_source = read_text(ZOOM_PAS)
+    assert "unit uzvfspellzoom;" in zoom_source
+    assert "uzvfspelldata" in zoom_source
+    assert "function ZoomToSpellError" in zoom_source
+    assert "function TryGetSpellErrorWordVolume" in zoom_source
+
+
+def test_errors_tree_double_click_invokes_zoom_without_applying_suggestions() -> None:
+    form_source = read_text(FORM_PAS)
+    lfm_source = read_text(FORM_LFM)
+
+    assert "uzvfspellzoom" in form_source
+    assert "procedure ErrorsTreeDblClick(Sender: TObject);" in form_source
+    assert "OnDblClick = ErrorsTreeDblClick" in lfm_source
+
+    handler = extract_routine(form_source, "TSpellCheckerForm.ErrorsTreeDblClick")
+    assert "ZoomToSpellError(GetFocusedError)" in handler
+    assert "ReplaceCurrentErrorWithSuggestion" not in handler
+    assert "ApplySelectedSuggestion" not in handler
+
+
+def test_zoom_uses_existing_view_area_zoom_to_volume_without_selection_side_effects() -> None:
+    zoom_source = read_text(ZOOM_PAS)
+
+    assert "drawings.GetCurrentDWG^.wa.ZoomToVolume" in zoom_source
+    assert "ZoomSel" not in zoom_source
+    assert "GetSelObjArray" not in zoom_source
+
+
+def test_mtext_word_volume_uses_error_position_and_rendered_line_layout() -> None:
+    zoom_source = read_text(ZOOM_PAS)
+
+    assert "PGDBObjMText" in zoom_source
+    assert "EntityPosition" in zoom_source
+    assert "ErrorWord" in zoom_source
+    assert "Text.beginiterate" in zoom_source
+    assert "PosEx" in zoom_source
+    assert "WordOffset" in zoom_source
+    assert "MeasureTextAdvance" in zoom_source
+
+
+def test_zoom_falls_back_to_entity_volume_when_word_volume_is_unavailable() -> None:
+    zoom_source = read_text(ZOOM_PAS)
+
+    assert "ZoomToSpellEntity" in zoom_source
+    assert "CreateDrawingRC" in zoom_source
+    assert "getonlyoutbound" in zoom_source
+
+
+if __name__ == "__main__":
+    test_spellchecker_zoom_helper_is_separate_unit()
+    test_errors_tree_double_click_invokes_zoom_without_applying_suggestions()
+    test_zoom_uses_existing_view_area_zoom_to_volume_without_selection_side_effects()
+    test_mtext_word_volume_uses_error_position_and_rendered_line_layout()
+    test_zoom_falls_back_to_entity_volume_when_word_volume_is_unavailable()
+    print("issue 1292 spellchecker error zoom checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1292

### Что изменено
- Добавлен отдельный модуль `uzvfspellzoom.pas` для зума к ошибке без изменения выбора объектов.
- Двойной щелчок по слову в списке ошибок теперь вызывает `ZoomToSpellError(GetFocusedError)`.
- Для `MTEXT` позиция ошибки сопоставляется с отформатированной строкой и шириной слова по метрикам шрифта; если точную область слова получить нельзя, выполняется fallback-зум к текстовому примитиву.

### Как воспроизвести
1. Открыть чертеж с `TEXT` или большим `MTEXT`, где есть слово с ошибкой.
2. Запустить проверку орфографии и выбрать найденную ошибку.
3. Выполнить двойной щелчок по слову в списке ошибок.
4. Вид чертежа должен приблизиться к области ошибочного слова, а для fallback-сценария - к самому текстовому примитиву.

### Проверка
- `python3 test_issue1282_spellchecker_registration.py`
- `python3 test_issue1284_spellchecker_result_type.py`
- `python3 test_issue1286_spellchecker_drawing_scan.py`
- `python3 test_issue1288_spellchecker_occurrences_ui.py`
- `python3 test_issue1290_spellchecker_suggestions.py`
- `python3 test_issue1292_spellchecker_error_zoom.py`
- `git diff --check`

Pascal GUI compile was not run locally because this workspace has no `lazbuild` or `fpc` binary installed.