### PR TITLE
AcadTable: make break direction editable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,3 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
-# Updated: 2026-06-10T10:51:04.132Z
-# Updated: 2026-06-11T10:58:24.394Z

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,2 +1,3 @@
 # .gitkeep file auto-generated at 2026-06-02T07:59:19.045Z for PR creation at branch issue-1272-4461738f2417 for issue https://github.com/veb86/zcadvelecAI/issues/1272
 # Updated: 2026-06-10T10:51:04.132Z
+# Updated: 2026-06-11T10:58:24.394Z

--- a/cad_source/zcad/register/uzcregacadtable.pas
+++ b/cad_source/zcad/register/uzcregacadtable.pas
@@ -21,9 +21,9 @@
   Модуль: uzcregacadtable
   Назначение: регистрация свойств AcadTable в инспекторе объектов ZCAD.
   Вынесено в отдельный модуль register по образцу uzcregleader,
-  чтобы не раздувать общие файлы инспектора. Свойства таблицы доступны
-  только для чтения и применяются исключительно к сущности AcadTable
-  (GDBAcadTableID), не затрагивая обычную сущность Table.
+  чтобы не раздувать общие файлы инспектора. Свойства применяются
+  исключительно к сущности AcadTable (GDBAcadTableID), не затрагивая
+  обычную сущность Table.
 
   Зависимости: uzcoimultiproperties, uzcoimultipropertiesutil,
                uzeacadtable_model, uzeacadtable_types, uzeconsts.
@@ -370,7 +370,8 @@ begin
   end;
 end;
 
-// Чтение направления разбиения (только чтение, отображается комбобоксом)
+// Чтение направления разбиения. При наличии change-процедуры свойство
+// редактируемое и отображается комбобоксом (issue #1315).
 procedure AcadTableBreakDirectionEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
   mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
   const f:TzeUnitsFormat);
@@ -387,6 +388,36 @@ begin
   else
     if PTEnumData(PVD^.data.Addr.Instance)^.Selected<>enumindex then
       ProcessVariableAttributes(PVD^.attrib,vda_different,0);
+end;
+
+// Запись направления разбиения (issue #1315). Изменение направления
+// пересчитывает точки вставки частей-продолжений в GDBObjAcadTable:
+// Left — влево от главной таблицы, Down — ниже главной таблицы.
+procedure AcadTableBreakDirectionEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  Table:PGDBObjAcadTable;
+  NewIndex:integer;
+  NewValue:TAcadTableBreakDirection;
+begin
+  Table:=PGDBObjAcadTable(ChangedData.PEntity);
+  NewIndex:=PTEnumData(pvardesk(pdata)^.data.Addr.Instance)^.Selected;
+  case NewIndex of
+    1: NewValue:=atbdDown;
+    2: NewValue:=atbdLeft;
+  else
+    NewValue:=atbdRight;
+  end;
+  if Table^.BreakDirection=NewValue then
+    exit;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  Table^.BreakDirection:=NewValue;
+  if drawings.GetCurrentDWG<>nil then
+    Table^.YouChanged(drawings.GetCurrentDWG^);
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
 end;
 
 procedure RegisterAcadTableProperties;
@@ -452,7 +483,7 @@ begin
 
   {AcadTable — разбиение таблицы}
   {Break enabled редактируется: снятие флага объединяет части (issue #1305).
-   Остальные параметры разбиения — только чтение.}
+   Break direction, Break spacing и Break height также редактируются.}
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableBreakEnabled','Break enabled',sysunit^.TypeName2PTD('Boolean'),
     MPCMisc,GDBAcadTableID,nil,0,0,
@@ -466,7 +497,8 @@ begin
     TMainIterateProcsData.Create(
       @GetAcadTableBreakDirectionData,@FreeTEnumData),
     TEntIterateProcsData.Create(
-      nil,@AcadTableBreakDirectionEntIterateProc,nil),
+      nil,@AcadTableBreakDirectionEntIterateProc,
+      @AcadTableBreakDirectionEntChangeProc),
     MPUM_AtLeastOneEntMatched);
   {Repeat top labels редактируется (issue #1309): снятие флага удаляет
    повторяющиеся верхние строки-метки из всех частей-продолжений, установка —

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -184,6 +184,8 @@ type
     // Чтение/запись вычисляемого признака разрыва таблицы (issue #1305)
     function GetBreakEnabled: Boolean;
     procedure SetBreakEnabled(AValue: Boolean);
+    // Чтение/запись направления разрыва таблицы (issue #1315)
+    procedure SetBreakDirection(AValue: TAcadTableBreakDirection);
     // Чтение/запись интервала между частями и высоты разбиения (issue #1307)
     function GetBreakSpacing: Double;
     procedure SetBreakSpacing(AValue: Double);
@@ -284,7 +286,7 @@ type
     // в False объединяет разорванную таблицу сверху вниз (часть 2b).
     property BreakEnabled: Boolean read GetBreakEnabled write SetBreakEnabled;
     property BreakDirection: TAcadTableBreakDirection
-      read FBreakDirection;
+      read FBreakDirection write SetBreakDirection;
     // Повтор верхних меток в каждой части разорванной таблицы (issue #1309).
     // Чтение возвращает определённое при загрузке значение; запись в False
     // удаляет повторяющиеся строки-метки из всех частей-продолжений, запись
@@ -1280,6 +1282,28 @@ begin
   programlog.LogOutFormatStr(
     'AcadTable: model: SetBreakEnabled(False) merged into ' +
     'single table rows=%d cols=%d', [FRowCount, FColCount], LM_Info);
+end;
+
+// Изменение направления разбиения (issue #1315). Для уже разорванной таблицы
+// смещает части-продолжения относительно главной части: Right/Left по ширине,
+// Down по высоте. Для inline-разбиения без частей достаточно сбросить
+// геометрию: RenderCurrentTable использует FBreakDirection напрямую.
+procedure GDBObjAcadTable.SetBreakDirection(AValue: TAcadTableBreakDirection);
+var
+  PartIdx: Integer;
+begin
+  if AValue = FBreakDirection then
+    Exit;
+
+  FBreakDirection := AValue;
+  for PartIdx := 0 to High(FContinuationParts) do
+    FContinuationParts[PartIdx].BreakDirection := AValue;
+  RepositionContinuationParts;
+  FGeometryBuilt := False;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetBreakDirection=%d parts=%d',
+    [Ord(FBreakDirection), Length(FContinuationParts)], LM_Info);
 end;
 
 // Объединяет все части-продолжения в главную часть: строки выстраиваются

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -72,6 +72,9 @@ type
     // issue #1307, часть 1: изменение интервала смещает части-продолжения
     // (меняется ширина отрисованного представления).
     procedure ChangingBreakSpacingRepositionsParts;
+    // issue #1315: изменение направления разбиения должно перемещать
+    // части-продолжения влево или вниз от главной таблицы.
+    procedure ChangingBreakDirectionRepositionsParts;
     // issue #1309, часть 1: при загрузке разорванной таблицы признак повтора
     // верхних меток определяется по содержимому частей-продолжений.
     procedure DetectsBreakRepeatTopOnLoad;
@@ -218,6 +221,50 @@ begin
       AHasGap := True;
     if Segments[i].MaxX > AMaxX then
       AMaxX := Segments[i].MaxX;
+  end;
+end;
+
+procedure CollectLineBounds2D(var AArr: GDBObjEntityTreeArray;
+  out AMinX, AMaxX, AMinY, AMaxY: Double; out AHasLines: Boolean);
+var
+  IR: itrec;
+  PEntity: PGDBObjEntity;
+  PLine: PGDBObjLine;
+  LineMinX, LineMaxX, LineMinY, LineMaxY: Double;
+begin
+  AMinX := 0;
+  AMaxX := 0;
+  AMinY := 0;
+  AMaxY := 0;
+  AHasLines := False;
+
+  PEntity := AArr.beginiterate(IR);
+  while PEntity <> nil do
+  begin
+    if PEntity^.GetObjType = GDBLineID then
+    begin
+      PLine := PGDBObjLine(PEntity);
+      LineMinX := Min(PLine^.CoordInWCS.lBegin.x, PLine^.CoordInWCS.lEnd.x);
+      LineMaxX := Max(PLine^.CoordInWCS.lBegin.x, PLine^.CoordInWCS.lEnd.x);
+      LineMinY := Min(PLine^.CoordInWCS.lBegin.y, PLine^.CoordInWCS.lEnd.y);
+      LineMaxY := Max(PLine^.CoordInWCS.lBegin.y, PLine^.CoordInWCS.lEnd.y);
+      if not AHasLines then
+      begin
+        AMinX := LineMinX;
+        AMaxX := LineMaxX;
+        AMinY := LineMinY;
+        AMaxY := LineMaxY;
+        AHasLines := True;
+      end
+      else
+      begin
+        if LineMinX < AMinX then AMinX := LineMinX;
+        if LineMaxX > AMaxX then AMaxX := LineMaxX;
+        if LineMinY < AMinY then AMinY := LineMinY;
+        if LineMaxY > AMaxY then AMaxY := LineMaxY;
+      end;
+    end;
+    PEntity := AArr.iterate(IR);
   end;
 end;
 
@@ -752,6 +799,61 @@ begin
 
     CheckTrue(MaxX2 > MaxX1 + 1e-6,
       'Увеличение интервала должно раздвинуть части и увеличить общую ширину');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1315. Направление разбиения должно быть редактируемым и менять
+// положение частей-продолжений: Left переносит их влево от главной таблицы,
+// Down — ниже главной таблицы.
+procedure TAcadTableStyleTest.ChangingBreakDirectionRepositionsParts;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  RightMinX, RightMaxX, RightMinY, RightMaxY: Double;
+  LeftMinX, LeftMaxX, LeftMinY, LeftMaxY: Double;
+  DownMinX, DownMaxX, DownMinY, DownMaxY: Double;
+  HasLines: Boolean;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckTrue(AcadTable^.ContinuationPartCount > 0,
+      'Таблица должна содержать части-продолжения');
+    CheckEquals(Ord(atbdRight), Ord(AcadTable^.BreakDirection),
+      'Исходное направление тестовой таблицы должно быть Right');
+
+    BuildTableGeometry(Drawing, AcadTable);
+    CollectLineBounds2D(AcadTable^.ConstObjArray,
+      RightMinX, RightMaxX, RightMinY, RightMaxY, HasLines);
+    CheckTrue(HasLines, 'Таблица должна отрисовать линии в WCS');
+
+    AcadTable^.BreakDirection := atbdLeft;
+    CheckEquals(Ord(atbdLeft), Ord(AcadTable^.BreakDirection),
+      'Свойство BreakDirection должно принимать значение Left');
+    BuildTableGeometry(Drawing, AcadTable);
+    CollectLineBounds2D(AcadTable^.ConstObjArray,
+      LeftMinX, LeftMaxX, LeftMinY, LeftMaxY, HasLines);
+    CheckTrue(HasLines, 'Таблица с направлением Left должна отрисовать линии');
+    CheckTrue(LeftMinX < RightMinX - 1e-6,
+      'Left должен переносить части-продолжения влево от главной таблицы');
+    CheckTrue(LeftMaxX < RightMaxX - 1e-6,
+      'Left не должен оставлять части-продолжения справа от главной таблицы');
+
+    AcadTable^.BreakDirection := atbdDown;
+    CheckEquals(Ord(atbdDown), Ord(AcadTable^.BreakDirection),
+      'Свойство BreakDirection должно принимать значение Down');
+    BuildTableGeometry(Drawing, AcadTable);
+    CollectLineBounds2D(AcadTable^.ConstObjArray,
+      DownMinX, DownMaxX, DownMinY, DownMaxY, HasLines);
+    CheckTrue(HasLines, 'Таблица с направлением Down должна отрисовать линии');
+    CheckTrue(DownMinY < RightMinY - 1e-6,
+      'Down должен переносить части-продолжения ниже главной таблицы');
+    CheckTrue(DownMaxX < RightMaxX - 1e-6,
+      'Down должен перестать раскладывать части вправо');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1315

## What changed
- Made `GDBObjAcadTable.BreakDirection` writable through a model setter.
- Reposition continuation parts when the direction changes: `Left` moves parts left of the main table, `Down` moves parts below it, and `Right` keeps the existing behavior.
- Wired the object inspector `Break direction` enum to the model setter instead of registering it as read-only.
- Added regression coverage for changing direction to `Left` and `Down` using rendered table line bounds.

## Reproduction
1. Load `cad_source/test/tablerazdel.dxf`.
2. Select the AcadTable and change `Break direction` from `Right` to `Left` or `Down`.
3. Before this fix the field was effectively read-only/right-only; after this fix the continuation parts are re-laid out in the selected direction.

## Tests
- `git diff --check` passed.
- `make -C cad_source/zengine/tests clean all` could not run in this container because `/home/box/lazarus/lazbuild` is not installed; the target exits with error 127 before compiling tests.
