### PR TITLE
AcadTable: reflow rows when disabling BreakRepeatTop (issue #1311)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
 # Updated: 2026-06-10T10:51:04.132Z
+# Updated: 2026-06-11T07:11:42.815Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,2 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
 # Updated: 2026-06-10T10:51:04.132Z
-# Updated: 2026-06-11T07:11:42.815Z

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_cell.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_cell.pas
@@ -55,6 +55,18 @@ function ResolveCellStyle(
   ARowCount, AColCount: Integer;
   ATableFlags: Integer): TCellStyle;
 
+// Резолвит стиль для строки, которая может быть визуально смещена внутри
+// части таблицы. AStyleRowIdx определяет базовый тип строки (Title/Header/Data),
+// ARowIdx индексирует локальные массивы строк/ячеек.
+function ResolveCellStyleForBaseRow(
+  AStyleRowIdx, ARowIdx, AColIdx: Integer;
+  const ATableStyle: TTableStyle;
+  const ARows: array of TTableRow;
+  const ACols: array of TTableColumn;
+  const ACells: TTableCellArray;
+  ARowCount, AColCount: Integer;
+  ATableFlags: Integer): TCellStyle;
+
 // Определяет базовый стиль строки по позиции в таблице.
 // RowIdx=0 → TitleCell, RowIdx=1 → HeaderCell, RowIdx>=2 → DataCell.
 function GetBaseRowStyle(
@@ -144,12 +156,27 @@ function ResolveCellStyle(
   const ACells: TTableCellArray;
   ARowCount, AColCount: Integer;
   ATableFlags: Integer): TCellStyle;
+begin
+  Result := ResolveCellStyleForBaseRow(
+    ARowIdx, ARowIdx, AColIdx, ATableStyle, ARows, ACols, ACells,
+    ARowCount, AColCount, ATableFlags);
+end;
+
+function ResolveCellStyleForBaseRow(
+  AStyleRowIdx, ARowIdx, AColIdx: Integer;
+  const ATableStyle: TTableStyle;
+  const ARows: array of TTableRow;
+  const ACols: array of TTableColumn;
+  const ACells: TTableCellArray;
+  ARowCount, AColCount: Integer;
+  ATableFlags: Integer): TCellStyle;
 var
   TableCell: TTableCell;
   RowStyle, ColStyle, BaseStyle: TCellStyle;
 begin
-  // Базовый стиль по позиции строки
-  BaseStyle := GetBaseRowStyle(ARowIdx, ATableStyle);
+  // Базовый стиль по логической позиции строки, а не по визуальному индексу
+  // внутри части таблицы.
+  BaseStyle := GetBaseRowStyle(AStyleRowIdx, ATableStyle);
   if BaseStyle.Overrides = [] then
     BaseStyle := ATableStyle.DefaultCell;
 

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -58,6 +58,10 @@ type
   // со смещением относительно точки вставки главной части (issue #1300).
   TAcadTablePart = record
     InsertPoint: TzePoint3d;
+    // Логический индекс первой строки части в полной таблице. Нужен для
+    // базового стиля Title/Header/Data, когда строки смещаются при удалении
+    // повторяющихся верхних меток (issue #1311).
+    RowBaseIndex: Integer;
     RowCount: Integer;
     ColCount: Integer;
     RowHeights: TZctnrVectorDouble;
@@ -148,9 +152,11 @@ type
       RowIdx, ColIdx: Integer): String;
     // Строит визуальное представление текущих полей таблицы в
     // ConstObjArray со смещением (ABaseX, ABaseY) в OCS.
+    // ARowBaseIndex задаёт логический индекс первой строки для выбора
+    // базового стиля строки.
     procedure RenderCurrentTable(
       var ADrawing: TDrawingDef; var ADC: TDrawContext;
-      ABaseX, ABaseY: Double);
+      ABaseX, ABaseY: Double; ARowBaseIndex: Integer);
     // Строит визуальное представление всей таблицы (главная часть и
     // все продолжения) в ConstObjArray
     procedure BuildVisualRepresentation(
@@ -204,6 +210,9 @@ type
     // части (тексты ячеек первых L строк совпадают) (issue #1309).
     function PartRepeatsTopLabels(
       const APart: TAcadTablePart; L: Integer): Boolean;
+    // Обновляет логические индексы первых строк продолжений для выбора
+    // базового стиля Title/Header/Data (issue #1311).
+    procedure UpdateContinuationRowBaseIndexes;
     // Определяет значение BreakRepeatTopLabels по данным частей-продолжений:
     // если все части повторяют ведущие строки-метки главной части, значит
     // таблица была разорвана с повтором верхних меток (issue #1309).
@@ -635,7 +644,7 @@ end;
 
 procedure GDBObjAcadTable.RenderCurrentTable(
   var ADrawing: TDrawingDef; var ADC: TDrawContext;
-  ABaseX, ABaseY: Double);
+  ABaseX, ABaseY: Double; ARowBaseIndex: Integer);
 var
   RowIdx, ColIdx, SegmentIdx, SegmentCount: Integer;
   CurrentY, CurrentX: Double;
@@ -851,8 +860,8 @@ begin
 
         if CellStr <> '' then
         begin
-          CellStyleLocal := uzeacadtable_cell.ResolveCellStyle(
-            RowIdx, ColIdx, FTableStyle,
+          CellStyleLocal := uzeacadtable_cell.ResolveCellStyleForBaseRow(
+            ARowBaseIndex + RowIdx, RowIdx, ColIdx, FTableStyle,
             FRows, FCols, FCells,
             FRowCount, FColCount, FTableFlags);
 
@@ -1028,7 +1037,7 @@ begin
   ConstObjArray.Free;
 
   // Главная часть в собственной системе координат
-  RenderCurrentTable(ADrawing, ADC, 0, 0);
+  RenderCurrentTable(ADrawing, ADC, 0, 0, 0);
 
   // Части-продолжения со смещением относительно главной точки вставки
   for PartIdx := 0 to High(FContinuationParts) do
@@ -1043,7 +1052,9 @@ begin
     // «разъезжается» относительно ячеек (issue #1300).
     uzeacadtable_stylemanager.ApplyDXFTableStyle(
       FTableStyle, FContinuationParts[PartIdx].TableStyleHandle, ADrawing);
-    RenderCurrentTable(ADrawing, ADC, BaseX, BaseY);
+    RenderCurrentTable(
+      ADrawing, ADC, BaseX, BaseY,
+      FContinuationParts[PartIdx].RowBaseIndex);
     SwapTableData(FContinuationParts[PartIdx]);
   end;
 
@@ -1062,6 +1073,7 @@ var
   Idx, Idx2: Integer;
 begin
   APart.InsertPoint := ASource.FInsertPoint;
+  APart.RowBaseIndex := 0;
   APart.RowCount := ASource.FRowCount;
   APart.ColCount := ASource.FColCount;
   APart.TableFlags := ASource.FTableFlags;
@@ -1115,6 +1127,7 @@ var
   Idx, Idx2: Integer;
 begin
   ADest.InsertPoint := ASource.InsertPoint;
+  ADest.RowBaseIndex := ASource.RowBaseIndex;
   ADest.RowCount := ASource.RowCount;
   ADest.ColCount := ASource.ColCount;
   ADest.TableFlags := ASource.TableFlags;
@@ -1165,6 +1178,7 @@ end;
 procedure GDBObjAcadTable.ClearPart(var APart: TAcadTablePart);
 begin
   APart.TableStyleHandle := '';
+  APart.RowBaseIndex := 0;
   APart.RowHeights.done;
   APart.ColWidths.done;
   System.SetLength(APart.CellTexts, 0);
@@ -1354,6 +1368,8 @@ end;
 // все части в единую таблицу, затем заново разбивает строки по новой
 // высоте — автоматически определяя необходимое число частей.
 procedure GDBObjAcadTable.SetBreakHeight(AValue: Double);
+var
+  L: Integer;
 begin
   if AValue = FBreakHeight then
     Exit;
@@ -1361,6 +1377,12 @@ begin
   // Перебор строк имеет смысл только при положительной высоте.
   if AValue > 0 then
   begin
+    if FBreakRepeatTopLabels then
+    begin
+      L := EffectiveRepeatTopRowCount;
+      if L > 0 then
+        RemoveTopLabelsFromParts(L);
+    end;
     MergeAllContinuationPartsIntoMain;
     SplitMainTableByBreakHeight(AValue);
   end;
@@ -1385,6 +1407,7 @@ begin
   ColCnt := ASource.ColCount;
 
   ADest.InsertPoint := ASource.InsertPoint;
+  ADest.RowBaseIndex := ASource.RowBaseIndex + AStart;
   ADest.RowCount := DstRows;
   ADest.ColCount := ColCnt;
   ADest.TableFlags := ASource.TableFlags;
@@ -1465,13 +1488,16 @@ end;
 // строки набираются в сегмент, пока их суммарная высота не превысит
 // порог AThreshold; затем начинается новый сегмент. Первый сегмент
 // остаётся в главной части, остальные выносятся в части-продолжения.
+// Если BreakRepeatTopLabels=True, верхние метки не считаются отдельными
+// строками логической таблицы в продолжениях: они добавляются поверх каждого
+// продолжения и уменьшают доступную высоту сегмента (issue #1311).
 // Число частей определяется автоматически (issue #1307).
 procedure GDBObjAcadTable.SplitMainTableByBreakHeight(AThreshold: Double);
 var
   FullData, TmpPart: TAcadTablePart;
   SegStart, SegEnd: array of Integer;
-  SegCount, StartRow, EndRow, PartIdx: Integer;
-  CurHeight, NextHeight: Double;
+  SegCount, StartRow, EndRow, PartIdx, RepeatRows, RowIdx: Integer;
+  CurHeight, NextHeight, RepeatHeight: Double;
 begin
   if (FRowCount <= 0) or (AThreshold <= 0) then
     Exit;
@@ -1479,6 +1505,18 @@ begin
   // Снимок текущей (объединённой) главной части
   CaptureTableDataToPart(Self, FullData);
   try
+    RepeatRows := 0;
+    RepeatHeight := 0;
+    if FBreakRepeatTopLabels then
+    begin
+      RepeatRows := ComputeTopLabelRowCount;
+      if RepeatRows > FullData.RowCount then
+        RepeatRows := FullData.RowCount;
+      for RowIdx := 0 to RepeatRows - 1 do
+        RepeatHeight := RepeatHeight +
+          uzeacadtable_layout.GetRowHeight(RowIdx, FullData.RowHeights);
+    end;
+
     // Вычисляем границы сегментов по высоте строк
     SegCount := 0;
     StartRow := 0;
@@ -1486,6 +1524,8 @@ begin
     begin
       EndRow := StartRow;
       CurHeight := 0;
+      if (SegCount > 0) and (RepeatRows > 0) then
+        CurHeight := RepeatHeight;
       while EndRow < FullData.RowCount do
       begin
         NextHeight := CurHeight +
@@ -1498,6 +1538,9 @@ begin
       end;
       if EndRow = StartRow then
         Inc(EndRow);
+      if (SegCount = 0) and (RepeatRows > 0) and
+         (EndRow < RepeatRows) then
+        EndRow := RepeatRows;
 
       System.SetLength(SegStart, SegCount + 1);
       System.SetLength(SegEnd, SegCount + 1);
@@ -1505,6 +1548,8 @@ begin
       SegEnd[SegCount] := EndRow - 1;
       Inc(SegCount);
       StartRow := EndRow;
+      if (RepeatRows > 0) and (StartRow < RepeatRows) then
+        StartRow := RepeatRows;
     end;
 
     // Части-продолжения для сегментов 1..SegCount-1
@@ -1512,8 +1557,12 @@ begin
       ClearPart(FContinuationParts[PartIdx]);
     System.SetLength(FContinuationParts, SegCount - 1);
     for PartIdx := 1 to SegCount - 1 do
+    begin
       SlicePartFromPart(FullData, SegStart[PartIdx], SegEnd[PartIdx],
         FContinuationParts[PartIdx - 1]);
+      if RepeatRows > 0 then
+        PrependTopLabelsToPart(RepeatRows, FContinuationParts[PartIdx - 1]);
+    end;
 
     // Сегмент 0 -> главная часть. Готовим временную часть и меняемся
     // данными с собой (точка вставки главной части сохраняется).
@@ -1656,6 +1705,36 @@ begin
   Result := True;
 end;
 
+// Обновляет логический индекс первой строки продолжений после чтения DXF или
+// автоопределения RepeatTop. Если верхние метки повторяются, визуальные строки
+// части начинаются с Title/Header и базовый стиль должен идти от нуля; иначе
+// первая визуальная строка продолжения получает стиль по логической позиции.
+procedure GDBObjAcadTable.UpdateContinuationRowBaseIndexes;
+var
+  PartIdx, BaseIdx, RepeatRows, LogicalRows: Integer;
+begin
+  BaseIdx := FRowCount;
+  RepeatRows := 0;
+  if FBreakRepeatTopLabels then
+    RepeatRows := EffectiveRepeatTopRowCount;
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    if (RepeatRows > 0) and
+       PartRepeatsTopLabels(FContinuationParts[PartIdx], RepeatRows) then
+    begin
+      FContinuationParts[PartIdx].RowBaseIndex := 0;
+      LogicalRows := FContinuationParts[PartIdx].RowCount - RepeatRows;
+    end
+    else
+    begin
+      FContinuationParts[PartIdx].RowBaseIndex := BaseIdx;
+      LogicalRows := FContinuationParts[PartIdx].RowCount;
+    end;
+    if LogicalRows > 0 then
+      Inc(BaseIdx, LogicalRows);
+  end;
+end;
+
 // Определяет признак повтора верхних меток по данным частей-продолжений.
 // Без частей сохраняется значение, прочитанное из DXF. При наличии частей
 // признак равен True тогда и только тогда, когда КАЖДАЯ часть повторяет
@@ -1666,6 +1745,7 @@ begin
   if Length(FContinuationParts) = 0 then
     Exit;
   FBreakRepeatTopLabels := EffectiveRepeatTopRowCount > 0;
+  UpdateContinuationRowBaseIndexes;
 end;
 
 function GDBObjAcadTable.GetBreakRepeatTopLabels: Boolean;
@@ -1683,13 +1763,20 @@ var
 begin
   if AValue = FBreakRepeatTopLabels then
     Exit;
+  L := 0;
   if Length(FContinuationParts) > 0 then
   begin
     if AValue then
     begin
       // Добавляем ведущие строки-метки главной части в каждую часть.
       L := ComputeTopLabelRowCount;
-      if L > 0 then
+      FBreakRepeatTopLabels := True;
+      if FBreakHeight > 0 then
+      begin
+        MergeAllContinuationPartsIntoMain;
+        SplitMainTableByBreakHeight(FBreakHeight);
+      end
+      else if L > 0 then
         AddTopLabelsToParts(L);
     end
     else
@@ -1698,16 +1785,21 @@ begin
       L := EffectiveRepeatTopRowCount;
       if L > 0 then
         RemoveTopLabelsFromParts(L);
+      FBreakRepeatTopLabels := False;
+      if FBreakHeight > 0 then
+      begin
+        MergeAllContinuationPartsIntoMain;
+        SplitMainTableByBreakHeight(FBreakHeight);
+      end;
     end;
-    if L > 0 then
+    if (FBreakHeight <= 0) and (L > 0) then
     begin
       RepositionContinuationParts;
-      FGeometryBuilt := False;
     end;
+    FGeometryBuilt := False;
   end
   else
-    L := 0;
-  FBreakRepeatTopLabels := AValue;
+    FBreakRepeatTopLabels := AValue;
   programlog.LogOutFormatStr(
     'AcadTable: model: SetBreakRepeatTopLabels=%d L=%d parts=%d',
     [Ord(AValue), L, Length(FContinuationParts)], LM_Info);
@@ -1765,6 +1857,7 @@ begin
 
   DstRows := L + Src.RowCount;
   APart.InsertPoint := Src.InsertPoint;
+  APart.RowBaseIndex := 0;
   APart.RowCount := DstRows;
   APart.ColCount := ColCnt;
   APart.TableFlags := Src.TableFlags;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -75,6 +75,9 @@ type
     // issue #1309, часть 2: снятие признака повтора удаляет повторяющиеся
     // строки-метки из всех частей, а возврат — добавляет их обратно.
     procedure TogglingBreakRepeatTopAddsAndRemovesLabelRows;
+    // issue #1311: строка данных, смещённая на место удалённых верхних меток,
+    // должна сохранять своё форматирование.
+    procedure ClearingBreakRepeatTopKeepsDataRowFormatting;
     // issue #1309: неразорванная таблица не имеет повтора верхних меток.
     procedure NonBrokenTableHasNoBreakRepeatTop;
   end;
@@ -245,6 +248,32 @@ begin
         if Sz > AMaxSize then AMaxSize := Sz;
       end;
       Inc(ACount);
+    end;
+    PEntity := AArr.iterate(IR);
+  end;
+end;
+
+function FindMTextSizeByTemplate(var AArr: GDBObjEntityTreeArray;
+  const ATemplate: String; out ASize: Double): Boolean;
+var
+  IR: itrec;
+  PEntity: PGDBObjEntity;
+  PMText: PGDBObjMText;
+begin
+  Result := False;
+  ASize := 0;
+  PEntity := AArr.beginiterate(IR);
+  while PEntity <> nil do
+  begin
+    if PEntity^.GetObjType = GDBMTextID then
+    begin
+      PMText := PGDBObjMText(PEntity);
+      if PMText^.Template = ATemplate then
+      begin
+        ASize := PMText^.textprop.size;
+        Result := True;
+        Exit;
+      end;
     end;
     PEntity := AArr.iterate(IR);
   end;
@@ -668,10 +697,11 @@ begin
   end;
 end;
 
-// issue #1309, часть 2. Установка BreakRepeatTopLabels=False должна удалить
-// повторяющиеся ведущие строки-метки (Title+Header, две строки) из всех
-// частей-продолжений; возврат в True — добавить их обратно. Проверяется как
-// число строк, так и содержимое первых ячеек, и повторное автоопределение.
+// issue #1309, часть 2 / issue #1311. Установка BreakRepeatTopLabels=False
+// должна удалить повторяющиеся ведущие строки-метки (Title+Header, две строки)
+// и пересегментировать строки по BreakHeight: освободившееся место заполняется
+// строками из следующих частей, пустые части исчезают. Возврат в True добавляет
+// метки обратно и снова пересегментирует таблицу.
 procedure TAcadTableStyleTest.TogglingBreakRepeatTopAddsAndRemovesLabelRows;
 var
   Drawing: TSimpleDrawing;
@@ -688,12 +718,15 @@ begin
     CheckTrue(AcadTable^.BreakRepeatTopLabels,
       'Исходно повтор верхних меток должен быть True');
 
-    // Снимаем повтор: две строки-метки удаляются из каждой части.
+    // Снимаем повтор: две строки-метки удаляются, строки следующих частей
+    // подтягиваются в освободившееся место, пустая часть исчезает.
     AcadTable^.BreakRepeatTopLabels := False;
-    CheckEquals(P0Before - 2, AcadTable^.ContinuationPartRowCount(0),
-      'После снятия повтора из части 0 должны исчезнуть две строки-метки');
-    CheckEquals(P1Before - 2, AcadTable^.ContinuationPartRowCount(1),
-      'После снятия повтора из части 1 должны исчезнуть две строки-метки');
+    CheckEquals(1, AcadTable^.ContinuationPartCount,
+      'После снятия повтора строки должны перераспределиться без пустой части');
+    CheckEquals(P0Before, AcadTable^.ContinuationPartRowCount(0),
+      'Первая часть-продолжение должна заполнить освободившееся место');
+    CheckEquals(-1, AcadTable^.ContinuationPartRowCount(1),
+      'Пустая вторая часть-продолжение должна исчезнуть');
     CheckFalse(AcadTable^.RecomputeBreakRepeatTopLabels,
       'После удаления меток автоопределение должно давать False');
     // Первой строкой части 0 теперь должна стать строка данных «11».
@@ -702,6 +735,8 @@ begin
 
     // Возвращаем повтор: строки-метки добавляются обратно.
     AcadTable^.BreakRepeatTopLabels := True;
+    CheckEquals(2, AcadTable^.ContinuationPartCount,
+      'После возврата повтора таблица снова должна разбиться на две части-продолжения');
     CheckEquals(P0Before, AcadTable^.ContinuationPartRowCount(0),
       'После возврата повтора число строк части 0 должно восстановиться');
     CheckEquals(P1Before, AcadTable^.ContinuationPartRowCount(1),
@@ -712,6 +747,39 @@ begin
       'После возврата повтора часть 0 снова начинается с «Zagolovok»');
     CheckEquals('A', AcadTable^.ContinuationPartCellText(0, 1, 0),
       'После возврата повтора часть 0 снова содержит шапку «A..E»');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1311. При снятии Repeat top labels строка данных «11» становится
+// первой визуальной строкой части-продолжения. Её стиль должен остаться стилем
+// данных, а не стать стилем Title/Header по новому локальному индексу строки.
+procedure TAcadTableStyleTest.ClearingBreakRepeatTopKeepsDataRowFormatting;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  SizeBefore, SizeAfter: Double;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    BuildTableGeometry(Drawing, AcadTable);
+    CheckTrue(FindMTextSizeByTemplate(
+      AcadTable^.ConstObjArray, '11', SizeBefore),
+      'До снятия повтора должна отрисоваться строка данных 11');
+
+    AcadTable^.BreakRepeatTopLabels := False;
+    BuildTableGeometry(Drawing, AcadTable);
+    CheckTrue(FindMTextSizeByTemplate(
+      AcadTable^.ConstObjArray, '11', SizeAfter),
+      'После снятия повтора должна отрисоваться строка данных 11');
+
+    CheckEquals(SizeBefore, SizeAfter, 1e-6,
+      'Смещение строки данных на место верхних меток не должно менять высоту текста');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
## Summary
- Preserve the logical row base for `AcadTable` continuation fragments so data rows keep Data formatting after repeated top labels are removed.
- Rebuild split fragments through `BreakHeight` when `BreakRepeatTopLabels` changes, so freed label height is filled by following data rows and empty fragments disappear.
- Treat repeated top labels as visual-only rows during split-height calculation, then prepend them back when repeat-top is enabled.
- Add regression coverage for both row reflow and the data-row formatting case from issue #1311.

## Reproduction
1. Load `cad_source/test/tablerazdel.dxf`.
2. Set `AcadTableBreakRepeatTop` / `BreakRepeatTopLabels` to `False`.
3. Before this change, data row `11` moved into the old top-label position but inherited Title/Header formatting, and an empty continuation fragment could remain.
4. After this change, row `11` keeps its data text formatting, rows reflow into the freed height, and the empty continuation fragment is removed.

## Tests
- Added/updated `TAcadTableStyleTest.TogglingBreakRepeatTopAddsAndRemovesLabelRows`.
- Added `TAcadTableStyleTest.ClearingBreakRepeatTopKeepsDataRowFormatting`.
- `git diff --check`
- `make -C cad_source/zengine/tests all` blocked locally: `/home/box/lazarus/lazbuild: not found`.

Fixes veb86/zcadvelecAI#1311
