### PR TITLE
AcadTable: распознавать разделённые таблицы как один объект (все части)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-09T20:29:01.544Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-09T20:29:01.544Z

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -51,6 +51,33 @@ type
   // Тип указателя на GDBObjAcadTable
   PGDBObjAcadTable = ^GDBObjAcadTable;
 
+  // Данные одной части (фрагмента) разделённой по ширине таблицы.
+  // AutoCAD сохраняет разбитую таблицу в DXF как несколько ACAD_TABLE
+  // сущностей (ROUNDTRIP_2008). Первая часть — это сам объект, остальные
+  // хранятся здесь как данные и отображаются в одном составном объекте
+  // со смещением относительно точки вставки главной части (issue #1300).
+  TAcadTablePart = record
+    InsertPoint: TzePoint3d;
+    RowCount: Integer;
+    ColCount: Integer;
+    RowHeights: TZctnrVectorDouble;
+    ColWidths: TZctnrVectorDouble;
+    CellTexts: TTableTextArray;
+    TableFlags: Integer;
+    TableStyle: TTableStyle;
+    Rows: TTableRowArray;
+    Cols: TTableColumnArray;
+    Cells: TTableCellArray;
+    Merges: TMergeRangeArray;
+    BreakEnabled: Boolean;
+    BreakDirection: TAcadTableBreakDirection;
+    BreakRepeatTopLabels: Boolean;
+    BreakRepeatBottomLabels: Boolean;
+    BreakManualPosition: Boolean;
+    BreakManualHeight: Boolean;
+    BreakSpacing: Double;
+  end;
+
   // Сущность ACAD_TABLE — таблица AutoCAD из формата DXF.
   // Хранит геометрию таблицы и текстовое содержимое ячеек.
   // При форматировании строит визуальное представление из линий и текста.
@@ -67,7 +94,7 @@ type
     // Ширины столбцов (один элемент на столбец)
     FColWidths: TZctnrVectorDouble;
     // Тексты ячеек: индекс = строка * FColCount + столбец
-    FCellTexts: array of String;
+    FCellTexts: TTableTextArray;
     // Признак того, что геометрия уже была построена
     FGeometryBuilt: Boolean;
     // Хэндл DXF-стиля таблицы (group code 342)
@@ -85,10 +112,15 @@ type
     // Стиль таблицы
     FTableStyle: TTableStyle;
     // Строки, столбцы, ячейки и объединения
-    FRows: array of TTableRow;
-    FCols: array of TTableColumn;
-    FCells: array of array of TTableCell;
-    FMerges: array of TMergeRange;
+    FRows: TTableRowArray;
+    FCols: TTableColumnArray;
+    FCells: TTableCellArray;
+    FMerges: TMergeRangeArray;
+    // Части (фрагменты) разделённой по ширине таблицы, объединённые
+    // в один объект AcadTable. Главная часть — это сам объект, а
+    // продолжения хранятся здесь как данные и отображаются со смещением
+    // относительно точки вставки главной части (issue #1300).
+    FContinuationParts: array of TAcadTablePart;
 
     // Обёртки для делегирования к модулю layout
     function GetRowHeightLocal(RowIndex: Integer): Double;
@@ -97,13 +129,31 @@ type
     function GetTotalWidth: Double;
     function GetCellTextLocal(
       RowIdx, ColIdx: Integer): String;
-    // Строит визуальное представление в ConstObjArray
+    // Строит визуальное представление текущих полей таблицы в
+    // ConstObjArray со смещением (ABaseX, ABaseY) в OCS.
+    procedure RenderCurrentTable(
+      var ADrawing: TDrawingDef; var ADC: TDrawContext;
+      ABaseX, ABaseY: Double);
+    // Строит визуальное представление всей таблицы (главная часть и
+    // все продолжения) в ConstObjArray
     procedure BuildVisualRepresentation(
       var ADrawing: TDrawingDef; var ADC: TDrawContext);
+    // Обмен данными рендеринга между Self и частью-продолжением
+    procedure SwapTableData(var APart: TAcadTablePart);
+    // Глубокое копирование данных другой таблицы в часть-продолжение
+    procedure CaptureTableDataToPart(
+      var ASource: GDBObjAcadTable; var APart: TAcadTablePart);
+    // Освобождение ресурсов части-продолжения
+    procedure ClearPart(var APart: TAcadTablePart);
+    // Глубокое копирование части-продолжения (для Clone)
+    procedure CopyTablePart(
+      const ASource: TAcadTablePart; var ADest: TAcadTablePart);
     // Вычисляет bounding box таблицы
     procedure getoutbound(var DC: TDrawContext);
     // Возвращает имя стиля таблицы
     function GetTableStyleName: String;
+    // Возвращает количество частей-продолжений
+    function GetContinuationPartCount: Integer;
 
   public
     constructor initnul(
@@ -131,6 +181,11 @@ type
     function GetObjType: TObjID; virtual;
     function GetObjTypeName: String; virtual;
     function DXFDelayedBuildGeometry: Boolean; virtual;
+    // Поглощает продолжение разделённой таблицы как ещё одну часть
+    // этого же объекта AcadTable (issue #1300). Возвращает True, если
+    // AOther поглощён и вызывающая сторона может его освободить.
+    function TryMergeContinuation(
+      AOther: PGDBObjEntity): Boolean; virtual;
 
     // Публичные свойства для инспектора объектов
     property InsertPoint: TzePoint3d read FInsertPoint;
@@ -151,6 +206,9 @@ type
     property BreakManualHeight: Boolean
       read FBreakManualHeight;
     property BreakSpacing: Double read FBreakSpacing;
+    // Количество поглощённых частей-продолжений (issue #1300).
+    // Для неразделённой таблицы равно 0.
+    property ContinuationPartCount: Integer read GetContinuationPartCount;
   end;
 
 function AllocAcadTable: Pointer;
@@ -232,9 +290,12 @@ begin
   System.SetLength(FCols, 0);
   System.SetLength(FCells, 0, 0);
   System.SetLength(FMerges, 0);
+  System.SetLength(FContinuationParts, 0);
 end;
 
 destructor GDBObjAcadTable.done;
+var
+  PartIdx: Integer;
 begin
   FRowHeights.done;
   FColWidths.done;
@@ -243,6 +304,9 @@ begin
   System.SetLength(FCols, 0);
   System.SetLength(FCells, 0, 0);
   System.SetLength(FMerges, 0);
+  for PartIdx := 0 to High(FContinuationParts) do
+    ClearPart(FContinuationParts[PartIdx]);
+  System.SetLength(FContinuationParts, 0);
   inherited done;
 end;
 
@@ -462,8 +526,9 @@ end;
 
 // --- Построение визуального представления ---
 
-procedure GDBObjAcadTable.BuildVisualRepresentation(
-  var ADrawing: TDrawingDef; var ADC: TDrawContext);
+procedure GDBObjAcadTable.RenderCurrentTable(
+  var ADrawing: TDrawingDef; var ADC: TDrawContext;
+  ABaseX, ABaseY: Double);
 var
   RowIdx, ColIdx, SegmentIdx, SegmentCount: Integer;
   CurrentY, CurrentX: Double;
@@ -480,15 +545,14 @@ var
   MergeRootPt: TPoint;
 begin
   programlog.LogOutFormatStr(
-    'AcadTable: model: BuildVisualRepresentation START ' +
-    'rows=%d cols=%d',
-    [FRowCount, FColCount], LM_Info);
-  ConstObjArray.Free;
+    'AcadTable: model: RenderCurrentTable START ' +
+    'rows=%d cols=%d baseX=%g baseY=%g',
+    [FRowCount, FColCount, ABaseX, ABaseY], LM_Info);
 
   if (FRowCount <= 0) or (FColCount <= 0) then
   begin
     programlog.LogOutStr(
-      'AcadTable: model: BuildVisualRepresentation — ' +
+      'AcadTable: model: RenderCurrentTable — ' +
       'таблица пуста', LM_Info);
     Exit;
   end;
@@ -508,8 +572,8 @@ begin
   // --- Горизонтальные линии ---
   for SegmentIdx := 0 to SegmentCount - 1 do
   begin
-    SegmentOffsetX := RenderSegments[SegmentIdx].OffsetX;
-    SegmentOffsetY := RenderSegments[SegmentIdx].OffsetY;
+    SegmentOffsetX := RenderSegments[SegmentIdx].OffsetX + ABaseX;
+    SegmentOffsetY := RenderSegments[SegmentIdx].OffsetY + ABaseY;
     CurrentY := 0;
     for RowIdx := RenderSegments[SegmentIdx].StartRow to
                   RenderSegments[SegmentIdx].EndRow + 1 do
@@ -572,8 +636,8 @@ begin
   LineCount := 0;
   for SegmentIdx := 0 to SegmentCount - 1 do
   begin
-    SegmentOffsetX := RenderSegments[SegmentIdx].OffsetX;
-    SegmentOffsetY := RenderSegments[SegmentIdx].OffsetY;
+    SegmentOffsetX := RenderSegments[SegmentIdx].OffsetX + ABaseX;
+    SegmentOffsetY := RenderSegments[SegmentIdx].OffsetY + ABaseY;
     SegmentHeight := 0;
     for RowIdx := RenderSegments[SegmentIdx].StartRow to
                   RenderSegments[SegmentIdx].EndRow do
@@ -640,8 +704,8 @@ begin
   TextCount := 0;
   for SegmentIdx := 0 to SegmentCount - 1 do
   begin
-    SegmentOffsetX := RenderSegments[SegmentIdx].OffsetX;
-    SegmentOffsetY := RenderSegments[SegmentIdx].OffsetY;
+    SegmentOffsetX := RenderSegments[SegmentIdx].OffsetX + ABaseX;
+    SegmentOffsetY := RenderSegments[SegmentIdx].OffsetY + ABaseY;
     CurrentY := 0;
     for RowIdx := RenderSegments[SegmentIdx].StartRow to
                   RenderSegments[SegmentIdx].EndRow do
@@ -789,10 +853,235 @@ begin
   end;
 
   programlog.LogOutFormatStr(
-    'AcadTable: model: BuildVisualRepresentation OK ' +
+    'AcadTable: model: RenderCurrentTable OK ' +
     'rows=%d cols=%d texts=%d TotalObj=%d',
     [FRowCount, FColCount, TextCount,
      ConstObjArray.Count], LM_Info);
+end;
+
+// Обмен данными рендеринга между Self и частью-продолжением.
+// TZctnrVectorDouble и динамические массивы обмениваются целиком
+// (3-сторонний обмен), что переносит владение буферами без копирования.
+procedure GDBObjAcadTable.SwapTableData(var APart: TAcadTablePart);
+var
+  TmpVec: TZctnrVectorDouble;
+  TmpInt: Integer;
+  TmpStyle: TTableStyle;
+  TmpFlags: Integer;
+  TmpBreakEnabled, TmpRepeatTop, TmpRepeatBottom: Boolean;
+  TmpManualPos, TmpManualHeight: Boolean;
+  TmpDir: TAcadTableBreakDirection;
+  TmpSpacing: Double;
+  TmpTexts: TTableTextArray;
+  TmpRows: TTableRowArray;
+  TmpCols: TTableColumnArray;
+  TmpCells: TTableCellArray;
+  TmpMerges: TMergeRangeArray;
+begin
+  TmpInt := FRowCount; FRowCount := APart.RowCount; APart.RowCount := TmpInt;
+  TmpInt := FColCount; FColCount := APart.ColCount; APart.ColCount := TmpInt;
+
+  TmpVec := FRowHeights; FRowHeights := APart.RowHeights; APart.RowHeights := TmpVec;
+  TmpVec := FColWidths;  FColWidths := APart.ColWidths;   APart.ColWidths := TmpVec;
+
+  TmpTexts := FCellTexts; FCellTexts := APart.CellTexts; APart.CellTexts := TmpTexts;
+
+  TmpFlags := FTableFlags; FTableFlags := APart.TableFlags; APart.TableFlags := TmpFlags;
+  TmpStyle := FTableStyle; FTableStyle := APart.TableStyle; APart.TableStyle := TmpStyle;
+
+  TmpRows := FRows;   FRows := APart.Rows;     APart.Rows := TmpRows;
+  TmpCols := FCols;   FCols := APart.Cols;     APart.Cols := TmpCols;
+  TmpCells := FCells; FCells := APart.Cells;   APart.Cells := TmpCells;
+  TmpMerges := FMerges; FMerges := APart.Merges; APart.Merges := TmpMerges;
+
+  TmpBreakEnabled := FBreakEnabled; FBreakEnabled := APart.BreakEnabled; APart.BreakEnabled := TmpBreakEnabled;
+  TmpDir := FBreakDirection; FBreakDirection := APart.BreakDirection; APart.BreakDirection := TmpDir;
+  TmpRepeatTop := FBreakRepeatTopLabels; FBreakRepeatTopLabels := APart.BreakRepeatTopLabels; APart.BreakRepeatTopLabels := TmpRepeatTop;
+  TmpRepeatBottom := FBreakRepeatBottomLabels; FBreakRepeatBottomLabels := APart.BreakRepeatBottomLabels; APart.BreakRepeatBottomLabels := TmpRepeatBottom;
+  TmpManualPos := FBreakManualPosition; FBreakManualPosition := APart.BreakManualPosition; APart.BreakManualPosition := TmpManualPos;
+  TmpManualHeight := FBreakManualHeight; FBreakManualHeight := APart.BreakManualHeight; APart.BreakManualHeight := TmpManualHeight;
+  TmpSpacing := FBreakSpacing; FBreakSpacing := APart.BreakSpacing; APart.BreakSpacing := TmpSpacing;
+end;
+
+// Строит визуальное представление всей таблицы: сначала главная часть
+// в нулевом смещении, затем каждое продолжение со смещением, равным
+// разнице точек вставки (продолжение минус главная). Все части
+// помещаются в ConstObjArray одного объекта AcadTable (issue #1300).
+procedure GDBObjAcadTable.BuildVisualRepresentation(
+  var ADrawing: TDrawingDef; var ADC: TDrawContext);
+var
+  PartIdx: Integer;
+  BaseX, BaseY: Double;
+begin
+  programlog.LogOutFormatStr(
+    'AcadTable: model: BuildVisualRepresentation START ' +
+    'rows=%d cols=%d parts=%d',
+    [FRowCount, FColCount, Length(FContinuationParts)], LM_Info);
+  ConstObjArray.Free;
+
+  // Главная часть в собственной системе координат
+  RenderCurrentTable(ADrawing, ADC, 0, 0);
+
+  // Части-продолжения со смещением относительно главной точки вставки
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    BaseX := FContinuationParts[PartIdx].InsertPoint.x - FInsertPoint.x;
+    BaseY := FContinuationParts[PartIdx].InsertPoint.y - FInsertPoint.y;
+    SwapTableData(FContinuationParts[PartIdx]);
+    RenderCurrentTable(ADrawing, ADC, BaseX, BaseY);
+    SwapTableData(FContinuationParts[PartIdx]);
+  end;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: BuildVisualRepresentation OK ' +
+    'parts=%d TotalObj=%d',
+    [Length(FContinuationParts), ConstObjArray.Count], LM_Info);
+end;
+
+// Глубокое копирование данных рендеринга исходной таблицы в
+// часть-продолжение. Вызывается до освобождения исходного объекта,
+// поэтому все буферы копируются, а не разделяются.
+procedure GDBObjAcadTable.CaptureTableDataToPart(
+  var ASource: GDBObjAcadTable; var APart: TAcadTablePart);
+var
+  Idx, Idx2: Integer;
+begin
+  APart.InsertPoint := ASource.FInsertPoint;
+  APart.RowCount := ASource.FRowCount;
+  APart.ColCount := ASource.FColCount;
+  APart.TableFlags := ASource.FTableFlags;
+  APart.TableStyle := ASource.FTableStyle;
+  APart.BreakEnabled := ASource.FBreakEnabled;
+  APart.BreakDirection := ASource.FBreakDirection;
+  APart.BreakRepeatTopLabels := ASource.FBreakRepeatTopLabels;
+  APart.BreakRepeatBottomLabels := ASource.FBreakRepeatBottomLabels;
+  APart.BreakManualPosition := ASource.FBreakManualPosition;
+  APart.BreakManualHeight := ASource.FBreakManualHeight;
+  APart.BreakSpacing := ASource.FBreakSpacing;
+
+  APart.RowHeights.initnul;
+  for Idx := 0 to ASource.FRowHeights.Count - 1 do
+    APart.RowHeights.PushBackData(ASource.FRowHeights.parray^[Idx]);
+  APart.ColWidths.initnul;
+  for Idx := 0 to ASource.FColWidths.Count - 1 do
+    APart.ColWidths.PushBackData(ASource.FColWidths.parray^[Idx]);
+
+  System.SetLength(APart.CellTexts, Length(ASource.FCellTexts));
+  for Idx := 0 to High(ASource.FCellTexts) do
+    APart.CellTexts[Idx] := ASource.FCellTexts[Idx];
+
+  System.SetLength(APart.Rows, Length(ASource.FRows));
+  for Idx := 0 to High(ASource.FRows) do
+    APart.Rows[Idx] := ASource.FRows[Idx];
+
+  System.SetLength(APart.Cols, Length(ASource.FCols));
+  for Idx := 0 to High(ASource.FCols) do
+    APart.Cols[Idx] := ASource.FCols[Idx];
+
+  System.SetLength(APart.Cells, Length(ASource.FCells));
+  for Idx := 0 to High(ASource.FCells) do
+  begin
+    System.SetLength(APart.Cells[Idx], Length(ASource.FCells[Idx]));
+    for Idx2 := 0 to High(ASource.FCells[Idx]) do
+      APart.Cells[Idx][Idx2] := ASource.FCells[Idx][Idx2];
+  end;
+
+  System.SetLength(APart.Merges, Length(ASource.FMerges));
+  for Idx := 0 to High(ASource.FMerges) do
+    APart.Merges[Idx] := ASource.FMerges[Idx];
+end;
+
+// Глубокое копирование части-продолжения (часть -> часть), для Clone.
+procedure GDBObjAcadTable.CopyTablePart(
+  const ASource: TAcadTablePart; var ADest: TAcadTablePart);
+var
+  Idx, Idx2: Integer;
+begin
+  ADest.InsertPoint := ASource.InsertPoint;
+  ADest.RowCount := ASource.RowCount;
+  ADest.ColCount := ASource.ColCount;
+  ADest.TableFlags := ASource.TableFlags;
+  ADest.TableStyle := ASource.TableStyle;
+  ADest.BreakEnabled := ASource.BreakEnabled;
+  ADest.BreakDirection := ASource.BreakDirection;
+  ADest.BreakRepeatTopLabels := ASource.BreakRepeatTopLabels;
+  ADest.BreakRepeatBottomLabels := ASource.BreakRepeatBottomLabels;
+  ADest.BreakManualPosition := ASource.BreakManualPosition;
+  ADest.BreakManualHeight := ASource.BreakManualHeight;
+  ADest.BreakSpacing := ASource.BreakSpacing;
+
+  ADest.RowHeights.initnul;
+  for Idx := 0 to ASource.RowHeights.Count - 1 do
+    ADest.RowHeights.PushBackData(ASource.RowHeights.parray^[Idx]);
+  ADest.ColWidths.initnul;
+  for Idx := 0 to ASource.ColWidths.Count - 1 do
+    ADest.ColWidths.PushBackData(ASource.ColWidths.parray^[Idx]);
+
+  System.SetLength(ADest.CellTexts, Length(ASource.CellTexts));
+  for Idx := 0 to High(ASource.CellTexts) do
+    ADest.CellTexts[Idx] := ASource.CellTexts[Idx];
+
+  System.SetLength(ADest.Rows, Length(ASource.Rows));
+  for Idx := 0 to High(ASource.Rows) do
+    ADest.Rows[Idx] := ASource.Rows[Idx];
+
+  System.SetLength(ADest.Cols, Length(ASource.Cols));
+  for Idx := 0 to High(ASource.Cols) do
+    ADest.Cols[Idx] := ASource.Cols[Idx];
+
+  System.SetLength(ADest.Cells, Length(ASource.Cells));
+  for Idx := 0 to High(ASource.Cells) do
+  begin
+    System.SetLength(ADest.Cells[Idx], Length(ASource.Cells[Idx]));
+    for Idx2 := 0 to High(ASource.Cells[Idx]) do
+      ADest.Cells[Idx][Idx2] := ASource.Cells[Idx][Idx2];
+  end;
+
+  System.SetLength(ADest.Merges, Length(ASource.Merges));
+  for Idx := 0 to High(ASource.Merges) do
+    ADest.Merges[Idx] := ASource.Merges[Idx];
+end;
+
+// Освобождение ресурсов части-продолжения.
+procedure GDBObjAcadTable.ClearPart(var APart: TAcadTablePart);
+begin
+  APart.RowHeights.done;
+  APart.ColWidths.done;
+  System.SetLength(APart.CellTexts, 0);
+  System.SetLength(APart.Rows, 0);
+  System.SetLength(APart.Cols, 0);
+  System.SetLength(APart.Cells, 0, 0);
+  System.SetLength(APart.Merges, 0);
+end;
+
+function GDBObjAcadTable.GetContinuationPartCount: Integer;
+begin
+  Result := Length(FContinuationParts);
+end;
+
+// Поглощает продолжение разделённой таблицы как часть этого объекта.
+function GDBObjAcadTable.TryMergeContinuation(
+  AOther: PGDBObjEntity): Boolean;
+var
+  PartIdx: Integer;
+begin
+  Result := False;
+  if AOther = nil then Exit;
+  if AOther^.GetObjType <> GDBAcadTableID then Exit;
+
+  PartIdx := Length(FContinuationParts);
+  System.SetLength(FContinuationParts, PartIdx + 1);
+  CaptureTableDataToPart(
+    PGDBObjAcadTable(AOther)^, FContinuationParts[PartIdx]);
+  // Геометрию нужно перестроить с учётом новой части
+  FGeometryBuilt := False;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: TryMergeContinuation merged part %d ' +
+    '(rows=%d cols=%d)',
+    [PartIdx, FContinuationParts[PartIdx].RowCount,
+     FContinuationParts[PartIdx].ColCount], LM_Info);
+  Result := True;
 end;
 
 // Вычисляет bounding box
@@ -800,6 +1089,9 @@ procedure GDBObjAcadTable.getoutbound(var DC: TDrawContext);
 var
   TotalWidthVal, TotalHeightVal: Double;
   MinX, MinY, MaxX, MaxY: Double;
+  PartIdx: Integer;
+  BaseX, BaseY, PartW, PartH: Double;
+  PartMinX, PartMaxX, PartMinY, PartMaxY: Double;
 begin
   if (FRowCount <= 0) or (FColCount <= 0) then
   begin
@@ -818,6 +1110,28 @@ begin
   MaxX := Local.P_insert.x + TotalWidthVal;
   MinY := Local.P_insert.y - TotalHeightVal;
   MaxY := Local.P_insert.y;
+
+  // Расширяем bounding box на все части-продолжения (issue #1300)
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    BaseX := FContinuationParts[PartIdx].InsertPoint.x - FInsertPoint.x;
+    BaseY := FContinuationParts[PartIdx].InsertPoint.y - FInsertPoint.y;
+    PartW := uzeacadtable_layout.GetTotalWidth(
+      FContinuationParts[PartIdx].ColCount,
+      FContinuationParts[PartIdx].ColWidths);
+    PartH := uzeacadtable_layout.GetTotalHeight(
+      FContinuationParts[PartIdx].RowCount,
+      FContinuationParts[PartIdx].RowHeights);
+    PartMinX := Local.P_insert.x + BaseX;
+    PartMaxX := PartMinX + PartW;
+    PartMaxY := Local.P_insert.y + BaseY;
+    PartMinY := PartMaxY - PartH;
+    if PartMinX < MinX then MinX := PartMinX;
+    if PartMaxX > MaxX then MaxX := PartMaxX;
+    if PartMinY < MinY then MinY := PartMinY;
+    if PartMaxY > MaxY then MaxY := PartMaxY;
+  end;
+
   vp.BoundingBox.LBN :=
     CreateVertex(MinX, MinY, Local.P_insert.z);
   vp.BoundingBox.RTF :=
@@ -961,6 +1275,14 @@ begin
   System.SetLength(NewTable^.FMerges, Length(FMerges));
   for Idx := 0 to High(FMerges) do
     NewTable^.FMerges[Idx] := FMerges[Idx];
+
+  // Глубокое копирование частей-продолжений (issue #1300)
+  System.SetLength(NewTable^.FContinuationParts,
+    Length(FContinuationParts));
+  for Idx := 0 to High(FContinuationParts) do
+    NewTable^.CopyTablePart(
+      FContinuationParts[Idx],
+      NewTable^.FContinuationParts[Idx]);
 
   NewTable^.bp.ListPos.Owner := AOwn;
   Result := NewTable;

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
@@ -158,6 +158,15 @@ type
 
   TTableCellArray = array of array of TTableCell;
 
+  // Именованные псевдонимы динамических массивов. Нужны, чтобы данные
+  // таблицы можно было обменивать целиком (присваиванием) между объектом
+  // и его частями-продолжениями (issue #1300): для оператора := FPC
+  // требует идентичности типов, а не структурной совместимости.
+  TTableRowArray = array of TTableRow;
+  TTableColumnArray = array of TTableColumn;
+  TMergeRangeArray = array of TMergeRange;
+  TTableTextArray = array of String;
+
 implementation
 
 end.

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -79,6 +79,14 @@ type
     function FromDXFPostProcessBeforeAdd(ptu:PExtensionData;
       const drawing:TDrawingDef):PGDBObjSubordinated;virtual;
     procedure FromDXFPostProcessAfterAdd;virtual;
+    { Пытается поглотить продолжение разделённой составной сущности
+      (например, очередную часть разбитой по ширине таблицы ACAD_TABLE,
+      сохранённой в DXF как несколько сущностей ради совместимости).
+      Базовая реализация ничего не делает и возвращает False. Специализированные
+      сущности переопределяют метод и при успехе копируют данные AOther в себя.
+      Возвращает True, если данные AOther поглощены и вызывающая сторона может
+      освободить AOther (issue #1300). }
+    function TryMergeContinuation(AOther:PGDBObjEntity):boolean;virtual;
     procedure postload(var context:TIODXFLoadContext);virtual;
     procedure createfield;virtual;
     function AddExtAttrib:PTExtAttrib;
@@ -438,6 +446,11 @@ end;
 
 procedure GDBObjEntity.FromDXFPostProcessAfterAdd;
 begin
+end;
+
+function GDBObjEntity.TryMergeContinuation(AOther:PGDBObjEntity):boolean;
+begin
+  Result:=false;
 end;
 
 procedure GDBObjEntity.postload(var context:TIODXFLoadContext);

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -484,8 +484,12 @@ var
   EntInfoData:TEntInfoData;
   bylayerlt:Pointer;
   lph:TLPSHandle;
+  // Последняя добавленная главная ACAD_TABLE — в неё поглощаются
+  // продолжения разделённой таблицы (issue #1300).
+  pLastMainTable:PGDBObjEntity;
 begin
   s:='';
+  pLastMainTable:=nil;
   lph:=lps.StartLongProcess('addentitiesfromdxf',@rdr,rdr.Size);
   if Assigned(CreateExtLoadData) then
     PExtLoadData:=CreateExtLoadData()
@@ -511,21 +515,27 @@ begin
       if assigned(PGDBObjEntity(pobj)^.EntExtensions) then
         PGDBObjEntity(pobj)^.EntExtensions.RunSupportOldVersions(pobj,drawing);
 
-      { Если ACAD_TABLE (или любая сущность, загруженная как proxy) имеет
-        handle из списка продолжений разделённой таблицы — её proxy graphic
-        уже включён в первую ACAD_TABLE, поэтому отдельный ProxyEntity
-        создавать не нужно. Освобождаем и переходим к следующей сущности.
-        Переменную group=0 не сбрасываем: LoadFromDXF остановился на коде 0
-        следующей сущности, и следующая итерация должна обрабатывать её имя. }
+      { Если ACAD_TABLE имеет handle из списка продолжений разделённой
+        таблицы — это часть, которую AutoCAD сохранил как отдельную
+        ACAD_TABLE. Поглощаем её данные в первую (главную) ACAD_TABLE,
+        чтобы все части отображались как один объект (issue #1300).
+        После поглощения освобождаем загруженную сущность и переходим
+        к следующей. Переменную group=0 не сбрасываем: LoadFromDXF
+        остановился на коде 0 следующей сущности. Если по какой-то
+        причине главной таблицы нет или поглощение не удалось — часть
+        обрабатывается обычным образом (добавляется как отдельный объект),
+        чтобы данные не были потеряны. }
       if (uppercase(s)='ACAD_TABLE') and
          (context.TableContinuationHandles<>nil) and
          (context.TableContinuationHandles.Count>0) and
          (PGDBObjEntity(pobj)^.PExtAttrib<>nil) and
          (PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle<>0) and
          (context.TableContinuationHandles.IndexOf(
-            NormalizeHandle(inttohex(PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle,0)))>=0) then begin
+            NormalizeHandle(inttohex(PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle,0)))>=0) and
+         (pLastMainTable<>nil) and
+         pLastMainTable^.TryMergeContinuation(pobj) then begin
         programlog.LogOutFormatStr(
-          'uzeffdxf: skipping ACAD_TABLE continuation handle=%s (merged into first table''s proxy graphic)',
+          'uzeffdxf: merging ACAD_TABLE continuation handle=%s into main table',
           [inttohex(PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle,0)], LM_Info);
         pobj^.done;
         Freemem(pointer(pobj));
@@ -577,6 +587,10 @@ begin
         end;
         if not trash then begin
           newowner^.DXFLoadAddMi(pobj);
+        // Запоминаем главную ACAD_TABLE для поглощения её продолжений
+        // (issue #1300). Продолжения идут после главной части в DXF.
+        if uppercase(s)='ACAD_TABLE' then
+          pLastMainTable:=pobj;
         if not(IsObjectIt(TypeOf(owner^),TypeOf(GDBObjBlockdef))) then begin
           if PGDBObjEntity(pobj)^.DXFDelayedBuildGeometry then begin
             {PGDBObjEntity(pobj)^.BuildGeometry(drawing);

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -43,6 +43,7 @@ type
     procedure LoadsBreakSettingsFromDXF;
     procedure LoadsBreakSettingsFromSecondSample;
     procedure RendersBrokenTableAsSeparatedFragments;
+    procedure LoadsSplitTableAsSingleMergedObject;
   end;
 
 implementation
@@ -58,6 +59,21 @@ begin
   begin
     if PEntity^.GetObjType = GDBAcadTableID then
       Exit(PGDBObjAcadTable(PEntity));
+    PEntity := ARoot^.ObjArray.iterate(IR);
+  end;
+end;
+
+function CountAcadTables(const ARoot: PGDBObjGenericSubEntry): Integer;
+var
+  IR: itrec;
+  PEntity: PGDBObjEntity;
+begin
+  Result := 0;
+  PEntity := ARoot^.ObjArray.beginiterate(IR);
+  while PEntity <> nil do
+  begin
+    if PEntity^.GetObjType = GDBAcadTableID then
+      Inc(Result);
     PEntity := ARoot^.ObjArray.iterate(IR);
   end;
 end;
@@ -259,6 +275,31 @@ begin
       'После применения правил разбиения у AcadTable должны быть разрывы между фрагментами');
     Check(MaxX - MinX > 20.0,
       'Ширина визуализации должна включать несколько разнесённых фрагментов таблицы');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// Разделённая по ширине таблица (tablerazdel.dxf) сохранена в DXF как три
+// отдельные ACAD_TABLE. Все три части должны быть объединены в один объект
+// AcadTable и отображаться вместе (issue #1300).
+procedure TAcadTableStyleTest.LoadsSplitTableAsSingleMergedObject;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  TableCount: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    TableCount := CountAcadTables(Drawing.pObjRoot);
+    CheckEquals(1, TableCount,
+      'Три части разделённой таблицы должны загружаться как один объект AcadTable');
+
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(2, AcadTable^.ContinuationPartCount,
+      'В главную таблицу должны быть поглощены две части-продолжения');
   finally
     Drawing.done;
   end;

--- a/experiments/test_issue1300_merge_parts.py
+++ b/experiments/test_issue1300_merge_parts.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+Verification for issue #1300 (corrected requirement).
+
+A single ACAD_TABLE that AutoCAD split into 3 display parts (with a horizontal
+offset between parts) is stored in DXF as 3 separate ACAD_TABLE entities.
+
+Previous fix (PR #1301) merely DROPPED the 2nd and 3rd parts, so only the first
+part was displayed. The correct behaviour (per issue comment 2026-06-09): all
+three parts must be DISPLAYED, combined as ONE AcadTable object — the same way
+the proxy-object path in issue #980 merges them.
+
+This script models the new merge logic in uzeacadtable_model.pas:
+  - the first ACAD_TABLE is the "main" object,
+  - the continuation parts (handles listed in the ROUNDTRIP XRECORD) are absorbed
+    as TAcadTablePart records,
+  - each part is rendered at a base offset = part.InsertPoint - main.InsertPoint.
+
+Expected for tablerazdel.dxf:
+  - 3 ACAD_TABLE entities in the file,
+  - after merge: 1 object with ContinuationPartCount == 2,
+  - the 3 parts are laid out side-by-side along +X (non-overlapping, monotone).
+"""
+import os
+import sys
+
+DXF_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    'cad_source', 'test', 'tablerazdel.dxf')
+
+
+def read_pairs(path):
+    with open(path, 'r', encoding='latin-1') as f:
+        lines = f.read().splitlines()
+    pairs = []
+    i = 0
+    while i + 1 < len(lines):
+        code = lines[i].strip()
+        value = lines[i + 1]
+        try:
+            code = int(code)
+        except ValueError:
+            i += 2
+            continue
+        pairs.append((code, value))
+        i += 2
+    return pairs
+
+
+def extract_acad_tables(pairs):
+    """Return list of dicts with handle + insert point for every ACAD_TABLE."""
+    tables = []
+    in_entities = False
+    i = 0
+    n = len(pairs)
+    while i < n:
+        code, value = pairs[i]
+        if code == 2 and value.strip() == 'ENTITIES':
+            in_entities = True
+        if in_entities and code == 0 and value.strip() == 'ACAD_TABLE':
+            t = {'handle': None, 'x': 0.0, 'y': 0.0, 'rows': 0}
+            j = i + 1
+            seen_block_ref = False
+            while j < n and pairs[j][0] != 0:
+                c, v = pairs[j]
+                if c == 5 and t['handle'] is None:
+                    t['handle'] = v.strip().upper().lstrip('0') or '0'
+                elif c == 100 and v.strip() == 'AcDbBlockReference':
+                    seen_block_ref = True
+                elif seen_block_ref and c == 10:
+                    t['x'] = float(v)
+                elif seen_block_ref and c == 20:
+                    t['y'] = float(v)
+                elif c == 91:
+                    t['rows'] += 1
+                j += 1
+            tables.append(t)
+            i = j
+            continue
+        i += 1
+    return tables
+
+
+def main():
+    if not os.path.exists(DXF_PATH):
+        print('MISSING DXF:', DXF_PATH)
+        return 1
+
+    pairs = read_pairs(DXF_PATH)
+    tables = extract_acad_tables(pairs)
+
+    print('ACAD_TABLE entities found:', len(tables))
+    for idx, t in enumerate(tables):
+        print('  part %d: handle=%s insert=(%.4f, %.4f)'
+              % (idx, t['handle'], t['x'], t['y']))
+
+    ok = True
+
+    if len(tables) != 3:
+        print('FAIL: expected 3 ACAD_TABLE entities, got', len(tables))
+        ok = False
+
+    if tables:
+        # Model the merge: main = tables[0]; the rest become continuation parts.
+        main = tables[0]
+        parts = tables[1:]
+        continuation_part_count = len(parts)
+        print('After merge -> 1 object, ContinuationPartCount =',
+              continuation_part_count)
+        if continuation_part_count != 2:
+            print('FAIL: expected ContinuationPartCount == 2')
+            ok = False
+
+        # Base offsets used by RenderCurrentTable(ABaseX, ABaseY).
+        base_x = [0.0] + [p['x'] - main['x'] for p in parts]
+        base_y = [0.0] + [p['y'] - main['y'] for p in parts]
+        print('Render base offsets X:', ['%.4f' % b for b in base_x])
+        print('Render base offsets Y:', ['%.4f' % b for b in base_y])
+
+        # All 3 parts must be laid out at distinct, strictly increasing X
+        # offsets — i.e. side-by-side, not stacked on top of each other.
+        if not all(base_x[k] < base_x[k + 1] - 1e-6
+                   for k in range(len(base_x) - 1)):
+            print('FAIL: part X offsets are not strictly increasing '
+                  '(parts would overlap instead of display side-by-side)')
+            ok = False
+        else:
+            print('OK: parts are displayed side-by-side along +X')
+
+    print('RESULT:', 'PASS' if ok else 'FAIL')
+    return 0 if ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## AcadTable: split-by-width tables now display as one merged object

Fixes veb86/zcadvelecAI#1300

### Problem
When AutoCAD splits a single table by width, it stores the table in DXF as
**several `ACAD_TABLE` entities** (a main entity plus continuation parts listed
in the `ACAD_ROUNDTRIP_2008_TABLE_ENTITY` XRECORD).

- Originally these parts loaded as **3 separate `AcadTable` objects**.
- The previous fix (PR #1301) merely **dropped** the 2nd and 3rd parts, so only
  the **first** part was displayed — also wrong, as reported in the issue.

The correct behaviour (per the issue comment, referencing the proxy-object
merge in #980): **all parts must be displayed, combined as one `AcadTable`
object**.

### Root cause
Each native `ACAD_TABLE` part holds only its own slice of cell data. Unlike the
proxy path in #980 (where the whole table is embedded in the first proxy
graphic, so the rest can simply be skipped), the native parser must **keep**
the continuation parts' data and render them side-by-side at their real
insert-point offsets.

### Solution
- **`uzeentity.pas`** — new virtual `TryMergeContinuation(AOther)` hook
  (default returns `False`).
- **`uzeffdxf.pas`** — the loader tracks the last main `ACAD_TABLE` and, when a
  continuation handle is seen, calls `TryMergeContinuation` to absorb it. On
  success the loaded entity is freed; if there is no main table or the merge
  fails, the part is added normally so no data is lost.
- **`uzeacadtable_model.pas`** — `GDBObjAcadTable` stores absorbed parts as
  `TAcadTablePart` records (deep-copied render data). `BuildVisualRepresentation`
  renders the main part, then each part at base offset
  `part.InsertPoint − main.InsertPoint` (via a buffer swap + `RenderCurrentTable`).
  `getoutbound`, `Clone`, `initnul`, `done` were extended to cover the parts, and
  a `ContinuationPartCount` property exposes the merged-part count.
- **`uzeacadtable_types.pas`** — named dynamic-array aliases so render data can be
  swapped wholesale (FPC's `:=` needs identical named types).

### Reproduction & test
`cad_source/test/tablerazdel.dxf` contains 3 `ACAD_TABLE` entities (handles EB,
209, 259) at insert X = 84.6651 / 98.1551 / 111.6451 (same Y), i.e. one table
split into 3 horizontally-offset parts.

- **Automated test** `LoadsSplitTableAsSingleMergedObject`
  (`cad_source/zengine/tests/uzctacadtable.pas`): asserts the file loads as
  **exactly one** `ACAD_TABLE` object with `ContinuationPartCount = 2`.
- **Layout model** `experiments/test_issue1300_merge_parts.py`: verifies the
  merge yields 1 object and the 3 parts lay out side-by-side along +X
  (render base offsets X = 0.0 / 13.49 / 26.98) — `RESULT: PASS`.

### Notes
The local environment cannot build the full LCL test suite (missing
`uzbLog`/`Interfaces` units, generated generic containers), and the project CI
does not run fpcunit tests. Verification was done by reading the code, compiling
the leaf `uzeacadtable_types` unit standalone with fpc (0 errors), and the
Python layout model above.
