### PR TITLE
AcadTable: editable Break spacing + new editable Break height (issue #1307)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
 # Updated: 2026-06-10T10:51:04.132Z
+# Updated: 2026-06-10T14:08:54.518Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
 # Updated: 2026-06-10T10:51:04.132Z
-# Updated: 2026-06-10T14:08:54.518Z

--- a/cad_source/zcad/register/uzcregacadtable.pas
+++ b/cad_source/zcad/register/uzcregacadtable.pas
@@ -235,7 +235,9 @@ begin
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
 end;
 
-// Чтение интервала между частями разбиения (только чтение)
+// Чтение интервала между частями разбиения (issue #1307, часть 1).
+// Свойство редактируемое: при наличии change-процедуры (@ecp<>nil) флаг
+// vda_RO не выставляется, поэтому значение можно менять в инспекторе.
 procedure AcadTableBreakSpacingEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
   mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
   const f:TzeUnitsFormat);
@@ -249,6 +251,75 @@ begin
   v:=PGDBObjAcadTable(ChangedData.PEntity)^.BreakSpacing;
   ChangedData.PGetDataInEtity:=@v;
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+// Запись интервала между частями разбиения (issue #1307, часть 1).
+// Изменение интервала смещает части-продолжения относительно главной части
+// (вся геометрия пересчитывается в GDBObjAcadTable.SetBreakSpacing ->
+// RepositionContinuationParts). После изменения вызывается YouChanged,
+// чтобы дерево чертежа перестроило геометрию таблицы.
+procedure AcadTableBreakSpacingEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  Table:PGDBObjAcadTable;
+  NewValue:Double;
+begin
+  Table:=PGDBObjAcadTable(ChangedData.PEntity);
+  NewValue:=PDouble(pvardesk(pdata)^.data.Addr.Instance)^;
+  if Table^.BreakSpacing=NewValue then
+    exit;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  Table^.BreakSpacing:=NewValue;
+  if drawings.GetCurrentDWG<>nil then
+    Table^.YouChanged(drawings.GetCurrentDWG^);
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
+end;
+
+// Чтение высоты разбиения (issue #1307, часть 2).
+// Свойство редактируемое: при наличии change-процедуры флаг vda_RO не
+// выставляется.
+procedure AcadTableBreakHeightEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
+  mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
+  const f:TzeUnitsFormat);
+var
+  PVD:pvardesk;
+  v:Double;
+begin
+  PVD:=PTOneVarData(pdata)^.VDAddr.Instance;
+  if @ecp=nil then
+    ProcessVariableAttributes(PVD^.attrib,vda_RO,0);
+  v:=PGDBObjAcadTable(ChangedData.PEntity)^.BreakHeight;
+  ChangedData.PGetDataInEtity:=@v;
+  GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+// Запись высоты разбиения (issue #1307, часть 2).
+// Изменение высоты пересегментирует таблицу: строки перераспределяются по
+// частям так, чтобы суммарная высота строк в каждой части не превышала
+// заданного порога, число частей определяется автоматически (вся работа
+// выполняется в GDBObjAcadTable.SetBreakHeight). После изменения вызывается
+// YouChanged для пересчёта геометрии.
+procedure AcadTableBreakHeightEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  Table:PGDBObjAcadTable;
+  NewValue:Double;
+begin
+  Table:=PGDBObjAcadTable(ChangedData.PEntity);
+  NewValue:=PDouble(pvardesk(pdata)^.data.Addr.Instance)^;
+  if Table^.BreakHeight=NewValue then
+    exit;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  Table^.BreakHeight:=NewValue;
+  if drawings.GetCurrentDWG<>nil then
+    Table^.YouChanged(drawings.GetCurrentDWG^);
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
 end;
 
 // Подготовка списка значений направления разбиения для комбобокса.
@@ -395,11 +466,23 @@ begin
     MPCMisc,GDBAcadTableID,nil,0,0,
     OneVarDataMIPD,
     TEntIterateProcsData.Create(nil,@AcadTableBreakManualHeightEntIterateProc,nil));
+  {Break spacing и Break height редактируются (issue #1307):
+   изменение интервала смещает части-продолжения, изменение высоты
+   пересегментирует таблицу с автоопределением числа частей.}
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableBreakSpacing','Break spacing',sysunit^.TypeName2PTD('Double'),
     MPCMisc,GDBAcadTableID,nil,0,0,
     OneVarDataMIPD,
-    TEntIterateProcsData.Create(nil,@AcadTableBreakSpacingEntIterateProc,nil));
+    TEntIterateProcsData.Create(
+      nil,@AcadTableBreakSpacingEntIterateProc,
+      @AcadTableBreakSpacingEntChangeProc));
+  MultiPropertiesManager.RegisterPhysMultiproperty(
+    'AcadTableBreakHeight','Break height',sysunit^.TypeName2PTD('Double'),
+    MPCMisc,GDBAcadTableID,nil,0,0,
+    OneVarDataMIPD,
+    TEntIterateProcsData.Create(
+      nil,@AcadTableBreakHeightEntIterateProc,
+      @AcadTableBreakHeightEntChangeProc));
 
   MultiPropertiesManager.sort;
 end;

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -81,6 +81,7 @@ type
     BreakManualPosition: Boolean;
     BreakManualHeight: Boolean;
     BreakSpacing: Double;
+    BreakHeight: Double;
   end;
 
   // Сущность ACAD_TABLE — таблица AutoCAD из формата DXF.
@@ -114,6 +115,10 @@ type
     FBreakManualPosition: Boolean;
     FBreakManualHeight: Boolean;
     FBreakSpacing: Double;
+    // Высота разбиения (break height): после какой суммарной высоты строк
+    // строки начинают переноситься в следующую часть разделённой таблицы.
+    // Читается из XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY (issue #1307).
+    FBreakHeight: Double;
     // Масштаб и поворот объекта (как у вставки блока). Хранятся отдельно,
     // потому что базовый CalcObjMatrixWithoutOwner восстанавливает ось OX
     // из OZ и теряет поворот в плоскости и масштаб. Благодаря этим полям
@@ -173,6 +178,22 @@ type
     // Чтение/запись вычисляемого признака разрыва таблицы (issue #1305)
     function GetBreakEnabled: Boolean;
     procedure SetBreakEnabled(AValue: Boolean);
+    // Чтение/запись интервала между частями и высоты разбиения (issue #1307)
+    function GetBreakSpacing: Double;
+    procedure SetBreakSpacing(AValue: Double);
+    function GetBreakHeight: Double;
+    procedure SetBreakHeight(AValue: Double);
+    // Объединяет все части-продолжения в главную часть (строки сверху вниз).
+    procedure MergeAllContinuationPartsIntoMain;
+    // Пересегментирует объединённую главную часть по высоте разбиения,
+    // вынося хвостовые строки в новые части-продолжения (issue #1307).
+    procedure SplitMainTableByBreakHeight(AThreshold: Double);
+    // Копирует диапазон строк [AStart..AEnd] исходной части в целевую часть.
+    procedure SlicePartFromPart(const ASource: TAcadTablePart;
+      AStart, AEnd: Integer; var ADest: TAcadTablePart);
+    // Пересчитывает точки вставки частей-продолжений из текущего интервала
+    // и направления разрыва (issue #1307).
+    procedure RepositionContinuationParts;
 
   public
     constructor initnul(
@@ -211,6 +232,11 @@ type
     // AOther поглощён и вызывающая сторона может его освободить.
     function TryMergeContinuation(
       AOther: PGDBObjEntity): Boolean; virtual;
+    // Сохраняет параметры разбиения (интервал и высоту), прочитанные
+    // загрузчиком DXF из XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY
+    // (issue #1307). Возвращает True.
+    function SetTableBreakData(
+      ASpacing, ABreakHeight: Double): Boolean; virtual;
 
     // Публичные свойства для инспектора объектов
     property InsertPoint: TzePoint3d read FInsertPoint;
@@ -233,7 +259,16 @@ type
       read FBreakManualPosition;
     property BreakManualHeight: Boolean
       read FBreakManualHeight;
-    property BreakSpacing: Double read FBreakSpacing;
+    // Интервал между частями разделённой таблицы (issue #1307). Чтение
+    // возвращает значение из XRECORD; запись перестраивает расстояние
+    // между всеми частями на чертеже.
+    property BreakSpacing: Double
+      read GetBreakSpacing write SetBreakSpacing;
+    // Высота разбиения (issue #1307). Чтение возвращает значение из
+    // XRECORD; запись пересчитывает число строк в каждой части
+    // (автоматически определяя необходимое число частей).
+    property BreakHeight: Double
+      read GetBreakHeight write SetBreakHeight;
     // Количество поглощённых частей-продолжений (issue #1300).
     // Для неразделённой таблицы равно 0.
     property ContinuationPartCount: Integer read GetContinuationPartCount;
@@ -313,6 +348,7 @@ begin
   FBreakManualPosition := False;
   FBreakManualHeight := False;
   FBreakSpacing := 0;
+  FBreakHeight := 0;
   // Трансформация по умолчанию: единичный масштаб, без поворота (issue #1305)
   FScale := ScaleOne;
   FRotate := 0;
@@ -902,7 +938,7 @@ var
   TmpBreakEnabled, TmpRepeatTop, TmpRepeatBottom: Boolean;
   TmpManualPos, TmpManualHeight: Boolean;
   TmpDir: TAcadTableBreakDirection;
-  TmpSpacing: Double;
+  TmpSpacing, TmpHeight: Double;
   TmpTexts: TTableTextArray;
   TmpRows: TTableRowArray;
   TmpCols: TTableColumnArray;
@@ -932,6 +968,7 @@ begin
   TmpManualPos := FBreakManualPosition; FBreakManualPosition := APart.BreakManualPosition; APart.BreakManualPosition := TmpManualPos;
   TmpManualHeight := FBreakManualHeight; FBreakManualHeight := APart.BreakManualHeight; APart.BreakManualHeight := TmpManualHeight;
   TmpSpacing := FBreakSpacing; FBreakSpacing := APart.BreakSpacing; APart.BreakSpacing := TmpSpacing;
+  TmpHeight := FBreakHeight; FBreakHeight := APart.BreakHeight; APart.BreakHeight := TmpHeight;
 end;
 
 // Строит визуальное представление всей таблицы: сначала главная часть
@@ -997,6 +1034,7 @@ begin
   APart.BreakManualPosition := ASource.FBreakManualPosition;
   APart.BreakManualHeight := ASource.FBreakManualHeight;
   APart.BreakSpacing := ASource.FBreakSpacing;
+  APart.BreakHeight := ASource.FBreakHeight;
 
   APart.RowHeights.initnul;
   for Idx := 0 to ASource.FRowHeights.Count - 1 do
@@ -1049,6 +1087,7 @@ begin
   ADest.BreakManualPosition := ASource.BreakManualPosition;
   ADest.BreakManualHeight := ASource.BreakManualHeight;
   ADest.BreakSpacing := ASource.BreakSpacing;
+  ADest.BreakHeight := ASource.BreakHeight;
 
   ADest.RowHeights.initnul;
   for Idx := 0 to ASource.RowHeights.Count - 1 do
@@ -1115,10 +1154,6 @@ end;
 // для разорванной таблицы объединяет все части-продолжения с главной
 // частью, выстраивая строки сверху вниз в единую непрерывную таблицу.
 procedure GDBObjAcadTable.SetBreakEnabled(AValue: Boolean);
-var
-  PartIdx, RowIdx, ColIdx, SrcCount: Integer;
-  RowOffset: Integer;
-  MergeBase: Integer;
 begin
   if AValue then
   begin
@@ -1130,7 +1165,26 @@ begin
 
   // Снять разрыв: объединяем части-продолжения в главную таблицу.
   FBreakEnabled := False;
+  MergeAllContinuationPartsIntoMain;
 
+  // Геометрию нужно перестроить
+  FGeometryBuilt := False;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetBreakEnabled(False) merged into ' +
+    'single table rows=%d cols=%d', [FRowCount, FColCount], LM_Info);
+end;
+
+// Объединяет все части-продолжения в главную часть: строки выстраиваются
+// сверху вниз в единую непрерывную таблицу. Части-продолжения
+// освобождаются. Не трогает FBreakEnabled и FGeometryBuilt — это делает
+// вызывающая сторона (issue #1305 часть 2b, issue #1307).
+procedure GDBObjAcadTable.MergeAllContinuationPartsIntoMain;
+var
+  PartIdx, RowIdx, ColIdx, SrcCount: Integer;
+  RowOffset: Integer;
+  MergeBase: Integer;
+begin
   if Length(FContinuationParts) = 0 then
     Exit;
 
@@ -1196,13 +1250,258 @@ begin
   for PartIdx := 0 to High(FContinuationParts) do
     ClearPart(FContinuationParts[PartIdx]);
   System.SetLength(FContinuationParts, 0);
+end;
 
-  // Геометрию нужно перестроить
+// --- Параметры разбиения: интервал и высота (issue #1307) ---
+
+function GDBObjAcadTable.GetBreakSpacing: Double;
+begin
+  Result := FBreakSpacing;
+end;
+
+// Изменение интервала между частями (issue #1307, часть 1). Пересчитывает
+// точки вставки всех частей-продолжений так, чтобы расстояние между
+// соседними частями изменилось на чертеже.
+procedure GDBObjAcadTable.SetBreakSpacing(AValue: Double);
+begin
+  if AValue = FBreakSpacing then
+    Exit;
+  FBreakSpacing := AValue;
+  RepositionContinuationParts;
   FGeometryBuilt := False;
-
   programlog.LogOutFormatStr(
-    'AcadTable: model: SetBreakEnabled(False) merged into ' +
-    'single table rows=%d cols=%d', [FRowCount, FColCount], LM_Info);
+    'AcadTable: model: SetBreakSpacing=%g parts=%d',
+    [FBreakSpacing, Length(FContinuationParts)], LM_Info);
+end;
+
+function GDBObjAcadTable.GetBreakHeight: Double;
+begin
+  Result := FBreakHeight;
+end;
+
+// Изменение высоты разбиения (issue #1307, часть 2). Сначала объединяет
+// все части в единую таблицу, затем заново разбивает строки по новой
+// высоте — автоматически определяя необходимое число частей.
+procedure GDBObjAcadTable.SetBreakHeight(AValue: Double);
+begin
+  if AValue = FBreakHeight then
+    Exit;
+  FBreakHeight := AValue;
+  // Перебор строк имеет смысл только при положительной высоте.
+  if AValue > 0 then
+  begin
+    MergeAllContinuationPartsIntoMain;
+    SplitMainTableByBreakHeight(AValue);
+  end;
+  FGeometryBuilt := False;
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetBreakHeight=%g rows=%d parts=%d',
+    [FBreakHeight, FRowCount, Length(FContinuationParts)], LM_Info);
+end;
+
+// Копирует диапазон строк [AStart..AEnd] исходной части в целевую часть.
+// Столбцы, стиль и флаги копируются целиком; строки/высоты/тексты/ячейки/
+// объединения вырезаются по диапазону. Точку вставки выставляет
+// RepositionContinuationParts (issue #1307).
+procedure GDBObjAcadTable.SlicePartFromPart(
+  const ASource: TAcadTablePart;
+  AStart, AEnd: Integer; var ADest: TAcadTablePart);
+var
+  RowIdx, ColIdx, ColCnt, SrcIdx, DstRows, TextBase: Integer;
+begin
+  DstRows := AEnd - AStart + 1;
+  if DstRows < 0 then DstRows := 0;
+  ColCnt := ASource.ColCount;
+
+  ADest.InsertPoint := ASource.InsertPoint;
+  ADest.RowCount := DstRows;
+  ADest.ColCount := ColCnt;
+  ADest.TableFlags := ASource.TableFlags;
+  ADest.TableStyle := ASource.TableStyle;
+  ADest.TableStyleHandle := ASource.TableStyleHandle;
+  ADest.BreakEnabled := ASource.BreakEnabled;
+  ADest.BreakDirection := ASource.BreakDirection;
+  ADest.BreakRepeatTopLabels := ASource.BreakRepeatTopLabels;
+  ADest.BreakRepeatBottomLabels := ASource.BreakRepeatBottomLabels;
+  ADest.BreakManualPosition := ASource.BreakManualPosition;
+  ADest.BreakManualHeight := ASource.BreakManualHeight;
+  ADest.BreakSpacing := ASource.BreakSpacing;
+  ADest.BreakHeight := ASource.BreakHeight;
+
+  // Высоты строк диапазона
+  ADest.RowHeights.initnul;
+  for RowIdx := AStart to AEnd do
+    if (RowIdx >= 0) and (RowIdx < ASource.RowHeights.Count) then
+      ADest.RowHeights.PushBackData(ASource.RowHeights.getData(RowIdx));
+
+  // Ширины столбцов — те же, что у источника
+  ADest.ColWidths.initnul;
+  for ColIdx := 0 to ASource.ColWidths.Count - 1 do
+    ADest.ColWidths.PushBackData(ASource.ColWidths.getData(ColIdx));
+
+  // Тексты ячеек (плоский массив, индекс = строка * ColCount + столбец)
+  System.SetLength(ADest.CellTexts, DstRows * ColCnt);
+  if ColCnt > 0 then
+    for RowIdx := 0 to DstRows - 1 do
+      for ColIdx := 0 to ColCnt - 1 do
+      begin
+        SrcIdx := (AStart + RowIdx) * ColCnt + ColIdx;
+        TextBase := RowIdx * ColCnt + ColIdx;
+        if (SrcIdx >= 0) and (SrcIdx <= High(ASource.CellTexts)) then
+          ADest.CellTexts[TextBase] := ASource.CellTexts[SrcIdx]
+        else
+          ADest.CellTexts[TextBase] := '';
+      end;
+
+  // Формат строк
+  System.SetLength(ADest.Rows, DstRows);
+  for RowIdx := 0 to DstRows - 1 do
+    if (AStart + RowIdx) <= High(ASource.Rows) then
+      ADest.Rows[RowIdx] := ASource.Rows[AStart + RowIdx];
+
+  // Столбцы — те же, что у источника
+  System.SetLength(ADest.Cols, Length(ASource.Cols));
+  for ColIdx := 0 to High(ASource.Cols) do
+    ADest.Cols[ColIdx] := ASource.Cols[ColIdx];
+
+  // Ячейки (двумерный массив [строка][столбец])
+  System.SetLength(ADest.Cells, DstRows);
+  for RowIdx := 0 to DstRows - 1 do
+    if (AStart + RowIdx) <= High(ASource.Cells) then
+    begin
+      System.SetLength(ADest.Cells[RowIdx],
+        Length(ASource.Cells[AStart + RowIdx]));
+      for ColIdx := 0 to High(ASource.Cells[AStart + RowIdx]) do
+        ADest.Cells[RowIdx][ColIdx] :=
+          ASource.Cells[AStart + RowIdx][ColIdx];
+    end;
+
+  // Объединения ячеек, попадающие целиком в диапазон, со сдвигом строк
+  System.SetLength(ADest.Merges, 0);
+  for RowIdx := 0 to High(ASource.Merges) do
+    if (ASource.Merges[RowIdx].Row1 >= AStart) and
+       (ASource.Merges[RowIdx].Row2 <= AEnd) then
+    begin
+      ColIdx := Length(ADest.Merges);
+      System.SetLength(ADest.Merges, ColIdx + 1);
+      ADest.Merges[ColIdx] := ASource.Merges[RowIdx];
+      Dec(ADest.Merges[ColIdx].Row1, AStart);
+      Dec(ADest.Merges[ColIdx].Row2, AStart);
+    end;
+end;
+
+// Пересегментирует объединённую главную часть по высоте разбиения:
+// строки набираются в сегмент, пока их суммарная высота не превысит
+// порог AThreshold; затем начинается новый сегмент. Первый сегмент
+// остаётся в главной части, остальные выносятся в части-продолжения.
+// Число частей определяется автоматически (issue #1307).
+procedure GDBObjAcadTable.SplitMainTableByBreakHeight(AThreshold: Double);
+var
+  FullData, TmpPart: TAcadTablePart;
+  SegStart, SegEnd: array of Integer;
+  SegCount, StartRow, EndRow, PartIdx: Integer;
+  CurHeight, NextHeight: Double;
+begin
+  if (FRowCount <= 0) or (AThreshold <= 0) then
+    Exit;
+
+  // Снимок текущей (объединённой) главной части
+  CaptureTableDataToPart(Self, FullData);
+  try
+    // Вычисляем границы сегментов по высоте строк
+    SegCount := 0;
+    StartRow := 0;
+    while StartRow < FullData.RowCount do
+    begin
+      EndRow := StartRow;
+      CurHeight := 0;
+      while EndRow < FullData.RowCount do
+      begin
+        NextHeight := CurHeight +
+          uzeacadtable_layout.GetRowHeight(EndRow, FullData.RowHeights);
+        if (EndRow > StartRow) and
+           (NextHeight > AThreshold + 1e-9) then
+          Break;
+        CurHeight := NextHeight;
+        Inc(EndRow);
+      end;
+      if EndRow = StartRow then
+        Inc(EndRow);
+
+      System.SetLength(SegStart, SegCount + 1);
+      System.SetLength(SegEnd, SegCount + 1);
+      SegStart[SegCount] := StartRow;
+      SegEnd[SegCount] := EndRow - 1;
+      Inc(SegCount);
+      StartRow := EndRow;
+    end;
+
+    // Части-продолжения для сегментов 1..SegCount-1
+    for PartIdx := 0 to High(FContinuationParts) do
+      ClearPart(FContinuationParts[PartIdx]);
+    System.SetLength(FContinuationParts, SegCount - 1);
+    for PartIdx := 1 to SegCount - 1 do
+      SlicePartFromPart(FullData, SegStart[PartIdx], SegEnd[PartIdx],
+        FContinuationParts[PartIdx - 1]);
+
+    // Сегмент 0 -> главная часть. Готовим временную часть и меняемся
+    // данными с собой (точка вставки главной части сохраняется).
+    SlicePartFromPart(FullData, SegStart[0], SegEnd[0], TmpPart);
+    SwapTableData(TmpPart);
+    ClearPart(TmpPart);
+
+    RepositionContinuationParts;
+  finally
+    ClearPart(FullData);
+  end;
+end;
+
+// Пересчитывает точки вставки частей-продолжений из текущего интервала
+// (FBreakSpacing) и направления разрыва (FBreakDirection). Расстояние
+// между соседними частями = (размер предыдущего сегмента вдоль оси
+// разрыва) + интервал (issue #1307).
+procedure GDBObjAcadTable.RepositionContinuationParts;
+var
+  PartIdx: Integer;
+  Horizontal: Boolean;
+  CumOffset, PrevExtent: Double;
+begin
+  if Length(FContinuationParts) = 0 then
+    Exit;
+
+  Horizontal := FBreakDirection in [atbdRight, atbdLeft];
+  if Horizontal then
+    PrevExtent := GetTotalWidth
+  else
+    PrevExtent := GetTotalHeight;
+
+  CumOffset := 0;
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    CumOffset := CumOffset + PrevExtent + FBreakSpacing;
+
+    FContinuationParts[PartIdx].InsertPoint := FInsertPoint;
+    case FBreakDirection of
+      atbdDown:
+        FContinuationParts[PartIdx].InsertPoint.y :=
+          FInsertPoint.y - CumOffset;
+      atbdLeft:
+        FContinuationParts[PartIdx].InsertPoint.x :=
+          FInsertPoint.x - CumOffset;
+    else // atbdRight
+      FContinuationParts[PartIdx].InsertPoint.x :=
+        FInsertPoint.x + CumOffset;
+    end;
+
+    if Horizontal then
+      PrevExtent := uzeacadtable_layout.GetTotalWidth(
+        FContinuationParts[PartIdx].ColCount,
+        FContinuationParts[PartIdx].ColWidths)
+    else
+      PrevExtent := uzeacadtable_layout.GetTotalHeight(
+        FContinuationParts[PartIdx].RowCount,
+        FContinuationParts[PartIdx].RowHeights);
+  end;
 end;
 
 // Поглощает продолжение разделённой таблицы как часть этого объекта.
@@ -1227,6 +1526,21 @@ begin
     '(rows=%d cols=%d)',
     [PartIdx, FContinuationParts[PartIdx].RowCount,
      FContinuationParts[PartIdx].ColCount], LM_Info);
+  Result := True;
+end;
+
+// Сохраняет параметры разбиения, прочитанные загрузчиком DXF из XRECORD
+// ACAD_ROUNDTRIP_2008_TABLE_ENTITY (issue #1307). Значения только
+// сохраняются — геометрия частей уже расставлена по точкам вставки из DXF,
+// перестройка не требуется.
+function GDBObjAcadTable.SetTableBreakData(
+  ASpacing, ABreakHeight: Double): Boolean;
+begin
+  FBreakSpacing := ASpacing;
+  FBreakHeight := ABreakHeight;
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetTableBreakData spacing=%g breakheight=%g',
+    [FBreakSpacing, FBreakHeight], LM_Info);
   Result := True;
 end;
 
@@ -1475,6 +1789,7 @@ begin
   NewTable^.FBreakManualPosition := FBreakManualPosition;
   NewTable^.FBreakManualHeight := FBreakManualHeight;
   NewTable^.FBreakSpacing := FBreakSpacing;
+  NewTable^.FBreakHeight := FBreakHeight;
   // Трансформация объекта (issue #1305, часть 1)
   NewTable^.FScale := FScale;
   NewTable^.FRotate := FRotate;

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -87,6 +87,14 @@ type
       Возвращает True, если данные AOther поглощены и вызывающая сторона может
       освободить AOther (issue #1300). }
     function TryMergeContinuation(AOther:PGDBObjEntity):boolean;virtual;
+    { Передаёт сущности параметры разбиения разделённой таблицы
+      (интервал между частями и высоту разбиения), прочитанные из
+      XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY в секции OBJECTS.
+      Базовая реализация ничего не делает и возвращает False.
+      GDBObjAcadTable переопределяет метод и сохраняет значения в себя,
+      чтобы свойства Break spacing/Break height отображались и
+      редактировались в инспекторе объектов (issue #1307). }
+    function SetTableBreakData(ASpacing,ABreakHeight:double):boolean;virtual;
     procedure postload(var context:TIODXFLoadContext);virtual;
     procedure createfield;virtual;
     function AddExtAttrib:PTExtAttrib;
@@ -449,6 +457,11 @@ begin
 end;
 
 function GDBObjEntity.TryMergeContinuation(AOther:PGDBObjEntity):boolean;
+begin
+  Result:=false;
+end;
+
+function GDBObjEntity.SetTableBreakData(ASpacing,ABreakHeight:double):boolean;
 begin
   Result:=false;
 end;

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -240,6 +240,89 @@ begin
   end;
 end;
 
+{ Сканирует секцию OBJECTS и извлекает из XRECORD'а с маркером
+  ACAD_ROUNDTRIP_2008_TABLE_ENTITY параметры разбиения разделённой
+  таблицы. Внутри roundtrip-блока идут две группы 40: первая —
+  интервал между частями (break spacing), вторая — высота разбиения
+  (break height). Эти значения не выводятся в современный DXF
+  отдельными группами, поэтому без чтения XRECORD они теряются
+  (issue #1307).
+
+  ASpacing/ABreakHeight получают найденные значения, AValid=True,
+  если в блоке найдено хотя бы две группы 40. }
+procedure ScanTableBreakData(const RawObjectsSection: string;
+  out ASpacing, ABreakHeight: Double; out AValid: Boolean);
+var
+  Lines: TStringList;
+  I, Code, Found: Integer;
+  Value: string;
+  V: Extended;
+  InXRecord, InRoundtripBlock: Boolean;
+begin
+  ASpacing := 0;
+  ABreakHeight := 0;
+  AValid := False;
+  if RawObjectsSection = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := RawObjectsSection;
+    InXRecord := False;
+    InRoundtripBlock := False;
+    Found := 0;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if not TryStrToInt(Trim(Lines[I]), Code) then begin
+        Inc(I, 2);
+        Continue;
+      end;
+      Value := Trim(Lines[I + 1]);
+
+      if Code = 0 then
+      begin
+        InXRecord := (UpperCase(Value) = 'XRECORD');
+        InRoundtripBlock := False;
+      end
+      else if InXRecord then
+      begin
+        if (Code = 102) and
+           (UpperCase(Value) = 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY') then
+          InRoundtripBlock := True
+        else if InRoundtripBlock then
+        begin
+          if Code = 361 then
+            InRoundtripBlock := False
+          else if (Code = 40) and (Found < 2) then
+          begin
+            { DXF использует точку как десятичный разделитель }
+            if TextToFloat(PChar(Value), V, fvExtended) then
+            begin
+              if Found = 0 then
+                ASpacing := V
+              else
+                ABreakHeight := V;
+              Inc(Found);
+              if Found >= 2 then
+                AValid := True;
+            end;
+          end;
+        end;
+      end;
+
+      Inc(I, 2);
+    end;
+
+    if AValid then
+      programlog.LogOutFormatStr(
+        'uzeffdxf: ScanTableBreakData: spacing=%g breakheight=%g',
+        [ASpacing, ABreakHeight], LM_Info);
+  finally
+    Lines.Free;
+  end;
+end;
+
 procedure gotodxf(var rdr:TZMemReader; fcode: Integer; const fname: String);
 var
   byt: Integer;
@@ -589,8 +672,16 @@ begin
           newowner^.DXFLoadAddMi(pobj);
         // Запоминаем главную ACAD_TABLE для поглощения её продолжений
         // (issue #1300). Продолжения идут после главной части в DXF.
-        if uppercase(s)='ACAD_TABLE' then
+        if uppercase(s)='ACAD_TABLE' then begin
           pLastMainTable:=pobj;
+          // Передаём параметры разбиения (интервал и высота), прочитанные
+          // из XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY, в главную таблицу,
+          // чтобы свойства Break spacing/Break height были доступны в
+          // инспекторе объектов (issue #1307).
+          if context.TableBreakDataValid then
+            pLastMainTable^.SetTableBreakData(
+              context.TableBreakSpacing, context.TableBreakHeight);
+        end;
         if not(IsObjectIt(TypeOf(owner^),TypeOf(GDBObjBlockdef))) then begin
           if PGDBObjEntity(pobj)^.DXFDelayedBuildGeometry then begin
             {PGDBObjEntity(pobj)^.BuildGeometry(drawing);
@@ -1525,6 +1616,15 @@ begin
         ScanTableContinuationHandles(
           dwgCtx.PDrawing^.RawObjectsSection,
           fileCtx.TableContinuationHandles);
+
+        { Извлекаем параметры разбиения разделённой таблицы (интервал между
+          частями и высоту разбиения) из XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY.
+          Передаются в главную ACAD_TABLE через SetTableBreakData (issue #1307). }
+        ScanTableBreakData(
+          dwgCtx.PDrawing^.RawObjectsSection,
+          fileCtx.TableBreakSpacing,
+          fileCtx.TableBreakHeight,
+          fileCtx.TableBreakDataValid);
 
         lph:=lps.StartLongProcess(rsLoadDXFFile,@rdr,rdr.Size,LPSOSilent);
         case fileCtx.Header.Version of

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -128,6 +128,15 @@ type
       ProxyEntity: их proxy graphic уже включён в первую таблицу. }
     TableContinuationHandles:TStringList;
 
+    { Параметры разбиения разделённой таблицы, прочитанные из XRECORD
+      ACAD_ROUNDTRIP_2008_TABLE_ENTITY (две группы 40: 1-я — интервал
+      между частями, 2-я — высота разбиения). Передаются в главную
+      ACAD_TABLE через SetTableBreakData, чтобы свойства Break spacing
+      и Break height отображались/редактировались в инспекторе (issue #1307). }
+    TableBreakSpacing:double;
+    TableBreakHeight:double;
+    TableBreakDataValid:boolean;
+
     procedure InitRec;
     procedure Done;
   end;
@@ -358,6 +367,10 @@ begin
   TableContinuationHandles.CaseSensitive:=False;
   TableContinuationHandles.Sorted:=True;
   TableContinuationHandles.Duplicates:=dupIgnore;
+
+  TableBreakSpacing:=0;
+  TableBreakHeight:=0;
+  TableBreakDataValid:=False;
 end;
 
 procedure TDXFHeaderInfo.InitRec;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -57,6 +57,18 @@ type
     // issue #1305, часть 2b: снятие признака разрыва объединяет
     // части-продолжения в единую непрерывную таблицу.
     procedure ClearingBreakMergesContinuationParts;
+    // issue #1307, часть 1: интервал между частями (Break spacing)
+    // читается из round-trip данных DXF (≈0.99).
+    procedure LoadsBreakSpacingFromDXF;
+    // issue #1307, часть 2: высота разбиения (Break height) читается
+    // из round-trip данных DXF (≈2.0486).
+    procedure LoadsBreakHeightFromDXF;
+    // issue #1307, часть 2: изменение высоты разбиения пересегментирует
+    // таблицу с автоопределением числа частей.
+    procedure ChangingBreakHeightResegmentsTable;
+    // issue #1307, часть 1: изменение интервала смещает части-продолжения
+    // (меняется ширина отрисованного представления).
+    procedure ChangingBreakSpacingRepositionsParts;
   end;
 
 implementation
@@ -482,6 +494,133 @@ begin
     CheckTrue(AcadTable^.RowCount > RowsBefore,
       'Объединённая таблица должна содержать строки всех частей ' +
       '(issue #1305, часть 2b)');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1307, часть 1. Интервал между частями разорванной таблицы
+// (Break spacing) хранится в round-trip данных DXF (XRECORD
+// ACAD_ROUNDTRIP_2008_TABLE_ENTITY, первое значение группы 40). Для
+// tablerazdel.dxf он равен ≈0.99 и согласуется с геометрией: шаг между
+// точками вставки частей (13.49) минус ширина таблицы (12.5) = 0.99.
+// Раньше это свойство вычислялось неверно (issue #1307).
+procedure TAcadTableStyleTest.LoadsBreakSpacingFromDXF;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    CheckEquals(0.99, AcadTable^.BreakSpacing, 1e-4,
+      'Интервал между частями (Break spacing) должен читаться из DXF ≈0.99');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1307, часть 2. Высота разбиения (Break height) — порог суммарной
+// высоты строк, после которого строки переносятся в следующую часть. Она
+// хранится только в round-trip данных DXF (второе значение группы 40
+// XRECORD) и не выводится из геометрии. Для tablerazdel.dxf — ≈2.0486.
+// Раньше это свойство полностью отсутствовало (issue #1307).
+procedure TAcadTableStyleTest.LoadsBreakHeightFromDXF;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    CheckEquals(2.048584359034151, AcadTable^.BreakHeight, 1e-4,
+      'Высота разбиения (Break height) должна читаться из DXF ≈2.0486');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1307, часть 2. Изменение высоты разбиения должно пересегментировать
+// таблицу: число частей определяется автоматически так, чтобы суммарная
+// высота строк в каждой части не превышала заданного порога. tablerazdel.dxf
+// загружается как [5,5,4] строк (главная часть + 2 продолжения = 14 строк).
+//   • Очень большой порог → все строки помещаются в одну часть (0 продолжений,
+//     главная часть содержит все 14 строк).
+//   • Возврат к исходному порогу ≈2.0486 → снова 2 части-продолжения.
+//   • Очень малый порог → больше частей, чем исходно.
+procedure TAcadTableStyleTest.ChangingBreakHeightResegmentsTable;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  MainRowsBefore: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    CheckEquals(2, AcadTable^.ContinuationPartCount,
+      'Исходно таблица разбита на главную часть и 2 продолжения');
+    MainRowsBefore := AcadTable^.RowCount;
+
+    // Очень большой порог — все строки умещаются в одной части.
+    AcadTable^.BreakHeight := 1000.0;
+    CheckEquals(0, AcadTable^.ContinuationPartCount,
+      'При большом пороге все строки должны помещаться в одну часть');
+    CheckTrue(AcadTable^.RowCount > MainRowsBefore,
+      'Объединённая главная часть должна содержать строки всех частей');
+
+    // Возврат к исходному порогу — снова две части-продолжения.
+    AcadTable^.BreakHeight := 2.048584359034151;
+    CheckEquals(2, AcadTable^.ContinuationPartCount,
+      'При исходном пороге ≈2.0486 таблица снова разбивается на 3 части');
+
+    // Очень малый порог — каждая часть вмещает меньше строк, частей больше.
+    AcadTable^.BreakHeight := 0.5;
+    CheckTrue(AcadTable^.ContinuationPartCount > 2,
+      'При малом пороге число частей-продолжений должно вырасти');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1307, часть 1. Изменение интервала между частями должно смещать
+// части-продолжения относительно главной части. Таблица разбита по ширине
+// (части идут вправо), поэтому увеличение интервала раздвигает части и
+// увеличивает общую ширину отрисованного представления.
+procedure TAcadTableStyleTest.ChangingBreakSpacingRepositionsParts;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  MinX1, MaxX1, MinX2, MaxX2: Double;
+  HasGap: Boolean;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckTrue(AcadTable^.ContinuationPartCount > 0,
+      'Таблица должна содержать части-продолжения');
+
+    BuildTableGeometry(Drawing, AcadTable);
+    CollectLineBounds(AcadTable^.ConstObjArray, MinX1, MaxX1, HasGap);
+    Check(MaxX1 > MinX1, 'Таблица должна отрисовать линии в WCS');
+
+    // Увеличиваем интервал между частями — части должны раздвинуться.
+    AcadTable^.BreakSpacing := 10.0;
+    BuildTableGeometry(Drawing, AcadTable);
+    CollectLineBounds(AcadTable^.ConstObjArray, MinX2, MaxX2, HasGap);
+
+    CheckTrue(MaxX2 > MaxX1 + 1e-6,
+      'Увеличение интервала должно раздвинуть части и увеличить общую ширину');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
## AcadTable: editable Break spacing + new editable Break height (issue #1307)

Fixes veb86/zcadvelecAI#1307

A split `ACAD_TABLE` is stored in the DXF as several physical tables merged through `FContinuationParts` (see #1300 / #1305). The issue had two parts.

### Part 1 — Break spacing (интервал)
`BreakSpacing` is the distance between the main part and the continuation parts of a split table. It was **read-only** in the Object Inspector and the value was not surfaced correctly.

- The value is now loaded from the DXF `ACAD_ROUNDTRIP_2008_TABLE_ENTITY` XRECORD (1st group `40`). For `cad_source/test/tablerazdel.dxf` this is **≈0.9900**, as required.
- `Break spacing` is now **editable**: a change procedure is registered for the multiproperty. Editing it calls `GDBObjAcadTable.SetBreakSpacing`, which repositions the continuation parts (`RepositionContinuationParts`) and rebuilds the geometry, so the on-drawing distance between parts changes.

### Part 2 — Break height (высота разбиения)
This property was **missing entirely**. It is the cumulative row-height threshold after which rows move into the next part; the number of parts is derived automatically.

- The value is now loaded from the DXF (2nd group `40`). For `tablerazdel.dxf` this is **≈2.0486**, as required.
- A new **editable** `Break height` multiproperty is registered. Editing it calls `GDBObjAcadTable.SetBreakHeight`, which merges all parts back into the main table and re-splits the rows by the new threshold (`SplitMainTableByBreakHeight`), auto-computing the part count. The 14 rows of `tablerazdel.dxf` at the default 2.0486 split into `[5,5,4]` → 3 parts.

### Layering
`zengine` cannot depend on `zcad/acadtable`, so the DXF-loaded break data is passed through a base virtual method on `GDBObjEntity` (`SetTableBreakData`), mirroring the existing cross-layer pattern. The DXF loader scans the roundtrip XRECORD and pushes the values onto the last main table.

### How to reproduce
Open `cad_source/test/tablerazdel.dxf` and select the table. Before the fix: `Break spacing` shows an incorrect value and is read-only, and there is no `Break height` property. After the fix: `Break spacing` ≈ 0.99 (editable), `Break height` ≈ 2.0486 (editable); editing either changes the drawing.

### Tests
Reproducing tests added in `cad_source/zengine/tests/uzctacadtable.pas`:
- `LoadsBreakSpacingFromDXF` — asserts `BreakSpacing` ≈ 0.99
- `LoadsBreakHeightFromDXF` — asserts `BreakHeight` ≈ 2.048584359034151
- `ChangingBreakHeightResegmentsTable` — changing `BreakHeight` re-segments (part count / row distribution change)
- `ChangingBreakSpacingRepositionsParts` — changing `BreakSpacing` moves the continuation parts

All 12 tests in the `TAcadTableStyleTest` suite pass via the standalone FPCUnit runner (`testacadtable_standalone --all`): `N:12 E:0 F:0 I:0`.

### Files changed
- `cad_source/zcad/register/uzcregacadtable.pas` — register editable `Break spacing` change proc + new editable `Break height` property
- `cad_source/zcad/velec/acadtable/uzeacadtable_model.pas` — `BreakSpacing`/`BreakHeight` properties, setters, re-segmentation and repositioning
- `cad_source/zengine/core/entities/uzeentity.pas`, `cad_source/zengine/fileformats/uzeffdxf.pas`, `uzeffdxfsupport.pas` — DXF load of break data via base virtual method
- `cad_source/zengine/tests/uzctacadtable.pas` — reproducing tests
