### PR TITLE
AcadTable: save ACAD_TABLE entities to DXF

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-11T19:12:13.216Z for PR creation at branch issue-1317-22d20d4a47b9 for issue https://github.com/veb86/zcadvelecAI/issues/1317

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-11T19:12:13.216Z for PR creation at branch issue-1317-22d20d4a47b9 for issue https://github.com/veb86/zcadvelecAI/issues/1317

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -19,9 +19,9 @@
 {
   Модуль: uzeacadtable_dxf_write
   Назначение: Экспорт данных таблицы ACAD_TABLE в DXF-поток.
-  На текущем этапе экспорт не реализован (этап 3).
   Зависимости: uzeacadtable_types, uzctnrVectorBytesStream,
-               uzedrawingdef, uzeffdxfsupport, uzclog
+               uzedrawingdef, uzedrawingsimple, uzeffdxfsupport,
+               uzclog
 }
 
 unit uzeacadtable_dxf_write;
@@ -32,27 +32,523 @@ interface
 
 uses
   uzeacadtable_types,
-  uzctnrVectorBytesStream, uzedrawingdef, uzeffdxfsupport,
-  uzclog, uzbLogIntf;
+  uzegeometrytypes, uzctnrVectorBytesStream,
+  uzedrawingdef, uzedrawingsimple, uzeffdxfsupport,
+  uzeTypes, uzeconsts, uzclog, uzbLogIntf;
 
-// Сохраняет таблицу в DXF-поток.
-// TODO (этап 3): добавить полноценный экспорт в формат ACAD_TABLE.
+type
+  TAcadTableDoubleArray = array of Double;
+
+  TAcadTableDXFWritePart = record
+    HandleKey: Pointer;
+    LayerName: String;
+    Color: Integer;
+    LineWeight: Integer;
+    LineTypeName: String;
+    LineTypeScale: Double;
+    InsertPoint: TzePoint3d;
+    Direction: TzePoint3d;
+    RowCount: Integer;
+    ColCount: Integer;
+    RowHeights: TAcadTableDoubleArray;
+    ColWidths: TAcadTableDoubleArray;
+    CellTexts: TTableTextArray;
+    Cells: TTableCellArray;
+    Merges: TMergeRangeArray;
+    TableStyleHandle: String;
+    TableFlags: Integer;
+    BreakEnabled: Boolean;
+    BreakDirection: TAcadTableBreakDirection;
+    BreakRepeatTopLabels: Boolean;
+    BreakRepeatBottomLabels: Boolean;
+    BreakManualPosition: Boolean;
+    BreakManualHeight: Boolean;
+    BreakSpacing: Double;
+    BreakHeight: Double;
+  end;
+
+  TAcadTableDXFWritePartArray = array of TAcadTableDXFWritePart;
+
+procedure ResetAcadTableDXFWriteState;
+
 procedure WriteAcadTableToDXF(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TDrawingDef;
+  var AIODXFContext: TIODXFSaveContext;
+  const APart: TAcadTableDXFWritePart;
+  APartIndex: Integer = 0);
+
+procedure WriteAcadTableContinuationPartsToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TDrawingDef;
+  var AIODXFContext: TIODXFSaveContext;
+  const AMainPart: TAcadTableDXFWritePart;
+  const AParts: TAcadTableDXFWritePartArray);
+
+procedure WriteAcadTableRoundTripObjectsToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TSimpleDrawing;
   var AIODXFContext: TIODXFSaveContext);
 
 implementation
 
+uses
+  SysUtils, uzeffdxfout;
+
+type
+  TAcadTableRoundTripRecord = record
+    MainHandle: TDWGHandle;
+    ContinuationHandles: array of TDWGHandle;
+    BreakSpacing: Double;
+    BreakHeight: Double;
+  end;
+
+var
+  RoundTripRecords: array of TAcadTableRoundTripRecord;
+
+procedure ResetAcadTableDXFWriteState;
+var
+  I: Integer;
+begin
+  for I := 0 to High(RoundTripRecords) do
+    System.SetLength(RoundTripRecords[I].ContinuationHandles, 0);
+  System.SetLength(RoundTripRecords, 0);
+end;
+
+function BoolToDXF(AValue: Boolean): Integer;
+begin
+  if AValue then
+    Result := 1
+  else
+    Result := 0;
+end;
+
+function BreakDirectionToDXF(
+  ADirection: TAcadTableBreakDirection): Integer;
+begin
+  case ADirection of
+    atbdDown:
+      Result := 2;
+    atbdLeft:
+      Result := 3;
+  else
+    Result := 1;
+  end;
+end;
+
+function NextAnonymousHandle(
+  var AIODXFContext: TIODXFSaveContext): TDWGHandle;
+begin
+  Result := AIODXFContext.handle;
+  Inc(AIODXFContext.handle);
+end;
+
+function EntityHandleForPart(
+  const APart: TAcadTableDXFWritePart;
+  var AIODXFContext: TIODXFSaveContext): TDWGHandle;
+begin
+  if APart.HandleKey <> nil then
+    AIODXFContext.p2h.MyGetOrCreateValue(
+      APart.HandleKey, AIODXFContext.handle, Result)
+  else
+    Result := NextAnonymousHandle(AIODXFContext);
+end;
+
+function RowHeightAt(
+  const APart: TAcadTableDXFWritePart;
+  ARow: Integer): Double;
+begin
+  if (ARow >= 0) and (ARow <= High(APart.RowHeights)) then
+    Result := APart.RowHeights[ARow]
+  else
+    Result := CAcadTableDefaultRowHeight;
+  if Result <= 0 then
+    Result := CAcadTableDefaultRowHeight;
+end;
+
+function ColWidthAt(
+  const APart: TAcadTableDXFWritePart;
+  ACol: Integer): Double;
+begin
+  if (ACol >= 0) and (ACol <= High(APart.ColWidths)) then
+    Result := APart.ColWidths[ACol]
+  else
+    Result := CAcadTableDefaultColWidth;
+  if Result <= 0 then
+    Result := CAcadTableDefaultColWidth;
+end;
+
+function CellTextAt(
+  const APart: TAcadTableDXFWritePart;
+  ARow, ACol: Integer): String;
+var
+  CellIndex: Integer;
+begin
+  Result := '';
+  if APart.ColCount <= 0 then
+    Exit;
+  CellIndex := ARow * APart.ColCount + ACol;
+  if (CellIndex >= 0) and
+     (CellIndex <= High(APart.CellTexts)) then
+    Result := APart.CellTexts[CellIndex];
+  if (Result = '') and
+     (ARow >= 0) and (ARow <= High(APart.Cells)) and
+     (ACol >= 0) and (ACol <= High(APart.Cells[ARow])) then
+    Result := APart.Cells[ARow][ACol].Text;
+end;
+
+function CellAlignmentAt(
+  const APart: TAcadTableDXFWritePart;
+  ARow, ACol: Integer): Integer;
+begin
+  Result := 0;
+  if (ARow >= 0) and (ARow <= High(APart.Cells)) and
+     (ACol >= 0) and (ACol <= High(APart.Cells[ARow])) then
+    Result := APart.Cells[ARow][ACol].CellAlignment;
+end;
+
+function FindMergeForCell(
+  const APart: TAcadTableDXFWritePart;
+  ARow, ACol: Integer;
+  out AMerge: TMergeRange): Boolean;
+var
+  I: Integer;
+begin
+  Result := False;
+  for I := 0 to High(APart.Merges) do
+    if (ARow >= APart.Merges[I].Row1) and
+       (ARow <= APart.Merges[I].Row2) and
+       (ACol >= APart.Merges[I].Col1) and
+       (ACol <= APart.Merges[I].Col2) then
+    begin
+      AMerge := APart.Merges[I];
+      Result := True;
+      Exit;
+    end;
+end;
+
+procedure GetCellSpanAndVirtualFlag(
+  const APart: TAcadTableDXFWritePart;
+  ARow, ACol: Integer;
+  out AColSpan, ARowSpan: Integer;
+  out AIsVirtual: Boolean);
+var
+  MergeRange: TMergeRange;
+begin
+  AColSpan := 1;
+  ARowSpan := 1;
+  AIsVirtual := False;
+
+  if FindMergeForCell(APart, ARow, ACol, MergeRange) then
+  begin
+    if (ARow = MergeRange.Row1) and
+       (ACol = MergeRange.Col1) then
+    begin
+      AColSpan := MergeRange.Col2 - MergeRange.Col1 + 1;
+      ARowSpan := MergeRange.Row2 - MergeRange.Row1 + 1;
+    end
+    else
+      AIsVirtual := True;
+  end
+  else if (ARow >= 0) and (ARow <= High(APart.Cells)) and
+          (ACol >= 0) and (ACol <= High(APart.Cells[ARow])) then
+  begin
+    if APart.Cells[ARow][ACol].ColSpan > 1 then
+      AColSpan := APart.Cells[ARow][ACol].ColSpan;
+    if APart.Cells[ARow][ACol].RowSpan > 1 then
+      ARowSpan := APart.Cells[ARow][ACol].RowSpan;
+  end;
+end;
+
+procedure WriteEntityPrefix(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const APart: TAcadTableDXFWritePart;
+  out AHandle: TDWGHandle);
+begin
+  AHandle := EntityHandleForPart(APart, AIODXFContext);
+
+  dxfStringWithoutEncodeOut(AOutStream, 0, 'ACAD_TABLE');
+  dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(AHandle, 0));
+  dxfStringWithoutEncodeOut(AOutStream, 100, dxfName_AcDbEntity);
+  if APart.LayerName <> '' then
+    dxfStringout(AOutStream, 8, APart.LayerName,
+      AIODXFContext.Header)
+  else
+    dxfStringout(AOutStream, 8, '0', AIODXFContext.Header);
+  if APart.Color <> ClByLayer then
+    dxfIntegerout(AOutStream, 62, APart.Color);
+  if APart.LineWeight <> -1 then
+    dxfIntegerout(AOutStream, 370, APart.LineWeight);
+  if APart.LineTypeName <> '' then
+    dxfStringout(AOutStream, 6, APart.LineTypeName,
+      AIODXFContext.Header);
+  if APart.LineTypeScale <> 1 then
+    dxfDoubleout(AOutStream, 48, APart.LineTypeScale);
+end;
+
+procedure WriteBlockReference(
+  var AOutStream: TZctnrVectorBytes;
+  const APart: TAcadTableDXFWritePart;
+  APartIndex: Integer);
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbBlockReference');
+  dxfStringWithoutEncodeOut(AOutStream, 2,
+    Format('*T%d', [APartIndex + 1]));
+  dxfvertexout(AOutStream, 10, APart.InsertPoint);
+end;
+
+procedure WriteTableHeader(
+  var AOutStream: TZctnrVectorBytes;
+  const APart: TAcadTableDXFWritePart);
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbTable');
+  if APart.TableStyleHandle <> '' then
+    dxfStringWithoutEncodeOut(AOutStream, 342, APart.TableStyleHandle);
+  dxfvertexout(AOutStream, 11, APart.Direction);
+  dxfIntegerout(AOutStream, 90, APart.TableFlags);
+  dxfIntegerout(AOutStream, 91, APart.RowCount);
+  dxfIntegerout(AOutStream, 92, APart.ColCount);
+  dxfIntegerout(AOutStream, 93, 0);
+  dxfIntegerout(AOutStream, 94, 0);
+  dxfIntegerout(AOutStream, 95, 0);
+  dxfIntegerout(AOutStream, 96, 0);
+
+  if APart.BreakEnabled or (APart.BreakSpacing <> 0) then
+  begin
+    dxfIntegerout(AOutStream, 292, BoolToDXF(APart.BreakEnabled));
+    dxfIntegerout(AOutStream, 282,
+      BreakDirectionToDXF(APart.BreakDirection));
+    dxfIntegerout(AOutStream, 291,
+      BoolToDXF(APart.BreakRepeatTopLabels));
+    dxfIntegerout(AOutStream, 294,
+      BoolToDXF(APart.BreakRepeatBottomLabels));
+    dxfIntegerout(AOutStream, 293,
+      BoolToDXF(APart.BreakManualPosition));
+    dxfIntegerout(AOutStream, 295,
+      BoolToDXF(APart.BreakManualHeight));
+    dxfDoubleout(AOutStream, 146, APart.BreakSpacing);
+  end;
+end;
+
+procedure WriteTableDimensions(
+  var AOutStream: TZctnrVectorBytes;
+  const APart: TAcadTableDXFWritePart);
+var
+  I: Integer;
+begin
+  for I := 0 to APart.RowCount - 1 do
+    dxfDoubleout(AOutStream, 141, RowHeightAt(APart, I));
+  for I := 0 to APart.ColCount - 1 do
+    dxfDoubleout(AOutStream, 142, ColWidthAt(APart, I));
+end;
+
+procedure WriteCell(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const APart: TAcadTableDXFWritePart;
+  ARow, ACol: Integer);
+var
+  CellText: String;
+  ColSpan, RowSpan: Integer;
+  IsVirtual: Boolean;
+  Alignment: Integer;
+begin
+  CellText := CellTextAt(APart, ARow, ACol);
+  GetCellSpanAndVirtualFlag(APart, ARow, ACol,
+    ColSpan, RowSpan, IsVirtual);
+  Alignment := CellAlignmentAt(APart, ARow, ACol);
+
+  dxfIntegerout(AOutStream, 171, 1);
+  dxfIntegerout(AOutStream, 172, 0);
+  dxfIntegerout(AOutStream, 173, BoolToDXF(IsVirtual));
+  if Alignment <> 0 then
+    dxfIntegerout(AOutStream, 170, Alignment);
+  dxfIntegerout(AOutStream, 174, 0);
+  dxfIntegerout(AOutStream, 175, ColSpan);
+  dxfIntegerout(AOutStream, 176, RowSpan);
+  dxfIntegerout(AOutStream, 91, 262144);
+  dxfIntegerout(AOutStream, 178, 0);
+  dxfDoubleout(AOutStream, 145, 0);
+  dxfIntegerout(AOutStream, 92, 0);
+  dxfStringWithoutEncodeOut(AOutStream, 301, 'CELL_VALUE');
+  if CellText <> '' then
+    dxfIntegerout(AOutStream, 93, 6)
+  else
+    dxfIntegerout(AOutStream, 93, 0);
+  dxfIntegerout(AOutStream, 90, 4);
+  if CellText <> '' then
+    dxfStringout(AOutStream, 1, CellText, AIODXFContext.Header);
+  dxfIntegerout(AOutStream, 94, 0);
+  dxfStringWithoutEncodeOut(AOutStream, 300, '');
+  dxfStringout(AOutStream, 302, CellText, AIODXFContext.Header);
+  dxfStringWithoutEncodeOut(AOutStream, 304, 'ACVALUE_END');
+end;
+
+procedure WriteTableCells(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const APart: TAcadTableDXFWritePart);
+var
+  RowIdx, ColIdx: Integer;
+begin
+  for RowIdx := 0 to APart.RowCount - 1 do
+    for ColIdx := 0 to APart.ColCount - 1 do
+      WriteCell(AOutStream, AIODXFContext, APart,
+        RowIdx, ColIdx);
+end;
+
+procedure AddRoundTripRecord(
+  AMainHandle: TDWGHandle;
+  const AContinuationHandles: array of TDWGHandle;
+  ABreakSpacing, ABreakHeight: Double);
+var
+  RecIdx, HandleIdx: Integer;
+begin
+  if Length(AContinuationHandles) = 0 then
+    Exit;
+
+  RecIdx := Length(RoundTripRecords);
+  System.SetLength(RoundTripRecords, RecIdx + 1);
+  RoundTripRecords[RecIdx].MainHandle := AMainHandle;
+  RoundTripRecords[RecIdx].BreakSpacing := ABreakSpacing;
+  RoundTripRecords[RecIdx].BreakHeight := ABreakHeight;
+  System.SetLength(
+    RoundTripRecords[RecIdx].ContinuationHandles,
+    Length(AContinuationHandles));
+  for HandleIdx := 0 to High(AContinuationHandles) do
+    RoundTripRecords[RecIdx].ContinuationHandles[HandleIdx] :=
+      AContinuationHandles[HandleIdx];
+end;
+
+procedure WriteAcadTablePartToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TDrawingDef;
+  var AIODXFContext: TIODXFSaveContext;
+  const APart: TAcadTableDXFWritePart;
+  APartIndex: Integer;
+  out AEntityHandle: TDWGHandle);
+begin
+  WriteEntityPrefix(AOutStream, AIODXFContext, APart,
+    AEntityHandle);
+  WriteBlockReference(AOutStream, APart, APartIndex);
+  WriteTableHeader(AOutStream, APart);
+  WriteTableDimensions(AOutStream, APart);
+  WriteTableCells(AOutStream, AIODXFContext, APart);
+
+  programlog.LogOutFormatStr(
+    'AcadTable: dxf_write: exported rows=%d cols=%d handle=%s',
+    [APart.RowCount, APart.ColCount, IntToHex(AEntityHandle, 0)],
+    LM_Info);
+end;
+
 procedure WriteAcadTableToDXF(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TDrawingDef;
-  var AIODXFContext: TIODXFSaveContext);
+  var AIODXFContext: TIODXFSaveContext;
+  const APart: TAcadTableDXFWritePart;
+  APartIndex: Integer = 0);
+var
+  EntityHandle: TDWGHandle;
 begin
-  // Экспорт не реализован (этап 3)
-  programlog.LogOutStr(
-    'AcadTable: dxf_write: WriteAcadTableToDXF — ' +
-    'экспорт не реализован (этап 3)', LM_Info);
+  WriteAcadTablePartToDXF(AOutStream, ADrawing, AIODXFContext,
+    APart, APartIndex, EntityHandle);
 end;
+
+procedure WriteAcadTableContinuationPartsToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TDrawingDef;
+  var AIODXFContext: TIODXFSaveContext;
+  const AMainPart: TAcadTableDXFWritePart;
+  const AParts: TAcadTableDXFWritePartArray);
+var
+  MainHandle: TDWGHandle;
+  ContinuationHandles: array of TDWGHandle;
+  ContinuationHandle: TDWGHandle;
+  PartIdx: Integer;
+begin
+  if Length(AParts) = 0 then
+    Exit;
+
+  if AMainPart.HandleKey <> nil then
+    AIODXFContext.p2h.MyGetOrCreateValue(
+      AMainPart.HandleKey, AIODXFContext.handle, MainHandle)
+  else
+    Exit;
+
+  System.SetLength(ContinuationHandles, Length(AParts));
+  for PartIdx := 0 to High(AParts) do
+  begin
+    WriteAcadTablePartToDXF(AOutStream, ADrawing, AIODXFContext,
+      AParts[PartIdx], PartIdx + 1, ContinuationHandle);
+    ContinuationHandles[PartIdx] := ContinuationHandle;
+  end;
+
+  AddRoundTripRecord(MainHandle, ContinuationHandles,
+    AMainPart.BreakSpacing, AMainPart.BreakHeight);
+end;
+
+procedure WriteRoundTripRecordToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const ARecord: TAcadTableRoundTripRecord);
+var
+  ObjectHandle: TDWGHandle;
+  HandleIdx: Integer;
+begin
+  ObjectHandle := NextAnonymousHandle(AIODXFContext);
+
+  dxfStringWithoutEncodeOut(AOutStream, 0, 'XRECORD');
+  dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(ObjectHandle, 0));
+  dxfStringWithoutEncodeOut(AOutStream, 330, '0');
+  dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbXrecord');
+  dxfIntegerout(AOutStream, 280, 1);
+  dxfStringWithoutEncodeOut(AOutStream, 102,
+    'ACAD_ROUNDTRIP_2008_TABLE_ENTITY');
+  dxfStringWithoutEncodeOut(AOutStream, 360,
+    IntToHex(ARecord.MainHandle, 0));
+  dxfIntegerout(AOutStream, 70, 1);
+  dxfIntegerout(AOutStream, 90, 3);
+  dxfIntegerout(AOutStream, 90, 1);
+  dxfDoubleout(AOutStream, 40, ARecord.BreakSpacing);
+  dxfIntegerout(AOutStream, 90, 2);
+  dxfIntegerout(AOutStream, 90, 0);
+  dxfIntegerout(AOutStream, 90, 1);
+  dxfDoubleout(AOutStream, 10, 0);
+  dxfDoubleout(AOutStream, 20, 0);
+  dxfDoubleout(AOutStream, 30, 0);
+  dxfDoubleout(AOutStream, 40, ARecord.BreakHeight);
+  for HandleIdx := 0 to High(ARecord.ContinuationHandles) do
+    dxfStringWithoutEncodeOut(AOutStream, 330,
+      IntToHex(ARecord.ContinuationHandles[HandleIdx], 0));
+  dxfStringWithoutEncodeOut(AOutStream, 361,
+    IntToHex(ARecord.MainHandle, 0));
+end;
+
+procedure WriteAcadTableRoundTripObjectsToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TSimpleDrawing;
+  var AIODXFContext: TIODXFSaveContext);
+var
+  RecIdx: Integer;
+begin
+  for RecIdx := 0 to High(RoundTripRecords) do
+    WriteRoundTripRecordToDXF(
+      AOutStream, AIODXFContext, RoundTripRecords[RecIdx]);
+  ResetAcadTableDXFWriteState;
+end;
+
+procedure ResetAcadTableDXFWriteStateBeforeSave(
+  var ADrawing: TSimpleDrawing);
+begin
+  ResetAcadTableDXFWriteState;
+end;
+
+initialization
+  RegisterBeforeSaveDxfProc(@ResetAcadTableDXFWriteStateBeforeSave);
+  RegisterObjectsSaveDxfProc(@WriteAcadTableRoundTripObjectsToDXF);
+
+finalization
+  ResetAcadTableDXFWriteState;
 
 end.

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -230,6 +230,12 @@ type
     // Вставляет первые L строк-меток главной части в начало одной
     // части-продолжения (issue #1309).
     procedure PrependTopLabelsToPart(L: Integer; var APart: TAcadTablePart);
+    // Подготовка данных для специализированного DXF writer.
+    procedure FillDXFWritePartFromSelf(var APart: TAcadTableDXFWritePart);
+    procedure FillDXFWritePartFromContinuation(
+      const ASource: TAcadTablePart; var APart: TAcadTableDXFWritePart);
+    procedure BuildDXFContinuationWriteParts(
+      var AParts: TAcadTableDXFWritePartArray);
 
   public
     constructor initnul(
@@ -2262,21 +2268,153 @@ begin
   Result := True;
 end;
 
+procedure CopyVectorToDXFDoubleArray(
+  const ASource: TZctnrVectorDouble;
+  var ADest: TAcadTableDoubleArray);
+var
+  Idx: Integer;
+begin
+  System.SetLength(ADest, ASource.Count);
+  for Idx := 0 to ASource.Count - 1 do
+    ADest[Idx] := ASource.getData(Idx);
+end;
+
+procedure CopyCellTextArray(
+  const ASource: TTableTextArray;
+  var ADest: TTableTextArray);
+var
+  Idx: Integer;
+begin
+  System.SetLength(ADest, Length(ASource));
+  for Idx := 0 to High(ASource) do
+    ADest[Idx] := ASource[Idx];
+end;
+
+procedure CopyCellArray(
+  const ASource: TTableCellArray;
+  var ADest: TTableCellArray);
+var
+  RowIdx, ColIdx: Integer;
+begin
+  System.SetLength(ADest, Length(ASource));
+  for RowIdx := 0 to High(ASource) do
+  begin
+    System.SetLength(ADest[RowIdx], Length(ASource[RowIdx]));
+    for ColIdx := 0 to High(ASource[RowIdx]) do
+      ADest[RowIdx][ColIdx] := ASource[RowIdx][ColIdx];
+  end;
+end;
+
+procedure CopyMergeArray(
+  const ASource: TMergeRangeArray;
+  var ADest: TMergeRangeArray);
+var
+  Idx: Integer;
+begin
+  System.SetLength(ADest, Length(ASource));
+  for Idx := 0 to High(ASource) do
+    ADest[Idx] := ASource[Idx];
+end;
+
+procedure GDBObjAcadTable.FillDXFWritePartFromSelf(
+  var APart: TAcadTableDXFWritePart);
+begin
+  APart.HandleKey := @Self;
+  if vp.Layer <> nil then
+    APart.LayerName := vp.Layer^.Name
+  else
+    APart.LayerName := '0';
+  APart.Color := vp.Color;
+  APart.LineWeight := vp.lineweight;
+  if vp.LineType <> nil then
+    APart.LineTypeName := vp.LineType^.Name
+  else
+    APart.LineTypeName := '';
+  APart.LineTypeScale := vp.LineTypeScale;
+
+  APart.InsertPoint := FInsertPoint;
+  APart.Direction.x := Cos(FRotate);
+  APart.Direction.y := Sin(FRotate);
+  APart.Direction.z := 0;
+  APart.RowCount := FRowCount;
+  APart.ColCount := FColCount;
+  CopyVectorToDXFDoubleArray(FRowHeights, APart.RowHeights);
+  CopyVectorToDXFDoubleArray(FColWidths, APart.ColWidths);
+  CopyCellTextArray(FCellTexts, APart.CellTexts);
+  CopyCellArray(FCells, APart.Cells);
+  CopyMergeArray(FMerges, APart.Merges);
+  APart.TableStyleHandle := FTableStyleHandle;
+  APart.TableFlags := FTableFlags;
+  APart.BreakEnabled := GetBreakEnabled;
+  APart.BreakDirection := FBreakDirection;
+  APart.BreakRepeatTopLabels := FBreakRepeatTopLabels;
+  APart.BreakRepeatBottomLabels := FBreakRepeatBottomLabels;
+  APart.BreakManualPosition := FBreakManualPosition;
+  APart.BreakManualHeight := FBreakManualHeight;
+  APart.BreakSpacing := FBreakSpacing;
+  APart.BreakHeight := FBreakHeight;
+end;
+
+procedure GDBObjAcadTable.FillDXFWritePartFromContinuation(
+  const ASource: TAcadTablePart; var APart: TAcadTableDXFWritePart);
+begin
+  FillDXFWritePartFromSelf(APart);
+  APart.HandleKey := nil;
+  APart.InsertPoint := ASource.InsertPoint;
+  APart.RowCount := ASource.RowCount;
+  APart.ColCount := ASource.ColCount;
+  CopyVectorToDXFDoubleArray(ASource.RowHeights, APart.RowHeights);
+  CopyVectorToDXFDoubleArray(ASource.ColWidths, APart.ColWidths);
+  CopyCellTextArray(ASource.CellTexts, APart.CellTexts);
+  CopyCellArray(ASource.Cells, APart.Cells);
+  CopyMergeArray(ASource.Merges, APart.Merges);
+  APart.TableStyleHandle := ASource.TableStyleHandle;
+  APart.TableFlags := ASource.TableFlags;
+  APart.BreakEnabled := ASource.BreakEnabled;
+  APart.BreakDirection := ASource.BreakDirection;
+  APart.BreakRepeatTopLabels := ASource.BreakRepeatTopLabels;
+  APart.BreakRepeatBottomLabels := ASource.BreakRepeatBottomLabels;
+  APart.BreakManualPosition := ASource.BreakManualPosition;
+  APart.BreakManualHeight := ASource.BreakManualHeight;
+  APart.BreakSpacing := ASource.BreakSpacing;
+  APart.BreakHeight := ASource.BreakHeight;
+end;
+
+procedure GDBObjAcadTable.BuildDXFContinuationWriteParts(
+  var AParts: TAcadTableDXFWritePartArray);
+var
+  PartIdx: Integer;
+begin
+  System.SetLength(AParts, Length(FContinuationParts));
+  for PartIdx := 0 to High(FContinuationParts) do
+    FillDXFWritePartFromContinuation(
+      FContinuationParts[PartIdx], AParts[PartIdx]);
+end;
+
 procedure GDBObjAcadTable.SaveToDXF(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TDrawingDef;
   var AIODXFContext: TIODXFSaveContext);
+var
+  DXFPart: TAcadTableDXFWritePart;
 begin
+  FillDXFWritePartFromSelf(DXFPart);
   uzeacadtable_dxf_write.WriteAcadTableToDXF(
-    AOutStream, ADrawing, AIODXFContext);
+    AOutStream, ADrawing, AIODXFContext, DXFPart, 0);
 end;
 
 procedure GDBObjAcadTable.SaveToDXFFollow(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TDrawingDef;
   var AIODXFContext: TIODXFSaveContext);
+var
+  MainPart: TAcadTableDXFWritePart;
+  Parts: TAcadTableDXFWritePartArray;
 begin
-  // Пустая реализация
+  FillDXFWritePartFromSelf(MainPart);
+  BuildDXFContinuationWriteParts(Parts);
+  uzeacadtable_dxf_write.WriteAcadTableContinuationPartsToDXF(
+    AOutStream, ADrawing, AIODXFContext, MainPart, Parts);
 end;
 
 function GDBObjAcadTable.Clone(

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -36,10 +36,17 @@ type
     на pre-save обработку чертежа (например, конвертацию ProxyEntity
     в BlockInsert). }
   TBeforeSaveDxfProc=procedure(var drawing:TSimpleDrawing);
+  { Callback, вызываемый перед закрытием секции OBJECTS. Позволяет
+    специализированным модулям записывать свои OBJECTS-сущности, не
+    добавляя предметные зависимости в общий DXF writer. }
+  TObjectsSaveDxfProc=procedure(var outstream:TZctnrVectorBytes;
+                                var drawing:TSimpleDrawing;
+                                var IODXFContext:TIODXFSaveContext);
 
 { Регистрирует pre-save callback. Все зарегистрированные callback'и
   вызываются в порядке регистрации в начале savedxf20XX. }
 procedure RegisterBeforeSaveDxfProc(proc:TBeforeSaveDxfProc);
+procedure RegisterObjectsSaveDxfProc(proc:TObjectsSaveDxfProc);
 
 function savedxf20XX(const SavedFileName:string;const TemplateFileName:string;var drawing:TSimpleDrawing;AVer:TZCDxfVersion):boolean;
 
@@ -47,6 +54,7 @@ implementation
 
 var
   BeforeSaveDxfProcs:array of TBeforeSaveDxfProc;
+  ObjectsSaveDxfProcs:array of TObjectsSaveDxfProc;
 
 procedure RegisterBeforeSaveDxfProc(proc:TBeforeSaveDxfProc);
 var
@@ -55,6 +63,15 @@ begin
   i:=Length(BeforeSaveDxfProcs);
   SetLength(BeforeSaveDxfProcs,i+1);
   BeforeSaveDxfProcs[i]:=proc;
+end;
+
+procedure RegisterObjectsSaveDxfProc(proc:TObjectsSaveDxfProc);
+var
+  i:Integer;
+begin
+  i:=Length(ObjectsSaveDxfProcs);
+  SetLength(ObjectsSaveDxfProcs,i+1);
+  ObjectsSaveDxfProcs[i]:=proc;
 end;
 
 procedure RegisterAcadAppInDXF(const appname:string;outstream:PTZctnrVectorBytes;var handle:TDWGHandle);
@@ -355,6 +372,16 @@ var
   tsHandles: array of TDWGHandle;
   tsCount: integer;
   beforeProcIdx: integer;
+
+  procedure RunObjectsSaveDxfProcs;
+  var
+    objectsProcIdx: Integer;
+  begin
+    for objectsProcIdx:=0 to High(ObjectsSaveDxfProcs) do
+      if Assigned(ObjectsSaveDxfProcs[objectsProcIdx]) then
+        ObjectsSaveDxfProcs[objectsProcIdx](
+          outstream,drawing,IODXFContext);
+  end;
 begin
   intable:=0;
   IODXFContext.InitRec;
@@ -1314,8 +1341,10 @@ begin
                 ptablestyle:=drawing.DXFTableStyleTable.iterate(tablestyleiter);
               end;
             end;
-            if values=dxfName_ENDSEC then
+            if values=dxfName_ENDSEC then begin
+              RunObjectsSaveDxfProcs;
               inobjectssec:=False;
+            end;
             outstream.TXTAddStringEOL(dxfGroupCode(0));
             outstream.TXTAddStringEOL(values);
           end else begin
@@ -1363,8 +1392,10 @@ begin
             end;
           end;
           { Записываем текущую пару (начало следующего объекта) }
-          if values=dxfName_ENDSEC then
+          if values=dxfName_ENDSEC then begin
+            RunObjectsSaveDxfProcs;
             inobjectssec:=False;
+          end;
           outstream.TXTAddStringEOL(dxfGroupCode(0));
           outstream.TXTAddStringEOL(values);
         end else if inobjectssec and (groupi=0) and (values=dxfName_ENDSEC) then begin
@@ -1382,6 +1413,7 @@ begin
               ptablestyle:=drawing.DXFTableStyleTable.iterate(tablestyleiter);
             end;
           end;
+          RunObjectsSaveDxfProcs;
           inobjectssec:=False;
           outstream.TXTAddStringEOL(groups);
           outstream.TXTAddStringEOL(values);

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -22,6 +22,8 @@ uses
   testregistry,
   Interfaces,
   uzeffdxf,
+  uzctnrVectorBytesStream,
+  uzeffdxfsupport,
   uzedrawingsimple,
   uzeffmanager,
   uzgldrawcontext,
@@ -40,7 +42,8 @@ uses
   uzeentblockinsert,
   uzeenttable,
   uzeacadtable_types,
-  uzeacadtable_model;
+  uzeacadtable_model,
+  uzeacadtable_dxf_write;
 
 type
   TAcadTableStyleTest = class(TTestCase)
@@ -51,6 +54,9 @@ type
     procedure RendersBrokenTableAsSeparatedFragments;
     procedure LoadsSplitTableAsSingleMergedObject;
     procedure AppliesTableStyleToContinuationParts;
+    // issue #1317: сохранение AcadTable в DXF должно писать структурированные
+    // ACAD_TABLE-сущности, включая части-продолжения разделённой таблицы.
+    procedure SavesSplitAcadTableToStructuredDXF;
     // issue #1305, часть 1: трансформация (перенос) должна перестраивать
     // визуальное представление таблицы.
     procedure TransformationMovesRenderedTable;
@@ -117,6 +123,49 @@ begin
     if PEntity^.GetObjType = GDBAcadTableID then
       Inc(Result);
     PEntity := ARoot^.ObjArray.iterate(IR);
+  end;
+end;
+
+function DxfStreamToText(var AStream: TZctnrVectorBytes): String;
+var
+  FileName: String;
+  Lines: TStringList;
+begin
+  FileName := IncludeTrailingPathDelimiter(GetTempDir(False)) +
+    'zcad_acadtable_save_test.dxf';
+  if AStream.SaveToFile(FileName) < 0 then
+    raise Exception.Create('Не удалось сохранить временный DXF-поток');
+
+  Lines := TStringList.Create;
+  try
+    Lines.LoadFromFile(FileName);
+    Result := Lines.Text;
+  finally
+    Lines.Free;
+    DeleteFile(FileName);
+  end;
+end;
+
+function CountDxfPairs(
+  const ADXF, ACode, AValue: String): Integer;
+var
+  Lines: TStringList;
+  I: Integer;
+begin
+  Result := 0;
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ADXF;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if (Trim(Lines[I]) = ACode) and
+         (Trim(Lines[I + 1]) = AValue) then
+        Inc(Result);
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
   end;
 end;
 
@@ -521,6 +570,59 @@ begin
     Check(MaxSize < CAcadTableDefaultTextHeight - 1e-6,
       'Высота текста частей-продолжений должна браться из DXF-стиля, ' +
       'а не из значения по умолчанию');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1317. Разделённая таблица должна сохраняться обратно в DXF как
+// структурированные ACAD_TABLE-сущности: главная часть, части-продолжения
+// и XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY, по которому загрузчик снова
+// объединяет продолжения с главной таблицей.
+procedure TAcadTableStyleTest.SavesSplitAcadTableToStructuredDXF;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  DXFText: String;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(2, AcadTable^.ContinuationPartCount,
+      'Тестовый DXF должен содержать две части-продолжения');
+
+    OutStream.init(64 * 1024);
+    SaveContext.InitRec;
+    SaveContext.Header.Version := AC1021;
+    SaveContext.Header.iVersion := 1021;
+    try
+      ResetAcadTableDXFWriteState;
+      AcadTable^.DXFOut(OutStream, Drawing, SaveContext);
+      WriteAcadTableRoundTripObjectsToDXF(
+        OutStream, Drawing, SaveContext);
+      DXFText := DxfStreamToText(OutStream);
+    finally
+      ResetAcadTableDXFWriteState;
+      SaveContext.Done;
+      OutStream.done;
+    end;
+
+    CheckEquals(3, CountDxfPairs(DXFText, '0', 'ACAD_TABLE'),
+      'Главная таблица и две части-продолжения должны сохраниться как ACAD_TABLE');
+    CheckEquals(3, CountDxfPairs(DXFText, '100', 'AcDbTable'),
+      'Каждая сохранённая ACAD_TABLE должна содержать subclass AcDbTable');
+    CheckTrue(CountDxfPairs(DXFText, '301', 'CELL_VALUE') > 0,
+      'Ячейки таблицы должны сохраняться как CELL_VALUE');
+    CheckTrue(Pos('Zagolovok', DXFText) > 0,
+      'DXF должен содержать текст ячейки из исходной таблицы');
+    CheckEquals(1,
+      CountDxfPairs(
+        DXFText, '102', 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY'),
+      'Для разделённой таблицы должен сохраняться round-trip XRECORD');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1317

## Summary
- Implemented structured `ACAD_TABLE` DXF export in `cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas`.
- Serialize table entity data: entity header, block reference data, `AcDbTable` header, row heights, column widths, cell values, alignment, merge spans, table style handle, and break settings.
- Save split-table continuation parts as additional `ACAD_TABLE` entities and write an `ACAD_ROUNDTRIP_2008_TABLE_ENTITY` XRECORD through an OBJECTS-section callback so the loader can associate continuations with the main table again.
- Added model marshaling from `GDBObjAcadTable` into writer records, keeping DXF save logic in the dedicated writer module.
- Added regression coverage for `tablerazdel.dxf` to verify that a split AcadTable saves as three structured `ACAD_TABLE` entities with `CELL_VALUE` data and round-trip metadata.

## Reproduction
1. Load `cad_source/test/tablerazdel.dxf`.
2. Save the loaded AcadTable to DXF.
3. Before this change, `WriteAcadTableToDXF` only logged that export was not implemented, so no structured table data was written.
4. After this change, the output includes the main table, two continuation `ACAD_TABLE` entities, cell data, and the round-trip XRECORD.

## Tests
- `git diff --check` passed.
- `make -C cad_source/zengine/tests all` is blocked locally because `/home/box/lazarus/lazbuild` is not installed; the target exits with error 127 before compiling tests.
