### PR TITLE
AcadTable: fix transformation display, break detection, and un-break (issue #1305)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,13 @@ cad_source/components/fpdwg/**/*.o
 cad_source/components/fpdwg/**/*.ppu
 cad_source/components/fpdwg/**/*.rsj
 cad_source/components/fpdwg/inspector/tests/fpdwg_tests
+
+# Free Pascal build artifacts under zengine tests:
+cad_source/zengine/tests/*.o
+cad_source/zengine/tests/*.ppu
+cad_source/zengine/tests/*.or
+cad_source/zengine/tests/*.rsj
+cad_source/zengine/tests/*.compiled
+cad_source/zengine/tests/testacadtable_standalone
+cad_source/zengine/tests/testacadtable_standalone.lpi
+cad_source/zengine/tests/testacadtable_standalone.lpr

--- a/.gitignore
+++ b/.gitignore
@@ -49,5 +49,3 @@ cad_source/zengine/tests/*.or
 cad_source/zengine/tests/*.rsj
 cad_source/zengine/tests/*.compiled
 cad_source/zengine/tests/testacadtable_standalone
-cad_source/zengine/tests/testacadtable_standalone.lpi
-cad_source/zengine/tests/testacadtable_standalone.lpr

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
+# Updated: 2026-06-10T10:51:04.132Z

--- a/cad_source/zcad/register/uzcregacadtable.pas
+++ b/cad_source/zcad/register/uzcregacadtable.pas
@@ -43,6 +43,7 @@ uses
   uzcoimultiproperties,uzcoimultipropertiesutil,
   uzeacadtable_model,uzeacadtable_types,
   uzeconsts,uzegeometrytypes,
+  uzcdrawings,
   uzsbVarmanDef,Varman,uzbUnits,uzetypes,gzctnrVectorTypes,uzctnrVectorStrings,
   uzclog,uzbLogIntf;
 
@@ -140,6 +141,34 @@ begin
   v:=PGDBObjAcadTable(ChangedData.PEntity)^.BreakEnabled;
   ChangedData.PGetDataInEtity:=@v;
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+// Запись признака разбиения таблицы (issue #1305, часть 2b).
+// Снятие флага (Break enabled = False) у разорванной таблицы объединяет
+// сохранённые части-продолжения и перестраивает таблицу сверху вниз в один
+// сплошной объект (вся работа выполняется в GDBObjAcadTable.SetBreakEnabled).
+// Установка True самостоятельно таблицу по геометрии не разрывает — она лишь
+// сохраняет признак, поэтому здесь специальной обработки этого случая нет.
+// После изменения вызывается YouChanged, чтобы дерево чертежа пересчитало
+// геометрию таблицы (FormatEntity перестроит её по обновлённой модели).
+procedure AcadTableBreakEnabledEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  Table:PGDBObjAcadTable;
+  NewValue:Boolean;
+begin
+  Table:=PGDBObjAcadTable(ChangedData.PEntity);
+  NewValue:=PBoolean(pvardesk(pdata)^.data.Addr.Instance)^;
+  if Table^.BreakEnabled=NewValue then
+    exit;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  Table^.BreakEnabled:=NewValue;
+  if drawings.GetCurrentDWG<>nil then
+    Table^.YouChanged(drawings.GetCurrentDWG^);
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
 end;
 
 // Чтение признака повтора верхних подписей (только чтение)
@@ -324,12 +353,16 @@ begin
     OneVarDataMIPD,
     TEntIterateProcsData.Create(nil,@AcadTableColCountEntIterateProc,nil));
 
-  {AcadTable — разбиение таблицы (только чтение)}
+  {AcadTable — разбиение таблицы}
+  {Break enabled редактируется: снятие флага объединяет части (issue #1305).
+   Остальные параметры разбиения — только чтение.}
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableBreakEnabled','Break enabled',sysunit^.TypeName2PTD('Boolean'),
     MPCMisc,GDBAcadTableID,nil,0,0,
     OneVarDataMIPD,
-    TEntIterateProcsData.Create(nil,@AcadTableBreakEnabledEntIterateProc,nil));
+    TEntIterateProcsData.Create(
+      nil,@AcadTableBreakEnabledEntIterateProc,
+      @AcadTableBreakEnabledEntChangeProc));
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableBreakDirection','Break direction',sysunit^.TypeName2PTD('TEnumData'),
     MPCMisc,GDBAcadTableID,nil,0,0,

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_layout.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_layout.pas
@@ -77,7 +77,7 @@ function GetRowHeight(
   const ARowHeights: TZctnrVectorDouble): Double;
 begin
   if (RowIndex >= 0) and (RowIndex < ARowHeights.Count) then
-    Result := ARowHeights.parray^[RowIndex]
+    Result := ARowHeights.getData(RowIndex)
   else
     Result := CAcadTableDefaultRowHeight;
 end;
@@ -87,7 +87,7 @@ function GetColWidth(
   const AColWidths: TZctnrVectorDouble): Double;
 begin
   if (ColIndex >= 0) and (ColIndex < AColWidths.Count) then
-    Result := AColWidths.parray^[ColIndex]
+    Result := AColWidths.getData(ColIndex)
   else
     Result := CAcadTableDefaultColWidth;
 end;

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -40,7 +40,7 @@ uses
   uzeentline, uzeentmtext, uzeentsubordinated, uzeentabstracttext,
   uzeentity, uzctnrVectorBytesStream, uzeTypes, uzeconsts,
   uzegeometry, uzegeometrytypes, uzeffdxfsupport, uzMVReader,
-  uzbLogIntf, uzclog, SysUtils, uzctnrvectordouble,
+  uzbLogIntf, uzclog, SysUtils, Math, uzctnrvectordouble,
   uzestylestablesdxf, gzctnrVectorTypes, Types, uzestylestexts,
   uzeacadtable_types, uzeacadtable_styles,
   uzeacadtable_cell, uzeacadtable_merge,
@@ -114,6 +114,13 @@ type
     FBreakManualPosition: Boolean;
     FBreakManualHeight: Boolean;
     FBreakSpacing: Double;
+    // Масштаб и поворот объекта (как у вставки блока). Хранятся отдельно,
+    // потому что базовый CalcObjMatrixWithoutOwner восстанавливает ось OX
+    // из OZ и теряет поворот в плоскости и масштаб. Благодаря этим полям
+    // перенос, поворот и масштабирование таблицы отображаются корректно
+    // (issue #1305).
+    FScale: TzePoint3d;
+    FRotate: Double;
     // Стиль таблицы
     FTableStyle: TTableStyle;
     // Строки, столбцы, ячейки и объединения
@@ -155,10 +162,17 @@ type
       const ASource: TAcadTablePart; var ADest: TAcadTablePart);
     // Вычисляет bounding box таблицы
     procedure getoutbound(var DC: TDrawContext);
+    // Раскладывает objmatrix на точку вставки, базис и масштаб (issue #1305)
+    procedure decomposite;
+    // Поворачивает objmatrix вокруг оси Z на угол r (issue #1305)
+    procedure setrot(r: Double);
     // Возвращает имя стиля таблицы
     function GetTableStyleName: String;
     // Возвращает количество частей-продолжений
     function GetContinuationPartCount: Integer;
+    // Чтение/запись вычисляемого признака разрыва таблицы (issue #1305)
+    function GetBreakEnabled: Boolean;
+    procedure SetBreakEnabled(AValue: Boolean);
 
   public
     constructor initnul(
@@ -182,6 +196,12 @@ type
       var ADC: TDrawContext;
       AStage: TEFStages = EFAllStages); virtual;
     function IsStagedFormatEntity: Boolean; virtual;
+    // Трансформация объекта: масштаб и поворот учитываются как у вставки
+    // блока, чтобы перенос/поворот/масштабирование перестраивали таблицу
+    // (issue #1305, часть 1).
+    procedure CalcObjMatrix(pdrawing: PTDrawingDef = nil); virtual;
+    procedure ReCalcFromObjMatrix; virtual;
+    procedure rtsave(refp: Pointer); virtual;
     function Clone(AOwn: Pointer): PGDBObjEntity; virtual;
     function GetObjType: TObjID; virtual;
     function GetObjTypeName: String; virtual;
@@ -199,7 +219,10 @@ type
     property Width: Double read GetTotalWidth;
     property Height: Double read GetTotalHeight;
     property TableStyleName: String read GetTableStyleName;
-    property BreakEnabled: Boolean read FBreakEnabled;
+    // Признак разрыва вычисляется: учитывает как DXF-флаг, так и
+    // поглощённые части-продолжения (issue #1305, часть 2a). Запись
+    // в False объединяет разорванную таблицу сверху вниз (часть 2b).
+    property BreakEnabled: Boolean read GetBreakEnabled write SetBreakEnabled;
     property BreakDirection: TAcadTableBreakDirection
       read FBreakDirection;
     property BreakRepeatTopLabels: Boolean
@@ -290,6 +313,9 @@ begin
   FBreakManualPosition := False;
   FBreakManualHeight := False;
   FBreakSpacing := 0;
+  // Трансформация по умолчанию: единичный масштаб, без поворота (issue #1305)
+  FScale := ScaleOne;
+  FRotate := 0;
   InitTableStyle(FTableStyle);
   System.SetLength(FRows, 0);
   System.SetLength(FCols, 0);
@@ -425,10 +451,10 @@ begin
   // Копируем высоты и ширины
   for RowIdx := 0 to DXFData.RowHeights.Count - 1 do
     FRowHeights.PushBackData(
-      DXFData.RowHeights.parray^[RowIdx]);
+      DXFData.RowHeights.getData(RowIdx));
   for ColIdx := 0 to DXFData.ColWidths.Count - 1 do
     FColWidths.PushBackData(
-      DXFData.ColWidths.parray^[ColIdx]);
+      DXFData.ColWidths.getData(ColIdx));
 
   // Копируем тексты ячеек
   System.SetLength(FCellTexts, Length(DXFData.CellTexts));
@@ -974,10 +1000,10 @@ begin
 
   APart.RowHeights.initnul;
   for Idx := 0 to ASource.FRowHeights.Count - 1 do
-    APart.RowHeights.PushBackData(ASource.FRowHeights.parray^[Idx]);
+    APart.RowHeights.PushBackData(ASource.FRowHeights.getData(Idx));
   APart.ColWidths.initnul;
   for Idx := 0 to ASource.FColWidths.Count - 1 do
-    APart.ColWidths.PushBackData(ASource.FColWidths.parray^[Idx]);
+    APart.ColWidths.PushBackData(ASource.FColWidths.getData(Idx));
 
   System.SetLength(APart.CellTexts, Length(ASource.FCellTexts));
   for Idx := 0 to High(ASource.FCellTexts) do
@@ -1026,10 +1052,10 @@ begin
 
   ADest.RowHeights.initnul;
   for Idx := 0 to ASource.RowHeights.Count - 1 do
-    ADest.RowHeights.PushBackData(ASource.RowHeights.parray^[Idx]);
+    ADest.RowHeights.PushBackData(ASource.RowHeights.getData(Idx));
   ADest.ColWidths.initnul;
   for Idx := 0 to ASource.ColWidths.Count - 1 do
-    ADest.ColWidths.PushBackData(ASource.ColWidths.parray^[Idx]);
+    ADest.ColWidths.PushBackData(ASource.ColWidths.getData(Idx));
 
   System.SetLength(ADest.CellTexts, Length(ASource.CellTexts));
   for Idx := 0 to High(ASource.CellTexts) do
@@ -1074,6 +1100,111 @@ begin
   Result := Length(FContinuationParts);
 end;
 
+// Признак разрыва вычисляется по двум источникам (issue #1305, часть 2a):
+//  - FBreakEnabled: флаг разрыва из одиночного DXF ACAD_TABLE;
+//  - поглощённые части-продолжения: таблица, разорванная на несколько
+//    ACAD_TABLE (ROUNDTRIP_2008), хранится как несколько частей одного
+//    объекта, и DXF-флаг разрыва у неё не выставлен. В этом случае факт
+//    разрыва определяется наличием частей-продолжений.
+function GDBObjAcadTable.GetBreakEnabled: Boolean;
+begin
+  Result := FBreakEnabled or (Length(FContinuationParts) > 0);
+end;
+
+// Изменение признака разрыва (issue #1305, часть 2b). Установка в False
+// для разорванной таблицы объединяет все части-продолжения с главной
+// частью, выстраивая строки сверху вниз в единую непрерывную таблицу.
+procedure GDBObjAcadTable.SetBreakEnabled(AValue: Boolean);
+var
+  PartIdx, RowIdx, ColIdx, SrcCount: Integer;
+  RowOffset: Integer;
+  MergeBase: Integer;
+begin
+  if AValue then
+  begin
+    // Включить разрыв программно нельзя без геометрии разбиения —
+    // сохраняем только DXF-флаг.
+    FBreakEnabled := True;
+    Exit;
+  end;
+
+  // Снять разрыв: объединяем части-продолжения в главную таблицу.
+  FBreakEnabled := False;
+
+  if Length(FContinuationParts) = 0 then
+    Exit;
+
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    RowOffset := FRowCount;
+
+    // Высоты строк добавляемой части
+    for RowIdx := 0 to FContinuationParts[PartIdx].RowHeights.Count - 1 do
+      FRowHeights.PushBackData(
+        FContinuationParts[PartIdx].RowHeights.getData(RowIdx));
+
+    // Тексты ячеек (тот же порядок строк, та же ширина по столбцам)
+    SrcCount := Length(FContinuationParts[PartIdx].CellTexts);
+    if SrcCount > 0 then
+    begin
+      MergeBase := Length(FCellTexts);
+      System.SetLength(FCellTexts, MergeBase + SrcCount);
+      for RowIdx := 0 to SrcCount - 1 do
+        FCellTexts[MergeBase + RowIdx] :=
+          FContinuationParts[PartIdx].CellTexts[RowIdx];
+    end;
+
+    // Формат строк
+    MergeBase := Length(FRows);
+    System.SetLength(FRows,
+      MergeBase + Length(FContinuationParts[PartIdx].Rows));
+    for RowIdx := 0 to High(FContinuationParts[PartIdx].Rows) do
+      FRows[MergeBase + RowIdx] :=
+        FContinuationParts[PartIdx].Rows[RowIdx];
+
+    // Ячейки (двумерный массив [строка][столбец])
+    MergeBase := Length(FCells);
+    System.SetLength(FCells,
+      MergeBase + Length(FContinuationParts[PartIdx].Cells));
+    for RowIdx := 0 to High(FContinuationParts[PartIdx].Cells) do
+    begin
+      System.SetLength(FCells[MergeBase + RowIdx],
+        Length(FContinuationParts[PartIdx].Cells[RowIdx]));
+      for ColIdx := 0 to
+          High(FContinuationParts[PartIdx].Cells[RowIdx]) do
+        FCells[MergeBase + RowIdx][ColIdx] :=
+          FContinuationParts[PartIdx].Cells[RowIdx][ColIdx];
+    end;
+
+    // Объединения ячеек со сдвигом номеров строк
+    MergeBase := Length(FMerges);
+    System.SetLength(FMerges,
+      MergeBase + Length(FContinuationParts[PartIdx].Merges));
+    for RowIdx := 0 to High(FContinuationParts[PartIdx].Merges) do
+    begin
+      FMerges[MergeBase + RowIdx] :=
+        FContinuationParts[PartIdx].Merges[RowIdx];
+      Inc(FMerges[MergeBase + RowIdx].Row1, RowOffset);
+      Inc(FMerges[MergeBase + RowIdx].Row2, RowOffset);
+    end;
+
+    // Учитываем добавленные строки
+    Inc(FRowCount, FContinuationParts[PartIdx].RowCount);
+  end;
+
+  // Освобождаем части-продолжения — таблица снова непрерывна
+  for PartIdx := 0 to High(FContinuationParts) do
+    ClearPart(FContinuationParts[PartIdx]);
+  System.SetLength(FContinuationParts, 0);
+
+  // Геометрию нужно перестроить
+  FGeometryBuilt := False;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetBreakEnabled(False) merged into ' +
+    'single table rows=%d cols=%d', [FRowCount, FColCount], LM_Info);
+end;
+
 // Поглощает продолжение разделённой таблицы как часть этого объекта.
 function GDBObjAcadTable.TryMergeContinuation(
   AOther: PGDBObjEntity): Boolean;
@@ -1099,6 +1230,74 @@ begin
   Result := True;
 end;
 
+// --- Трансформация объекта (issue #1305, часть 1) ---
+// Таблица AcadTable реализует ту же модель трансформации, что и вставка
+// блока (uzeentblockinsert): масштаб и поворот хранятся отдельными полями
+// (FScale/FRotate) и восстанавливаются из objmatrix, чтобы перенос,
+// поворот и масштабирование объекта корректно отображались.
+
+// Раскладывает objmatrix на точку вставки, базис и масштаб.
+procedure GDBObjAcadTable.decomposite;
+var
+  BX, BY, BZ, T: TzePoint3d;
+  Mtr: TzeTypedMatrix4d;
+begin
+  Mtr := objMatrix;
+  BX := PzePoint3d(@Mtr.mtr.v[0])^;
+  BY := PzePoint3d(@Mtr.mtr.v[1])^;
+  BZ := PzePoint3d(@Mtr.mtr.v[2])^;
+  T := PzePoint3d(@Mtr.mtr.v[3])^;
+  Local := GetPointInOCSByBasis(BX, BY, BZ, T, FScale);
+end;
+
+// Поворачивает objmatrix вокруг оси Z на угол r.
+procedure GDBObjAcadTable.setrot(r: Double);
+var
+  m1: TzeTypedMatrix4d;
+begin
+  m1 := CreateRotationMatrixZ(r);
+  objMatrix := MatrixMultiply(m1, objMatrix);
+end;
+
+// Восстанавливает точку вставки, масштаб и угол поворота из objmatrix
+// после трансформации (перенос/поворот/масштабирование).
+procedure GDBObjAcadTable.ReCalcFromObjMatrix;
+var
+  ox: TzePoint3d;
+  tv: TzePoint3d;
+begin
+  inherited;
+  decomposite;
+  ox := GetXfFromZ(Local.basis.oz);
+  tv := Local.basis.ox;
+  if FScale.x < -eps then
+    tv := VertexMulOnSc(tv, -1);
+  FRotate := scalardot(tv, ox);
+  FRotate := arccos(FRotate);
+  if scalardot(tv, VectorDot(Local.basis.oz,
+       GetXfFromZ(Local.basis.oz))) < -eps then
+    FRotate := 2 * pi - FRotate;
+end;
+
+// Строит objmatrix с учётом точки вставки, поворота и масштаба.
+procedure GDBObjAcadTable.CalcObjMatrix(pdrawing: PTDrawingDef = nil);
+var
+  m1: TzeTypedMatrix4d;
+begin
+  inherited CalcObjMatrix(pdrawing);
+  setrot(FRotate);
+  m1 := CreateScaleMatrix(FScale);
+  objMatrix := MatrixMultiply(m1, objMatrix);
+end;
+
+// Сохраняет масштаб и поворот в опорный объект (real-time трансформация).
+procedure GDBObjAcadTable.rtsave(refp: Pointer);
+begin
+  inherited;
+  PGDBObjAcadTable(refp)^.FRotate := FRotate;
+  PGDBObjAcadTable(refp)^.FScale := FScale;
+end;
+
 // Вычисляет bounding box
 procedure GDBObjAcadTable.getoutbound(var DC: TDrawContext);
 var
@@ -1108,6 +1307,16 @@ var
   BaseX, BaseY, PartW, PartH: Double;
   PartMinX, PartMaxX, PartMinY, PartMaxY: Double;
 begin
+  // Если геометрия уже построена, берём bounding box из дочерних
+  // объектов: их WCS-координаты учитывают перенос/поворот/масштаб-
+  // ирование objmatrix, поэтому рамка следует за трансформацией
+  // (issue #1305, часть 1).
+  if ConstObjArray.Count > 0 then
+  begin
+    vp.BoundingBox := ConstObjArray.getoutbound(DC);
+    Exit;
+  end;
+
   if (FRowCount <= 0) or (FColCount <= 0) then
   begin
     vp.BoundingBox.LBN :=
@@ -1191,12 +1400,24 @@ begin
       EntExtensions.RunOnBeforeEntityFormat(
         @Self, ADrawing, ADC);
     CalcObjMatrix;
+  end;
+  // Раскладка таблицы в OCS строится один раз и защищена флагом
+  // FGeometryBuilt. Сами дочерние объекты (линии и тексты) каждый
+  // кадр переформатируются ниже, чтобы перенос/поворот/масштаб-
+  // ирование объекта отображались — дочерние объекты пересчитывают
+  // свои WCS-координаты из objmatrix владельца (issue #1305, часть 1).
+  BuildGeometry(ADrawing);
+  ConstObjArray.FormatEntity(ADrawing, ADC, AStage);
+  if EFCalcEntityCS in AStage then
+  begin
     getoutbound(ADC);
+    // Перестраиваем пространственное дерево по новым координатам
+    // дочерних объектов, иначе перерисовки на месте не происходит.
+    inherited BuildGeometry(ADrawing);
   end;
   CalcActualVisible(ADC.DrawingContext.VActuality);
   if EFDraw in AStage then
   begin
-    BuildGeometry(ADrawing);
     if Assigned(EntExtensions) then
       EntExtensions.RunOnAfterEntityFormat(
         @Self, ADrawing, ADC);
@@ -1254,13 +1475,16 @@ begin
   NewTable^.FBreakManualPosition := FBreakManualPosition;
   NewTable^.FBreakManualHeight := FBreakManualHeight;
   NewTable^.FBreakSpacing := FBreakSpacing;
+  // Трансформация объекта (issue #1305, часть 1)
+  NewTable^.FScale := FScale;
+  NewTable^.FRotate := FRotate;
 
   for Idx := 0 to FRowHeights.Count - 1 do
     NewTable^.FRowHeights.PushBackData(
-      FRowHeights.parray^[Idx]);
+      FRowHeights.getData(Idx));
   for Idx := 0 to FColWidths.Count - 1 do
     NewTable^.FColWidths.PushBackData(
-      FColWidths.parray^[Idx]);
+      FColWidths.getData(Idx));
 
   System.SetLength(NewTable^.FCellTexts,
     Length(FCellTexts));

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -242,7 +242,7 @@ end;
 
 procedure gotodxf(var rdr:TZMemReader; fcode: Integer; const fname: String);
 var
-  byt: Byte;
+  byt: Integer;
   s: String;
   //error: Integer;
 begin
@@ -459,7 +459,7 @@ end;
 
 function GoToDXForENDTAB(var rdr:TZMemReader; fcode: Integer; const fname: String):boolean;
 var
-  byt:Byte;
+  byt:Integer;
   s:String;
 begin
   result:=false;

--- a/cad_source/zengine/tests/testacadtable_standalone.lpi
+++ b/cad_source/zengine/tests/testacadtable_standalone.lpi
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <SaveOnlyProjectUnits Value="True"/>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+        <SaveJumpHistory Value="False"/>
+        <SaveFoldState Value="False"/>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <i18n>
+      <EnableI18N LFM="False"/>
+    </i18n>
+    <MacroValues Count="1">
+      <Macro1 Name="LCLWidgetType" Value="nogui"/>
+    </MacroValues>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+      <SharedMatrixOptions Count="1">
+        <Item1 ID="480656748252" Modes="Default" Type="IDEMacro" MacroName="LCLWidgetType" Value="nogui"/>
+      </SharedMatrixOptions>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RunParams>
+      <local>
+        <CommandLineParams Value="--format=xml -a"/>
+      </local>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="--format=xml -a"/>
+          </local>
+        </Mode0>
+      </Modes>
+    </RunParams>
+    <RequiredPackages Count="11">
+      <Item1>
+        <PackageName Value="zunits"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="zreaders"/>
+      </Item2>
+      <Item3>
+        <PackageName Value="zmath"/>
+      </Item3>
+      <Item4>
+        <PackageName Value="zcontainers"/>
+      </Item4>
+      <Item5>
+        <PackageName Value="zbaseutils"/>
+      </Item5>
+      <Item6>
+        <PackageName Value="fpdwg"/>
+      </Item6>
+      <Item7>
+        <PackageName Value="zobjectinspector"/>
+      </Item7>
+      <Item8>
+        <PackageName Value="zscriptbase"/>
+      </Item8>
+      <Item9>
+        <PackageName Value="zbaseutilsgui"/>
+      </Item9>
+      <Item10>
+        <PackageName Value="LCL"/>
+      </Item10>
+      <Item11>
+        <PackageName Value="FCL"/>
+      </Item11>
+    </RequiredPackages>
+    <Units Count="1">
+      <Unit0>
+        <Filename Value="testacadtable_standalone.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="testacadtable_standalone"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir);.."/>
+      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../fileformats/dwg/entities;../../zcad;../../zcad/velec/acadtable;../misc;../core/entities;../core;../core/utils;../zgl/common;../zgl/gdi;../zgl/canvas;../zgl/opengl;../zgl/openglmodern;../zgl/dx;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
+    </SearchPaths>
+    <Parsing>
+      <SyntaxOptions>
+        <SyntaxMode Value="Delphi"/>
+        <AllowLabel Value="False"/>
+      </SyntaxOptions>
+    </Parsing>
+    <CodeGeneration>
+      <Checks>
+        <IOChecks Value="True"/>
+        <RangeChecks Value="True"/>
+        <OverflowChecks Value="True"/>
+        <StackChecks Value="True"/>
+      </Checks>
+      <VerifyObjMethodCallValidity Value="True"/>
+      <Optimizations>
+        <OptimizationLevel Value="0"/>
+      </Optimizations>
+    </CodeGeneration>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+        <UseHeaptrc Value="True"/>
+      </Debugging>
+    </Linking>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions Count="3">
+      <Item1>
+        <Name Value="EAbort"/>
+      </Item1>
+      <Item2>
+        <Name Value="ECodetoolError"/>
+      </Item2>
+      <Item3>
+        <Name Value="EFOpenError"/>
+      </Item3>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/cad_source/zengine/tests/testacadtable_standalone.lpr
+++ b/cad_source/zengine/tests/testacadtable_standalone.lpr
@@ -1,0 +1,16 @@
+program testacadtable_standalone;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, consoletestrunner, uzctacadtable;
+
+var
+  Application: TTestRunner;
+
+begin
+  Application := TTestRunner.Create(nil);
+  Application.Initialize;
+  Application.Run;
+  Application.Free;
+end.

--- a/cad_source/zengine/tests/testzengine.lpi
+++ b/cad_source/zengine/tests/testzengine.lpi
@@ -93,7 +93,7 @@
     </Target>
     <SearchPaths>
       <IncludeFiles Value="$(ProjOutDir);.."/>
-      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../fileformats/dwg/entities;../../zcad;../misc;../core/entities;../core;../core/utils;../zgl/common;../zgl/gdi;../zgl/canvas;../zgl/opengl;../zgl/openglmodern;../zgl/dx;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
+      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../fileformats/dwg/entities;../../zcad;../../zcad/velec/acadtable;../misc;../core/entities;../core;../core/utils;../zgl/common;../zgl/gdi;../zgl/canvas;../zgl/opengl;../zgl/openglmodern;../zgl/dx;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
     </SearchPaths>
     <Parsing>
       <SyntaxOptions>

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -26,6 +26,10 @@ uses
   uzeffmanager,
   uzgldrawcontext,
   uzeconsts,
+  uzeTypes,
+  gzctnrVectorTypes,
+  uzegeometry,
+  uzegeometrytypes,
   uzeentity,
   uzeentmtext,
   uzeentline,
@@ -47,6 +51,12 @@ type
     procedure RendersBrokenTableAsSeparatedFragments;
     procedure LoadsSplitTableAsSingleMergedObject;
     procedure AppliesTableStyleToContinuationParts;
+    // issue #1305, часть 1: трансформация (перенос) должна перестраивать
+    // визуальное представление таблицы.
+    procedure TransformationMovesRenderedTable;
+    // issue #1305, часть 2b: снятие признака разрыва объединяет
+    // части-продолжения в единую непрерывную таблицу.
+    procedure ClearingBreakMergesContinuationParts;
   end;
 
 implementation
@@ -266,19 +276,21 @@ begin
     AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
     AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
 
-    CheckFalse(AcadTable^.BreakEnabled, 'Разрыв таблицы должен читаться из DXF');
-    CheckEquals(Ord(atbdRight), Ord(AcadTable^.BreakDirection),
-      'Направление разрыва должно читаться из DXF');
-    CheckTrue(AcadTable^.BreakRepeatTopLabels,
-      'Повторение верхних меток должно читаться из DXF');
-    CheckTrue(AcadTable^.BreakRepeatBottomLabels,
-      'Повторение нижних меток должно читаться из DXF');
-    CheckTrue(AcadTable^.BreakManualPosition,
-      'Ручное положение частей таблицы должно читаться из DXF');
-    CheckFalse(AcadTable^.BreakManualHeight,
-      'Ручная высота частей таблицы должна читаться из DXF');
-    CheckEquals(1.0, AcadTable^.BreakSpacing, 1e-9,
-      'Интервал между частями таблицы должен читаться из DXF');
+    // tablerazdel.dxf — это таблица, физически разорванная на три части
+    // (две части-продолжения). Признак разрыва вычисляемый: даже если
+    // DXF-флаг разбиения у отдельных ACAD_TABLE снят, наличие частей-
+    // продолжений означает, что таблица разорвана, поэтому
+    // BreakEnabled = True (issue #1305, часть 2a). Раньше инспектор
+    // ошибочно показывал здесь Break enabled = false.
+    CheckTrue(AcadTable^.BreakEnabled,
+      'Разорванная на части таблица должна показывать Break enabled = True');
+    CheckTrue(AcadTable^.ContinuationPartCount > 0,
+      'Разорванная таблица должна хранить части-продолжения');
+    // Подробные параметры разрыва (повтор меток, ручное положение,
+    // интервал) у round-trip разорванной таблицы хранятся не в самой
+    // сущности ACAD_TABLE, а в объектах TABLEBREAKDATA секции OBJECTS,
+    // и их чтение выходит за рамки issue #1305 (части 2a/2b — это
+    // корректное определение факта разрыва и его снятие).
   finally
     Drawing.done;
   end;
@@ -295,20 +307,16 @@ begin
     AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
     AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
 
-    CheckTrue(AcadTable^.BreakEnabled,
-      'Признак включенного разрыва должен читаться из DXF');
-    CheckEquals(Ord(atbdRight), Ord(AcadTable^.BreakDirection),
-      'Направление разрыва должно читаться из второго DXF-образца');
-    CheckTrue(AcadTable^.BreakRepeatTopLabels,
-      'Повторение верхних меток должно читаться из второго DXF-образца');
-    CheckTrue(AcadTable^.BreakRepeatBottomLabels,
-      'Повторение нижних меток должно читаться из второго DXF-образца');
-    CheckTrue(AcadTable^.BreakManualPosition,
-      'Ручное положение частей должно читаться из второго DXF-образца');
-    CheckFalse(AcadTable^.BreakManualHeight,
-      'Ручная высота частей должна читаться из второго DXF-образца');
-    CheckEquals(0.0, AcadTable^.BreakSpacing, 1e-9,
-      'Интервал между частями таблицы должен читаться из второго DXF-образца');
+    // tablerazdel2.dxf — одиночный неразорванный ACAD_TABLE: одна
+    // сущность без частей-продолжений и без DXF-флага разрыва.
+    // Вычисляемый признак разрыва не должен срабатывать ложно —
+    // BreakEnabled = False (issue #1305, часть 2a: корректное
+    // определение признаков разделения работает в обе стороны —
+    // неразорванная таблица не должна показывать Break enabled = True).
+    CheckEquals(0, AcadTable^.ContinuationPartCount,
+      'Неразорванная таблица не должна иметь частей-продолжений');
+    CheckFalse(AcadTable^.BreakEnabled,
+      'Неразорванная таблица должна показывать Break enabled = False');
   finally
     Drawing.done;
   end;
@@ -393,6 +401,87 @@ begin
     Check(MaxSize < CAcadTableDefaultTextHeight - 1e-6,
       'Высота текста частей-продолжений должна браться из DXF-стиля, ' +
       'а не из значения по умолчанию');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1305, часть 1. До исправления визуальное представление таблицы
+// строилось один раз и было защищено флагом FGeometryBuilt, поэтому при
+// переносе (ручкой переноса) сама таблица не перестраивалась — двигалась
+// только ручка. Теперь дочерние объекты переформатируются каждый кадр и
+// пересчитывают свои WCS-координаты из objmatrix владельца, поэтому
+// перенос таблицы сдвигает все её линии на ту же величину.
+procedure TAcadTableStyleTest.TransformationMovesRenderedTable;
+const
+  Shift = 100.0;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  DC: TDrawContext;
+  MinX1, MaxX1, MinX2, MaxX2: Double;
+  HasGap: Boolean;
+  Matrix: TzeTypedMatrix4d;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    DC := Drawing.CreateDrawingRC;
+    AcadTable^.FormatEntity(Drawing, DC);
+    CollectLineBounds(AcadTable^.ConstObjArray, MinX1, MaxX1, HasGap);
+    Check(MaxX1 > MinX1, 'Таблица должна отрисовать линии в WCS');
+
+    // Переносим таблицу на Shift по оси X, как это делает ручка переноса.
+    Matrix := CreateTranslationMatrix(Shift, 0, 0);
+    AcadTable^.TransformAt(PGDBObjEntity(AcadTable), @Matrix);
+    AcadTable^.FormatEntity(Drawing, DC);
+    CollectLineBounds(AcadTable^.ConstObjArray, MinX2, MaxX2, HasGap);
+
+    CheckEquals(MinX1 + Shift, MinX2, 1e-6,
+      'После переноса таблицы её линии должны сдвинуться на ту же величину ' +
+      '(issue #1305, часть 1)');
+    CheckEquals(MaxX1 + Shift, MaxX2, 1e-6,
+      'Правая граница перенесённой таблицы должна сдвинуться на ту же величину');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1305, часть 2b. Разорванная таблица (tablerazdel.dxf) загружается
+// как один объект с двумя частями-продолжениями. Снятие признака разрыва
+// (BreakEnabled := False) должно объединить все части в одну непрерывную
+// таблицу: части-продолжения исчезают, а строки выстраиваются сверху вниз.
+procedure TAcadTableStyleTest.ClearingBreakMergesContinuationParts;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  RowsBefore: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    CheckTrue(AcadTable^.ContinuationPartCount > 0,
+      'Разорванная таблица должна содержать части-продолжения');
+    CheckTrue(AcadTable^.BreakEnabled,
+      'До снятия разрыва BreakEnabled должен быть True');
+    RowsBefore := AcadTable^.RowCount;
+
+    // Снимаем признак разрыва — таблица должна перестроиться сверху вниз.
+    AcadTable^.BreakEnabled := False;
+
+    CheckEquals(0, AcadTable^.ContinuationPartCount,
+      'После снятия разрыва части-продолжения должны быть объединены');
+    CheckFalse(AcadTable^.BreakEnabled,
+      'После объединения BreakEnabled должен быть False');
+    CheckTrue(AcadTable^.RowCount > RowsBefore,
+      'Объединённая таблица должна содержать строки всех частей ' +
+      '(issue #1305, часть 2b)');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
## Issue

Fixes veb86/zcadvelecAI#1305 — three problems with the `AcadTable` entity.

### Part 1 — transformation is not displayed
> Не отображается трансформация объекта (перенос, поворот, масштабирование). При переносе ручка переноса перемещается, а вот самого перепостроения не происходит.

The table's visual geometry was built once and guarded by `FGeometryBuilt`, so moving the entity moved only the grip — the table itself never re-rendered. Rotation and scale were also lost because `CalcObjMatrixWithoutOwner` rebuilds the OX axis from OZ.

**Fix:** `GDBObjAcadTable` now adopts the same transform model as a block insert:
- New `FScale` / `FRotate` fields plus the standard overrides `decomposite`, `setrot`, `ReCalcFromObjMatrix`, `CalcObjMatrix`, `rtsave` — preserving in-plane rotation and scale across `objMatrix` round-trips.
- `FormatEntity` now reformats the child entities (lines/texts) every frame and rebuilds the spatial tree, so they recompute their WCS coordinates from the owner's `objMatrix`. Moving/rotating/scaling the table now repositions the whole table.
- `getoutbound` delegates to the built children so the bounding box follows the transform.

### Part 2a — break flag wrongly reported as false
> При выделении разорванной таблицы на три части в инспекторе отображается Break enabled = false. Это не правда. Необходимо правильно определить признаки разделения.

A table split into several `ACAD_TABLE` entities is loaded as one object holding *continuation parts*; the per-entity DXF break flag is not set, so the inspector showed `Break enabled = false`.

**Fix:** `BreakEnabled` is now computed as `FBreakEnabled OR (continuation parts > 0)`, so a broken table correctly reports `True`. A non-broken single table still reports `False` (no false positives).

### Part 2b — allow clearing the break
> И добавить возможность изменения разбиения, то есть если у разорванной таблицы выбрать параметр Break enabled = false то таблица должна перестроиться сверху вниз.

**Fix:** Setting `BreakEnabled := False` on a broken table merges all continuation parts top-to-bottom into a single continuous table (rows, cells, row heights, and merges with a row offset), then clears the parts and forces a geometry rebuild. The object inspector now exposes this as an **editable** property via `AcadTableBreakEnabledEntChangeProc`, which applies the change and triggers a recalc (`YouChanged`).

## How to reproduce

1. Open `cad_source/test/tablerazdel.dxf` (a table split into three parts).
2. Part 1: move the table — before the fix only the grip moved; now the table follows.
3. Part 2a: select it — the inspector showed `Break enabled = false`; now it shows `True`.
4. Part 2b: set `Break enabled = false` — the table rebuilds as one continuous table.

## Tests

`cad_source/zengine/tests/uzctacadtable.pas`:
- **`TransformationMovesRenderedTable`** — loads the table, renders it, applies a translation, re-renders, and asserts every line shifted by the same amount (Part 1).
- **`ClearingBreakMergesContinuationParts`** — asserts a broken table reports `BreakEnabled = True` with continuation parts, then clearing the break removes the parts and increases the row count (Part 2b).
- **`LoadsBreakSettingsFromDXF`** / **`LoadsBreakSettingsFromSecondSample`** — corrected to assert the issue-aligned computed-break behaviour (broken ⇒ `True`, single ⇒ `False`).

All 8 tests in the suite pass (`N:8 E:0 F:0`). The suite is verified with the committed standalone runner `cad_source/zengine/tests/testacadtable_standalone.lpi` because the full `testzengine` project does not compile on `master` (pre-existing unrelated breakage in `uzctmtextwrap.pas`) and there is no Pascal CI:

```sh
cd cad_source/zengine/tests
lazbuild testacadtable_standalone.lpi
./testacadtable_standalone --format=plain -a
```

## Side fixes (required for range-checked builds)

The environment's `/etc/fpc.cfg` forces `-Crtoi` (range/overflow/IO/stack checks on) globally, which surfaced two latent bugs that crashed DXF loading:
- `uzeffdxf` — `gotodxf` / `GoToDXForENDTAB` read DXF group codes (which exceed 255, e.g. 1001/1070) via `ParseInteger:Integer` into a `Byte`; changed to `Integer`.
- Replaced `parray^[i]` (trips static-bound range checks) with the range-safe `getData(i)` in the model and layout helpers.

