### PR TITLE
Preserve raw AcadTable DXF data on save

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-12T07:44:32.698Z for PR creation at branch issue-1317-b6750023a005 for issue https://github.com/veb86/zcadvelecAI/issues/1317

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-12T07:44:32.698Z for PR creation at branch issue-1317-b6750023a005 for issue https://github.com/veb86/zcadvelecAI/issues/1317

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -85,6 +85,13 @@ procedure WriteAcadTableContinuationPartsToDXF(
   const AMainPart: TAcadTableDXFWritePart;
   const AParts: TAcadTableDXFWritePartArray);
 
+function WriteRawAcadTablePartsToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const AMainRawEntity: String;
+  const AContinuationRawEntities: array of String;
+  ABreakSpacing, ABreakHeight: Double): Boolean;
+
 procedure WriteAcadTableRoundTripObjectsToDXF(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TSimpleDrawing;
@@ -93,7 +100,7 @@ procedure WriteAcadTableRoundTripObjectsToDXF(
 implementation
 
 uses
-  SysUtils, uzeffdxfout;
+  SysUtils, Classes, uzeffdxfout;
 
 type
   TAcadTableRoundTripRecord = record
@@ -421,6 +428,64 @@ begin
       AContinuationHandles[HandleIdx];
 end;
 
+function RawAcadTableHandle(
+  const ARawEntity: String; out AHandle: TDWGHandle): Boolean;
+var
+  Lines: TStringList;
+  I: Integer;
+begin
+  Result := False;
+  AHandle := 0;
+  if ARawEntity = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ARawEntity;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if Trim(Lines[I]) = '5' then
+      begin
+        try
+          AHandle := DXFHandle(Trim(Lines[I + 1]));
+          Result := AHandle <> 0;
+        except
+          AHandle := 0;
+          Result := False;
+        end;
+        Exit;
+      end;
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure BumpHandleAfterRawEntity(
+  var AIODXFContext: TIODXFSaveContext; AHandle: TDWGHandle);
+begin
+  if AHandle >= AIODXFContext.handle then
+    AIODXFContext.handle := AHandle + 1;
+end;
+
+procedure WriteRawEntityText(
+  var AOutStream: TZctnrVectorBytes; const ARawEntity: String);
+var
+  Lines: TStringList;
+  I: Integer;
+begin
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ARawEntity;
+    for I := 0 to Lines.Count - 1 do
+      AOutStream.TXTAddStringEOL(Lines[I]);
+  finally
+    Lines.Free;
+  end;
+end;
+
 procedure WriteAcadTablePartToDXF(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TDrawingDef;
@@ -486,6 +551,43 @@ begin
 
   AddRoundTripRecord(MainHandle, ContinuationHandles,
     AMainPart.BreakSpacing, AMainPart.BreakHeight);
+end;
+
+function WriteRawAcadTablePartsToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const AMainRawEntity: String;
+  const AContinuationRawEntities: array of String;
+  ABreakSpacing, ABreakHeight: Double): Boolean;
+var
+  MainHandle: TDWGHandle;
+  ContinuationHandles: array of TDWGHandle;
+  PartIdx: Integer;
+begin
+  Result := False;
+  if not RawAcadTableHandle(AMainRawEntity, MainHandle) then
+    Exit;
+
+  System.SetLength(ContinuationHandles, Length(AContinuationRawEntities));
+  for PartIdx := 0 to High(AContinuationRawEntities) do
+    if not RawAcadTableHandle(
+      AContinuationRawEntities[PartIdx],
+      ContinuationHandles[PartIdx]) then
+      Exit;
+
+  WriteRawEntityText(AOutStream, AMainRawEntity);
+  BumpHandleAfterRawEntity(AIODXFContext, MainHandle);
+
+  for PartIdx := 0 to High(AContinuationRawEntities) do
+  begin
+    WriteRawEntityText(AOutStream, AContinuationRawEntities[PartIdx]);
+    BumpHandleAfterRawEntity(
+      AIODXFContext, ContinuationHandles[PartIdx]);
+  end;
+
+  AddRoundTripRecord(MainHandle, ContinuationHandles,
+    ABreakSpacing, ABreakHeight);
+  Result := True;
 end;
 
 procedure WriteRoundTripRecordToDXF(

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -86,6 +86,8 @@ type
     BreakManualHeight: Boolean;
     BreakSpacing: Double;
     BreakHeight: Double;
+    RawDXFEntity: String;
+    RawDXFEntityValid: Boolean;
   end;
 
   // Сущность ACAD_TABLE — таблица AutoCAD из формата DXF.
@@ -142,6 +144,10 @@ type
     // продолжения хранятся здесь как данные и отображаются со смещением
     // относительно точки вставки главной части (issue #1300).
     FContinuationParts: array of TAcadTablePart;
+    // Исходный текст DXF-entity для точного round-trip сохранения
+    // неизменённых ACAD_TABLE (issue #1317).
+    FRawDXFEntity: String;
+    FRawDXFEntityValid: Boolean;
 
     // Обёртки для делегирования к модулю layout
     function GetRowHeightLocal(RowIndex: Integer): Double;
@@ -236,6 +242,8 @@ type
       const ASource: TAcadTablePart; var APart: TAcadTableDXFWritePart);
     procedure BuildDXFContinuationWriteParts(
       var AParts: TAcadTableDXFWritePartArray);
+    procedure InvalidateRawDXFEntity;
+    function CanSaveRawDXFEntity: Boolean;
 
   public
     constructor initnul(
@@ -253,6 +261,9 @@ type
       var AOutStream: TZctnrVectorBytes;
       var ADrawing: TDrawingDef;
       var AIODXFContext: TIODXFSaveContext); virtual;
+    procedure DXFOut(var AOutStream: TZctnrVectorBytes;
+      var ADrawing: TDrawingDef;
+      var AIODXFContext: TIODXFSaveContext); virtual;
     procedure BuildGeometry(
       var ADrawing: TDrawingDef); virtual;
     procedure FormatEntity(var ADrawing: TDrawingDef;
@@ -265,6 +276,8 @@ type
     procedure CalcObjMatrix(pdrawing: PTDrawingDef = nil); virtual;
     procedure ReCalcFromObjMatrix; virtual;
     procedure rtsave(refp: Pointer); virtual;
+    procedure TransformAt(p: PGDBObjEntity;
+      t_matrix: PzeTypedMatrix4d); virtual;
     function Clone(AOwn: Pointer): PGDBObjEntity; virtual;
     function GetObjType: TObjID; virtual;
     function GetObjTypeName: String; virtual;
@@ -279,6 +292,7 @@ type
     // (issue #1307). Возвращает True.
     function SetTableBreakData(
       ASpacing, ABreakHeight: Double): Boolean; virtual;
+    procedure SetDXFRawEntityText(const ARawText: string); virtual;
 
     // Публичные свойства для инспектора объектов
     property InsertPoint: TzePoint3d read FInsertPoint;
@@ -415,6 +429,8 @@ begin
   System.SetLength(FCells, 0, 0);
   System.SetLength(FMerges, 0);
   System.SetLength(FContinuationParts, 0);
+  FRawDXFEntity := '';
+  FRawDXFEntityValid := False;
 end;
 
 destructor GDBObjAcadTable.done;
@@ -428,10 +444,38 @@ begin
   System.SetLength(FCols, 0);
   System.SetLength(FCells, 0, 0);
   System.SetLength(FMerges, 0);
+  FRawDXFEntity := '';
+  FRawDXFEntityValid := False;
   for PartIdx := 0 to High(FContinuationParts) do
     ClearPart(FContinuationParts[PartIdx]);
   System.SetLength(FContinuationParts, 0);
   inherited done;
+end;
+
+procedure GDBObjAcadTable.InvalidateRawDXFEntity;
+var
+  PartIdx: Integer;
+begin
+  FRawDXFEntity := '';
+  FRawDXFEntityValid := False;
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    FContinuationParts[PartIdx].RawDXFEntity := '';
+    FContinuationParts[PartIdx].RawDXFEntityValid := False;
+  end;
+end;
+
+function GDBObjAcadTable.CanSaveRawDXFEntity: Boolean;
+var
+  PartIdx: Integer;
+begin
+  Result := FRawDXFEntityValid and (FRawDXFEntity <> '');
+  if not Result then
+    Exit;
+  for PartIdx := 0 to High(FContinuationParts) do
+    if (not FContinuationParts[PartIdx].RawDXFEntityValid) or
+       (FContinuationParts[PartIdx].RawDXFEntity = '') then
+      Exit(False);
 end;
 
 // --- Загрузка из DXF ---
@@ -1009,6 +1053,8 @@ var
   TmpCols: TTableColumnArray;
   TmpCells: TTableCellArray;
   TmpMerges: TMergeRangeArray;
+  TmpRaw: String;
+  TmpRawValid: Boolean;
 begin
   TmpInt := FRowCount; FRowCount := APart.RowCount; APart.RowCount := TmpInt;
   TmpInt := FColCount; FColCount := APart.ColCount; APart.ColCount := TmpInt;
@@ -1034,6 +1080,9 @@ begin
   TmpManualHeight := FBreakManualHeight; FBreakManualHeight := APart.BreakManualHeight; APart.BreakManualHeight := TmpManualHeight;
   TmpSpacing := FBreakSpacing; FBreakSpacing := APart.BreakSpacing; APart.BreakSpacing := TmpSpacing;
   TmpHeight := FBreakHeight; FBreakHeight := APart.BreakHeight; APart.BreakHeight := TmpHeight;
+
+  TmpRaw := FRawDXFEntity; FRawDXFEntity := APart.RawDXFEntity; APart.RawDXFEntity := TmpRaw;
+  TmpRawValid := FRawDXFEntityValid; FRawDXFEntityValid := APart.RawDXFEntityValid; APart.RawDXFEntityValid := TmpRawValid;
 end;
 
 // Строит визуальное представление всей таблицы: сначала главная часть
@@ -1103,6 +1152,8 @@ begin
   APart.BreakManualHeight := ASource.FBreakManualHeight;
   APart.BreakSpacing := ASource.FBreakSpacing;
   APart.BreakHeight := ASource.FBreakHeight;
+  APart.RawDXFEntity := ASource.FRawDXFEntity;
+  APart.RawDXFEntityValid := ASource.FRawDXFEntityValid;
 
   APart.RowHeights.initnul;
   for Idx := 0 to ASource.FRowHeights.Count - 1 do
@@ -1157,6 +1208,8 @@ begin
   ADest.BreakManualHeight := ASource.BreakManualHeight;
   ADest.BreakSpacing := ASource.BreakSpacing;
   ADest.BreakHeight := ASource.BreakHeight;
+  ADest.RawDXFEntity := ASource.RawDXFEntity;
+  ADest.RawDXFEntityValid := ASource.RawDXFEntityValid;
 
   ADest.RowHeights.initnul;
   for Idx := 0 to ASource.RowHeights.Count - 1 do
@@ -1195,6 +1248,8 @@ procedure GDBObjAcadTable.ClearPart(var APart: TAcadTablePart);
 begin
   APart.TableStyleHandle := '';
   APart.RowBaseIndex := 0;
+  APart.RawDXFEntity := '';
+  APart.RawDXFEntityValid := False;
   APart.RowHeights.done;
   APart.ColWidths.done;
   System.SetLength(APart.CellTexts, 0);
@@ -1260,6 +1315,7 @@ var
 begin
   if AValue then
   begin
+    InvalidateRawDXFEntity;
     FBreakEnabled := True;
     if (Length(FContinuationParts) = 0) and (FBreakHeight > 0) then
       SplitMainTableByBreakHeight(FBreakHeight)
@@ -1279,6 +1335,7 @@ begin
     L := EffectiveRepeatTopRowCount;
   if L > 0 then
     RemoveTopLabelsFromParts(L);
+  InvalidateRawDXFEntity;
   FBreakEnabled := False;
   MergeAllContinuationPartsIntoMain;
 
@@ -1301,6 +1358,7 @@ begin
   if AValue = FBreakDirection then
     Exit;
 
+  InvalidateRawDXFEntity;
   FBreakDirection := AValue;
   for PartIdx := 0 to High(FContinuationParts) do
     FContinuationParts[PartIdx].BreakDirection := AValue;
@@ -1403,6 +1461,7 @@ procedure GDBObjAcadTable.SetBreakSpacing(AValue: Double);
 begin
   if AValue = FBreakSpacing then
     Exit;
+  InvalidateRawDXFEntity;
   FBreakSpacing := AValue;
   RepositionContinuationParts;
   FGeometryBuilt := False;
@@ -1426,6 +1485,7 @@ var
 begin
   if AValue = FBreakHeight then
     Exit;
+  InvalidateRawDXFEntity;
   WasBreakEnabled := GetBreakEnabled;
   FBreakHeight := AValue;
   // Перебор строк имеет смысл только при положительной высоте и
@@ -1478,6 +1538,8 @@ begin
   ADest.BreakManualHeight := ASource.BreakManualHeight;
   ADest.BreakSpacing := ASource.BreakSpacing;
   ADest.BreakHeight := ASource.BreakHeight;
+  ADest.RawDXFEntity := '';
+  ADest.RawDXFEntityValid := False;
 
   // Высоты строк диапазона
   ADest.RowHeights.initnul;
@@ -1820,6 +1882,7 @@ var
 begin
   if AValue = FBreakRepeatTopLabels then
     Exit;
+  InvalidateRawDXFEntity;
   L := 0;
   if Length(FContinuationParts) > 0 then
   begin
@@ -1928,6 +1991,8 @@ begin
   APart.BreakManualHeight := Src.BreakManualHeight;
   APart.BreakSpacing := Src.BreakSpacing;
   APart.BreakHeight := Src.BreakHeight;
+  APart.RawDXFEntity := '';
+  APart.RawDXFEntityValid := False;
 
   // Высоты строк: сверху L строк главной части, затем строки исходной части.
   APart.RowHeights.initnul;
@@ -2064,6 +2129,12 @@ begin
   Result := True;
 end;
 
+procedure GDBObjAcadTable.SetDXFRawEntityText(const ARawText: string);
+begin
+  FRawDXFEntity := ARawText;
+  FRawDXFEntityValid := ARawText <> '';
+end;
+
 // --- Трансформация объекта (issue #1305, часть 1) ---
 // Таблица AcadTable реализует ту же модель трансформации, что и вставка
 // блока (uzeentblockinsert): масштаб и поворот хранятся отдельными полями
@@ -2130,6 +2201,14 @@ begin
   inherited;
   PGDBObjAcadTable(refp)^.FRotate := FRotate;
   PGDBObjAcadTable(refp)^.FScale := FScale;
+  PGDBObjAcadTable(refp)^.InvalidateRawDXFEntity;
+end;
+
+procedure GDBObjAcadTable.TransformAt(
+  p: PGDBObjEntity; t_matrix: PzeTypedMatrix4d);
+begin
+  inherited TransformAt(p, t_matrix);
+  InvalidateRawDXFEntity;
 end;
 
 // Вычисляет bounding box
@@ -2417,6 +2496,28 @@ begin
     AOutStream, ADrawing, AIODXFContext, MainPart, Parts);
 end;
 
+procedure GDBObjAcadTable.DXFOut(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TDrawingDef;
+  var AIODXFContext: TIODXFSaveContext);
+var
+  RawParts: array of String;
+  PartIdx: Integer;
+begin
+  if CanSaveRawDXFEntity then
+  begin
+    System.SetLength(RawParts, Length(FContinuationParts));
+    for PartIdx := 0 to High(FContinuationParts) do
+      RawParts[PartIdx] := FContinuationParts[PartIdx].RawDXFEntity;
+    if uzeacadtable_dxf_write.WriteRawAcadTablePartsToDXF(
+      AOutStream, AIODXFContext, FRawDXFEntity, RawParts,
+      FBreakSpacing, FBreakHeight) then
+      Exit;
+  end;
+
+  inherited DXFOut(AOutStream, ADrawing, AIODXFContext);
+end;
+
 function GDBObjAcadTable.Clone(
   AOwn: Pointer): PGDBObjEntity;
 var
@@ -2445,6 +2546,8 @@ begin
   // Трансформация объекта (issue #1305, часть 1)
   NewTable^.FScale := FScale;
   NewTable^.FRotate := FRotate;
+  NewTable^.FRawDXFEntity := FRawDXFEntity;
+  NewTable^.FRawDXFEntityValid := FRawDXFEntityValid;
 
   for Idx := 0 to FRowHeights.Count - 1 do
     NewTable^.FRowHeights.PushBackData(

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -95,6 +95,9 @@ type
       чтобы свойства Break spacing/Break height отображались и
       редактировались в инспекторе объектов (issue #1307). }
     function SetTableBreakData(ASpacing,ABreakHeight:double):boolean;virtual;
+    { Передаёт сущности исходный текст DXF-entity, если загрузчик сохранил
+      его для round-trip экспорта. Базовая реализация ничего не делает. }
+    procedure SetDXFRawEntityText(const ARawText:string);virtual;
     procedure postload(var context:TIODXFLoadContext);virtual;
     procedure createfield;virtual;
     function AddExtAttrib:PTExtAttrib;
@@ -464,6 +467,10 @@ end;
 function GDBObjEntity.SetTableBreakData(ASpacing,ABreakHeight:double):boolean;
 begin
   Result:=false;
+end;
+
+procedure GDBObjEntity.SetDXFRawEntityText(const ARawText:string);
+begin
 end;
 
 procedure GDBObjEntity.postload(var context:TIODXFLoadContext);

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -171,6 +171,95 @@ begin
     Result := Copy(Result, I, Length(Result) - I + 1);
 end;
 
+procedure StoreRawAcadTableEntity(
+  RawEntities: TStringList; const Handle, RawText: string);
+var
+  Idx: Integer;
+begin
+  if (RawEntities = nil) or (Handle = '') or (RawText = '') then
+    Exit;
+
+  Idx := RawEntities.IndexOf(Handle);
+  if Idx >= 0 then
+  begin
+    RawEntities.Objects[Idx].Free;
+    RawEntities.Objects[Idx] := TDXFRawTextObject.Create(RawText);
+  end
+  else
+    RawEntities.AddObject(Handle, TDXFRawTextObject.Create(RawText));
+end;
+
+{ Сканирует секцию ENTITIES и сохраняет исходный текст каждой ACAD_TABLE
+  по handle. Это нужно для точного round-trip сохранения: таблицы AutoCAD
+  содержат binary chunks (310) и детальные флаги ячеек, которые обычная
+  модель таблицы пока не умеет полностью восстановить (issue #1317). }
+procedure ScanAcadTableRawEntities(
+  const RawEntitiesSection: string; RawEntities: TStringList);
+var
+  Lines: TStringList;
+  I, J, K, EntityStart, EntityEnd: Integer;
+  Handle, RawText: string;
+begin
+  if (RawEntitiesSection = '') or (RawEntities = nil) then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := RawEntitiesSection;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if (Trim(Lines[I]) = '0') and
+         (UpperCase(Trim(Lines[I + 1])) = 'ACAD_TABLE') then
+      begin
+        EntityStart := I;
+        EntityEnd := Lines.Count;
+        J := I + 2;
+        while J < Lines.Count - 1 do
+        begin
+          if Trim(Lines[J]) = '0' then
+          begin
+            EntityEnd := J;
+            Break;
+          end;
+          Inc(J, 2);
+        end;
+
+        Handle := '';
+        K := EntityStart + 2;
+        while K < EntityEnd - 1 do
+        begin
+          if Trim(Lines[K]) = '5' then
+          begin
+            Handle := NormalizeHandle(Lines[K + 1]);
+            Break;
+          end;
+          Inc(K, 2);
+        end;
+
+        RawText := '';
+        for K := EntityStart to EntityEnd - 1 do
+        begin
+          if K > EntityStart then
+            RawText := RawText + LineEnding;
+          RawText := RawText + Lines[K];
+        end;
+        StoreRawAcadTableEntity(RawEntities, Handle, RawText);
+        I := EntityEnd;
+        Continue;
+      end;
+      Inc(I, 2);
+    end;
+
+    if RawEntities.Count > 0 then
+      programlog.LogOutFormatStr(
+        'uzeffdxf: ScanAcadTableRawEntities: найдено %d raw ACAD_TABLE entity',
+        [RawEntities.Count], LM_Info);
+  finally
+    Lines.Free;
+  end;
+end;
+
 { Сканирует секцию OBJECTS, находит XRECORD'ы с маркером
   ACAD_ROUNDTRIP_2008_TABLE_ENTITY и собирает из них хэндлы
   ACAD_TABLE-сущностей, являющихся продолжениями разделённой таблицы.
@@ -567,6 +656,7 @@ var
   EntInfoData:TEntInfoData;
   bylayerlt:Pointer;
   lph:TLPSHandle;
+  rawIdx:Integer;
   // Последняя добавленная главная ACAD_TABLE — в неё поглощаются
   // продолжения разделённой таблицы (issue #1300).
   pLastMainTable:PGDBObjEntity;
@@ -597,6 +687,21 @@ begin
         PGDBObjEntity(pobj)^.vp.LineType:=bylayerlt;
       if assigned(PGDBObjEntity(pobj)^.EntExtensions) then
         PGDBObjEntity(pobj)^.EntExtensions.RunSupportOldVersions(pobj,drawing);
+
+      if (uppercase(s)='ACAD_TABLE') and
+         (context.TableRawAcadTableEntities<>nil) and
+         (PGDBObjEntity(pobj)^.PExtAttrib<>nil) and
+         (PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle<>0) then
+      begin
+        rawIdx := context.TableRawAcadTableEntities.IndexOf(
+          NormalizeHandle(inttohex(
+            PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle,0)));
+        if (rawIdx >= 0) and
+           (context.TableRawAcadTableEntities.Objects[rawIdx]<>nil) then
+          PGDBObjEntity(pobj)^.SetDXFRawEntityText(
+            TDXFRawTextObject(
+              context.TableRawAcadTableEntities.Objects[rawIdx]).Text);
+      end;
 
       { Если ACAD_TABLE имеет handle из списка продолжений разделённой
         таблицы — это часть, которую AutoCAD сохранил как отдельную
@@ -1569,6 +1674,7 @@ var
   DxfStream:TZMVSMemoryMappedFile;
   rdr:TZMemReader;
   globalTimer: TTimeMeter;
+  RawEntitiesSection: string;
 const
    ffs='%s (%s)';
 begin
@@ -1609,6 +1715,12 @@ begin
           ExtractDxfRawSection(AFileName, 'CLASSES');
         dwgCtx.PDrawing^.RawObjectsSection :=
           ExtractDxfRawSection(AFileName, 'OBJECTS');
+        RawEntitiesSection :=
+          ExtractDxfRawSection(AFileName, 'ENTITIES');
+
+        ScanAcadTableRawEntities(
+          RawEntitiesSection,
+          fileCtx.TableRawAcadTableEntities);
 
         { Сканируем OBJECTS, собираем handles ACAD_TABLE-продолжений.
           Хранятся в fileCtx, используются в addentitiesfromdxf для отбрасывания

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -113,6 +113,11 @@ type
 
   TDXFHandle2ZCObject=GMapHandle2Pointer<TDWGHandle,Pointer,TObjectTypes>;
 
+  TDXFRawTextObject=class
+    Text:string;
+    constructor Create(const AText:string);
+  end;
+
   TIODXFLoadContext=record
     h2p:TDXFHandle2ZCObject;
     DWGVarsDict:TString2StringDictionary;
@@ -127,6 +132,13 @@ type
       (группа 330). Такие продолжения не должны создавать отдельные
       ProxyEntity: их proxy graphic уже включён в первую таблицу. }
     TableContinuationHandles:TStringList;
+
+    { Сырые тексты ACAD_TABLE-сущностей из секции ENTITIES, индексированные
+      по нормализованному handle. Нужны для round-trip сохранения таблиц,
+      потому что современные ACAD_TABLE содержат бинарные chunks и точные
+      флаги ячеек, которые модель ZCAD пока не реконструирует полностью
+      (issue #1317). }
+    TableRawAcadTableEntities:TStringList;
 
     { Параметры разбиения разделённой таблицы, прочитанные из XRECORD
       ACAD_ROUNDTRIP_2008_TABLE_ENTITY (две группы 40: 1-я — интервал
@@ -192,6 +204,12 @@ function ZCDxfVer2ACVer(AZCVer:TZCDxfVersion):integer;
 function ZCDxfVer2DXF_ACVer(AZCVer:TZCDxfVersion):TACDWGVer;
 
 implementation
+
+constructor TDXFRawTextObject.Create(const AText:string);
+begin
+  inherited Create;
+  Text:=AText;
+end;
 
 function ZCDxfVer2ACVer(AZCVer:TZCDxfVersion):integer;
 begin
@@ -368,6 +386,11 @@ begin
   TableContinuationHandles.Sorted:=True;
   TableContinuationHandles.Duplicates:=dupIgnore;
 
+  TableRawAcadTableEntities:=TStringList.Create;
+  TableRawAcadTableEntities.CaseSensitive:=False;
+  TableRawAcadTableEntities.Sorted:=True;
+  TableRawAcadTableEntities.Duplicates:=dupIgnore;
+
   TableBreakSpacing:=0;
   TableBreakHeight:=0;
   TableBreakDataValid:=False;
@@ -382,11 +405,18 @@ begin
 end;
 
 procedure TIODXFLoadContext.Done;
+var
+  I:Integer;
 begin
   h2p.Free;
   DWGVarsDict.Free;
   GDBVertexLoadCache.Done;
   FreeAndNil(TableContinuationHandles);
+  if TableRawAcadTableEntities<>nil then begin
+    for I:=0 to TableRawAcadTableEntities.Count-1 do
+      TableRawAcadTableEntities.Objects[I].Free;
+    FreeAndNil(TableRawAcadTableEntities);
+  end;
 end;
 
 function DXFHandle(const sh:string):TDWGHandle;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -169,6 +169,54 @@ begin
   end;
 end;
 
+function CountDxfCode(const ADXF, ACode: String): Integer;
+var
+  Lines: TStringList;
+  I: Integer;
+begin
+  Result := 0;
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ADXF;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if Trim(Lines[I]) = ACode then
+        Inc(Result);
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+function HasDxfSequence(
+  const ADXF: String; const ASequence: array of String): Boolean;
+var
+  Lines: TStringList;
+  StartIdx, SeqIdx: Integer;
+begin
+  Result := False;
+  if Length(ASequence) = 0 then
+    Exit(True);
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ADXF;
+    for StartIdx := 0 to Lines.Count - Length(ASequence) do
+    begin
+      SeqIdx := 0;
+      while (SeqIdx <= High(ASequence)) and
+        (Trim(Lines[StartIdx + SeqIdx]) = ASequence[SeqIdx]) do
+        Inc(SeqIdx);
+      if SeqIdx > High(ASequence) then
+        Exit(True);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
 function LoadDrawingFromDXF(const AFileName: string; var ADrawing: TSimpleDrawing): Integer;
 var
   DC: TDrawContext;
@@ -615,6 +663,30 @@ begin
       'Главная таблица и две части-продолжения должны сохраниться как ACAD_TABLE');
     CheckEquals(3, CountDxfPairs(DXFText, '100', 'AcDbTable'),
       'Каждая сохранённая ACAD_TABLE должна содержать subclass AcDbTable');
+    CheckTrue(CountDxfCode(DXFText, '310') > 0,
+      'Сырые binary chunks ACAD_TABLE (310) должны сохраняться');
+    CheckEquals(3, CountDxfCode(DXFText, '343'),
+      'Каждая часть таблицы должна сохранить ссылку group 343');
+    CheckTrue(
+      HasDxfSequence(DXFText,
+        ['301', 'CELL_VALUE',
+         '93', '6',
+         '90', '1',
+         '91', '1']),
+      'Числовые значения ячеек должны сохранять DXF-тип, а не превращаться в строки');
+    CheckTrue(
+      HasDxfSequence(DXFText,
+        ['173', '1',
+         '174', '0',
+         '175', '1',
+         '176', '1',
+         '91', '0',
+         '178', '0',
+         '145', '0.0',
+         '92', '0',
+         '301', 'CELL_VALUE',
+         '93', '7']),
+      'Виртуальные ячейки объединений должны сохранять исходные флаги');
     CheckTrue(CountDxfPairs(DXFText, '301', 'CELL_VALUE') > 0,
       'Ячейки таблицы должны сохраняться как CELL_VALUE');
     CheckTrue(Pos('Zagolovok', DXFText) > 0,


### PR DESCRIPTION
## Summary
- Capture raw ACAD_TABLE entity text from DXF ENTITIES by handle during load and attach it to loaded table entities before continuation merge.
- Re-emit the raw main/continuation ACAD_TABLE entities for unmodified loaded tables, while preserving the round-trip XRECORD and falling back to the structured writer after edits/transforms.
- Extend the split-table regression to assert that 310 binary chunks, group 343 references, numeric CELL_VALUE typing, and merge-cell flags survive save.

## Reproduction
1. Open `cad_source/test/tablerazdel.dxf`.
2. Save it immediately as a DXF 2007 file and reload it.
3. The three ACAD_TABLE parts should keep the original table payload instead of being reconstructed with oversized/missing text.

Fixes #1317

## Tests
- `git diff --check`
- `make -C cad_source/zengine/tests all` (blocked locally: `/home/box/lazarus/lazbuild` is not installed; `lazbuild`, `fpc`, and `ppcx64` are absent from PATH)
