### PR TITLE
AcadTable: apply DXF table style to split-table continuation parts (#1300)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-10T07:00:13.330Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,1 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-10T07:00:13.330Z

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -65,6 +65,11 @@ type
     CellTexts: TTableTextArray;
     TableFlags: Integer;
     TableStyle: TTableStyle;
+    // Хэндл DXF-стиля таблицы этой части (group code 342). Нужен, чтобы
+    // применить тот же табличный стиль, что и к главной части: иначе у
+    // продолжений остаётся стиль по умолчанию и текст рендерится высотой
+    // CAcadTableDefaultTextHeight вместо высоты из DXF (issue #1300).
+    TableStyleHandle: String;
     Rows: TTableRowArray;
     Cols: TTableColumnArray;
     Cells: TTableCellArray;
@@ -928,6 +933,13 @@ begin
     BaseX := FContinuationParts[PartIdx].InsertPoint.x - FInsertPoint.x;
     BaseY := FContinuationParts[PartIdx].InsertPoint.y - FInsertPoint.y;
     SwapTableData(FContinuationParts[PartIdx]);
+    // Часть-продолжение поглощается до того, как для неё вызывается
+    // BuildGeometry, поэтому её FTableStyle остаётся стилем по умолчанию.
+    // Применяем DXF-стиль части (тот же handle 342, что и у главной части),
+    // иначе текст рендерится высотой CAcadTableDefaultTextHeight и
+    // «разъезжается» относительно ячеек (issue #1300).
+    uzeacadtable_stylemanager.ApplyDXFTableStyle(
+      FTableStyle, FContinuationParts[PartIdx].TableStyleHandle, ADrawing);
     RenderCurrentTable(ADrawing, ADC, BaseX, BaseY);
     SwapTableData(FContinuationParts[PartIdx]);
   end;
@@ -951,6 +963,7 @@ begin
   APart.ColCount := ASource.FColCount;
   APart.TableFlags := ASource.FTableFlags;
   APart.TableStyle := ASource.FTableStyle;
+  APart.TableStyleHandle := ASource.FTableStyleHandle;
   APart.BreakEnabled := ASource.FBreakEnabled;
   APart.BreakDirection := ASource.FBreakDirection;
   APart.BreakRepeatTopLabels := ASource.FBreakRepeatTopLabels;
@@ -1002,6 +1015,7 @@ begin
   ADest.ColCount := ASource.ColCount;
   ADest.TableFlags := ASource.TableFlags;
   ADest.TableStyle := ASource.TableStyle;
+  ADest.TableStyleHandle := ASource.TableStyleHandle;
   ADest.BreakEnabled := ASource.BreakEnabled;
   ADest.BreakDirection := ASource.BreakDirection;
   ADest.BreakRepeatTopLabels := ASource.BreakRepeatTopLabels;
@@ -1045,6 +1059,7 @@ end;
 // Освобождение ресурсов части-продолжения.
 procedure GDBObjAcadTable.ClearPart(var APart: TAcadTablePart);
 begin
+  APart.TableStyleHandle := '';
   APart.RowHeights.done;
   APart.ColWidths.done;
   System.SetLength(APart.CellTexts, 0);

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -30,6 +30,8 @@ uses
   uzeentmtext,
   uzeentline,
   uzeentgenericsubentry,
+  uzeentcomplex,
+  UGDBVisibleTreeArray,
   uzeenttext,
   uzeentblockinsert,
   uzeenttable,
@@ -44,6 +46,7 @@ type
     procedure LoadsBreakSettingsFromSecondSample;
     procedure RendersBrokenTableAsSeparatedFragments;
     procedure LoadsSplitTableAsSingleMergedObject;
+    procedure AppliesTableStyleToContinuationParts;
   end;
 
 implementation
@@ -90,14 +93,24 @@ begin
   Result := ADrawing.pObjRoot^.ObjArray.Count;
 end;
 
-procedure CollectMTextStyles(const ARoot: PGDBObjGenericSubEntry;
+// Геометрия AcadTable (линии и MText ячеек) генерируется в собственный
+// ConstObjArray объекта, а не в корень чертежа. Построение отложенное
+// (DXFDelayedBuildGeometry=True), поэтому тесты обязаны сначала вызвать
+// BuildGeometry на таблице, а затем обходить именно её ConstObjArray.
+procedure BuildTableGeometry(var ADrawing: TSimpleDrawing;
+  ATable: PGDBObjAcadTable);
+begin
+  ATable^.BuildGeometry(ADrawing);
+end;
+
+procedure CollectMTextStyles(var AArr: GDBObjEntityTreeArray;
   AStyles: TStrings);
 var
   IR: itrec;
   PEntity: PGDBObjEntity;
   PMText: PGDBObjMText;
 begin
-  PEntity := ARoot^.ObjArray.beginiterate(IR);
+  PEntity := AArr.beginiterate(IR);
   while PEntity <> nil do
   begin
     if PEntity^.GetObjType = GDBMTextID then
@@ -107,11 +120,11 @@ begin
         if AStyles.IndexOf(PMText^.TXTStyle^.Name) < 0 then
           AStyles.Add(PMText^.TXTStyle^.Name);
     end;
-    PEntity := ARoot^.ObjArray.iterate(IR);
+    PEntity := AArr.iterate(IR);
   end;
 end;
 
-procedure CollectLineBounds(const ARoot: PGDBObjGenericSubEntry;
+procedure CollectLineBounds(var AArr: GDBObjEntityTreeArray;
   out AMinX, AMaxX: Double; out AHasGap: Boolean);
 var
   IR: itrec;
@@ -130,7 +143,7 @@ begin
   AHasGap := False;
   SegCount := 0;
 
-  PEntity := ARoot^.ObjArray.beginiterate(IR);
+  PEntity := AArr.beginiterate(IR);
   while PEntity <> nil do
   begin
     if PEntity^.GetObjType = GDBLineID then
@@ -143,7 +156,7 @@ begin
       Segments[SegCount].MaxX := MaxSegX;
       Inc(SegCount);
     end;
-    PEntity := ARoot^.ObjArray.iterate(IR);
+    PEntity := AArr.iterate(IR);
   end;
 
   if SegCount = 0 then
@@ -172,9 +185,45 @@ begin
   end;
 end;
 
+// Собирает высоты текста (textprop.size) всех MText, отрисованных таблицей.
+procedure CollectMTextSizes(var AArr: GDBObjEntityTreeArray;
+  out AMinSize, AMaxSize: Double; out ACount: Integer);
+var
+  IR: itrec;
+  PEntity: PGDBObjEntity;
+  PMText: PGDBObjMText;
+  Sz: Double;
+begin
+  AMinSize := 0;
+  AMaxSize := 0;
+  ACount := 0;
+  PEntity := AArr.beginiterate(IR);
+  while PEntity <> nil do
+  begin
+    if PEntity^.GetObjType = GDBMTextID then
+    begin
+      PMText := PGDBObjMText(PEntity);
+      Sz := PMText^.textprop.size;
+      if ACount = 0 then
+      begin
+        AMinSize := Sz;
+        AMaxSize := Sz;
+      end
+      else
+      begin
+        if Sz < AMinSize then AMinSize := Sz;
+        if Sz > AMaxSize then AMaxSize := Sz;
+      end;
+      Inc(ACount);
+    end;
+    PEntity := AArr.iterate(IR);
+  end;
+end;
+
 procedure TAcadTableStyleTest.LoadsCellTextStylesFromDXFTableStyle;
 var
   Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
   StyleNames: TStringList;
   EntityCount: Integer;
 begin
@@ -183,11 +232,15 @@ begin
   try
     Check(EntityCount > 0, 'DXF должен загрузить сущности');
 
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    BuildTableGeometry(Drawing, AcadTable);
+
     StyleNames := TStringList.Create;
     try
       StyleNames.Sorted := False;
       StyleNames.Duplicates := dupIgnore;
-      CollectMTextStyles(Drawing.pObjRoot, StyleNames);
+      CollectMTextStyles(AcadTable^.ConstObjArray, StyleNames);
 
       Check(StyleNames.Count > 0, 'Ожидались текстовые сущности таблицы');
       Check(StyleNames.IndexOf('newtext') >= 0,
@@ -264,13 +317,18 @@ end;
 procedure TAcadTableStyleTest.RendersBrokenTableAsSeparatedFragments;
 var
   Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
   MinX, MaxX: Double;
   HasGap: Boolean;
 begin
   LoadDrawingFromDXF(
     ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
   try
-    CollectLineBounds(Drawing.pObjRoot, MinX, MaxX, HasGap);
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    BuildTableGeometry(Drawing, AcadTable);
+
+    CollectLineBounds(AcadTable^.ConstObjArray, MinX, MaxX, HasGap);
     Check(HasGap,
       'После применения правил разбиения у AcadTable должны быть разрывы между фрагментами');
     Check(MaxX - MinX > 20.0,
@@ -300,6 +358,41 @@ begin
     AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
     CheckEquals(2, AcadTable^.ContinuationPartCount,
       'В главную таблицу должны быть поглощены две части-продолжения');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// Все три части разделённой таблицы (tablerazdel.dxf) используют один и тот же
+// DXF-стиль таблицы (handle 342 = "87", высоты текста 0.18/0.25). Части-
+// продолжения поглощаются до вызова BuildGeometry, поэтому раньше их стиль
+// оставался по умолчанию и текст рендерился высотой CAcadTableDefaultTextHeight
+// (2.5) — намного крупнее ячеек, из-за чего «разъезжался». После исправления
+// табличный стиль применяется ко всем частям, и высота текста не превышает
+// высоту из DXF (issue #1300).
+procedure TAcadTableStyleTest.AppliesTableStyleToContinuationParts;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  MinSize, MaxSize: Double;
+  TextCount: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    Check(AcadTable^.ContinuationPartCount > 0,
+      'Таблица должна содержать части-продолжения');
+
+    BuildTableGeometry(Drawing, AcadTable);
+    CollectMTextSizes(AcadTable^.ConstObjArray, MinSize, MaxSize, TextCount);
+    Check(TextCount > 0, 'Таблица должна отрисовать текст ячеек');
+    // Высоты текста стиля 0.18/0.25 — задаём порог заметно ниже значения
+    // по умолчанию 2.5, чтобы поймать неприменённый стиль у продолжений.
+    Check(MaxSize < CAcadTableDefaultTextHeight - 1e-6,
+      'Высота текста частей-продолжений должна браться из DXF-стиля, ' +
+      'а не из значения по умолчанию');
   finally
     Drawing.done;
   end;

--- a/experiments/issue1300_table_style_heights.py
+++ b/experiments/issue1300_table_style_heights.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""
+issue #1300 — AcadTable: split table continuation parts ignore table style.
+
+A horizontally split table is stored in DXF as several ACAD_TABLE entities
+that all reference the SAME table style (group code 342). ZCAD merges them
+into one AcadTable object (main part + continuation parts). The bug: only the
+main part had ApplyDXFTableStyle() applied; continuation parts kept the default
+TTableStyle (CAcadTableDefaultTextHeight = 2.5), so their cell text rendered
+giant and misaligned ("текст разъехался").
+
+This script confirms, straight from the sample DXF, that:
+  * all ACAD_TABLE parts share one style handle, and
+  * that style's text heights are far below the 2.5 default,
+which is exactly what the regression test threshold (MaxSize < 2.5) relies on.
+
+Pure-stdlib DXF group reader — no external deps.
+"""
+import sys
+from pathlib import Path
+
+DXF = Path(__file__).resolve().parents[1] / "cad_source/test/tablerazdel.dxf"
+DEFAULT_TEXT_HEIGHT = 2.5  # CAcadTableDefaultTextHeight (uzeacadtable_types)
+
+
+def read_groups(path):
+    lines = path.read_text(errors="replace").splitlines()
+    for i in range(0, len(lines) - 1, 2):
+        yield lines[i].strip(), lines[i + 1].strip()
+
+
+def main():
+    if not DXF.exists():
+        sys.exit(f"sample not found: {DXF}")
+
+    groups = list(read_groups(DXF))
+
+    # Collect the style handle (342) of every ACAD_TABLE entity.
+    table_style_handles = []
+    in_entities = False
+    cur_type = None
+    for code, val in groups:
+        if code == "2" and val == "ENTITIES":
+            in_entities = True
+        if code == "2" and val == "OBJECTS":
+            in_entities = False
+        if not in_entities:
+            continue
+        if code == "0":
+            cur_type = val
+        if code == "342" and cur_type == "ACAD_TABLE":
+            table_style_handles.append(val)
+
+    # Collect TABLESTYLE text heights (group 140) per style handle (group 5).
+    style_heights = {}
+    cur_type = None
+    cur_handle = None
+    for code, val in groups:
+        if code == "0":
+            cur_type = val
+            cur_handle = None
+        if cur_type == "TABLESTYLE" and code == "5":
+            cur_handle = val
+            style_heights.setdefault(cur_handle, [])
+        if cur_type == "TABLESTYLE" and code == "140" and cur_handle:
+            style_heights[cur_handle].append(float(val))
+
+    print(f"ACAD_TABLE entities: {len(table_style_handles)}")
+    print(f"  style handles (342): {table_style_handles}")
+    print(f"TABLESTYLE heights (140): {style_heights}")
+
+    assert len(table_style_handles) >= 2, "expected a split table (>=2 parts)"
+    assert len(set(table_style_handles)) == 1, \
+        "all split parts must share one table style handle"
+
+    handle = table_style_handles[0]
+    heights = style_heights.get(handle, [])
+    assert heights, f"no TABLESTYLE heights for handle {handle}"
+    assert max(heights) < DEFAULT_TEXT_HEIGHT, (
+        f"style heights {heights} must be below the {DEFAULT_TEXT_HEIGHT} "
+        "default — otherwise the regression test threshold is meaningless"
+    )
+
+    print(
+        f"OK: {len(table_style_handles)} parts share style '{handle}'; "
+        f"max text height {max(heights)} < default {DEFAULT_TEXT_HEIGHT}. "
+        "Continuation parts must therefore render below 2.5 once the style "
+        "is applied to every part (the fix)."
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Проблема (issue #1300)

Горизонтально разделённая таблица хранится в DXF как несколько отдельных
сущностей `ACAD_TABLE`, ссылающихся на **один и тот же** табличный стиль
(group code 342). ZCAD объединяет их в один объект `AcadTable` (главная часть
+ части-продолжения).

На последнем шаге у 2-й и 3-й частей **не применялся табличный стиль**: текст
рендерился высотой по умолчанию `CAcadTableDefaultTextHeight = 2.5` вместо
высоты из DXF-стиля (0.18/0.25) и «разъезжался» относительно ячеек.

| До | После |
|----|-------|
| У продолжений гигантский текст (см. фото в issue) | Все части используют стиль из DXF |

## Причина

Часть-продолжение поглощается (`TryMergeContinuation` → `CaptureTableDataToPart`)
**до** того, как для неё вызывается `BuildGeometry`/`ApplyDXFTableStyle`. В
результате её `FTableStyle` оставался дефолтным. При рендеринге
`BuildVisualRepresentation` подменял данные части (`SwapTableData`) и рисовал её
этим дефолтным стилем (высота 2.5).

## Исправление

- В запись `TAcadTablePart` добавлено поле `TableStyleHandle` — хэндл DXF-стиля
  (group 342) каждой части. Заполняется/копируется/очищается в
  `CaptureTableDataToPart` / `CopyTablePart` / `ClearPart`.
- В `BuildVisualRepresentation`, после `SwapTableData` каждой части и перед
  `RenderCurrentTable`, вызывается `ApplyDXFTableStyle(FTableStyle, part.TableStyleHandle, ...)`.
  Теперь каждая часть рендерится тем же стилем и высотой текста, что и главная.

Хэндл хранится для каждой части отдельно (а не один общий), что
forward-совместимо с будущим управлением разделением таблиц (объединение
частей в одну длинную таблицу, изменение смещений и т.п.), о котором сказано
в комментарии к issue.

## Воспроизведение и тест

Образец: `cad_source/test/tablerazdel.dxf` — 3 части `ACAD_TABLE`, все со
стилем `87` (высоты 0.18/0.25).

Геометрия `AcadTable` строится **отложенно** (`DXFDelayedBuildGeometry=True`)
и попадает в собственный `ConstObjArray` сущности, а не в корень чертежа.
Поэтому коллекторы MText/Line в тестах поправлены: сначала вызывается
`BuildGeometry` на таблице, затем обходится её `ConstObjArray` (раньше они
ошибочно обходили `pObjRoot`, где этой геометрии нет).

Новый регрессионный тест `AppliesTableStyleToContinuationParts`
(`cad_source/zengine/tests/uzctacadtable.pas`):
- строит геометрию таблицы;
- собирает высоты всех MText ячеек;
- проверяет, что максимальная высота **меньше** дефолтных 2.5.

До исправления части-продолжения давали высоту 2.5 → тест падает; после —
0.18/0.25 → тест проходит.

`experiments/issue1300_table_style_heights.py` подтверждает прямо из DXF, что
все три части используют один стиль, чьи высоты заметно ниже 2.5.

## Примечание

В окружении нет компилятора FPC/Lazarus и тесты не входят в CI, поэтому
проверка выполнена анализом кода и моделированием логики; тест добавлен в
`testzengine.lpr` и готов к запуску локально.



Fixes veb86/zcadvelecAI#1300