### PR TITLE
AcadTable: make manual break position editable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T18:40:38.041Z for PR creation at branch issue-1320-c5f94c6bd637 for issue https://github.com/veb86/zcadvelecAI/issues/1320

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T18:40:38.041Z for PR creation at branch issue-1320-c5f94c6bd637 for issue https://github.com/veb86/zcadvelecAI/issues/1320

--- a/cad_source/zcad/register/uzcregacadtable.pas
+++ b/cad_source/zcad/register/uzcregacadtable.pas
@@ -229,7 +229,9 @@ begin
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
 end;
 
-// Чтение признака ручного позиционирования разбиения (только чтение)
+// Чтение признака ручного позиционирования разбиения. Свойство редактируемое:
+// включение показывает ручки частей-продолжений, отключение возвращает части
+// в автоматические положения по Break direction и Break spacing (issue #1320).
 procedure AcadTableBreakManualPosEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
   mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
   const f:TzeUnitsFormat);
@@ -243,6 +245,30 @@ begin
   v:=PGDBObjAcadTable(ChangedData.PEntity)^.BreakManualPosition;
   ChangedData.PGetDataInEtity:=@v;
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+// Запись признака ручного позиционирования разбиения (issue #1320).
+// Вся логика изменения находится в GDBObjAcadTable.SetBreakManualPosition:
+// True включает ручки частей-продолжений, False возвращает автоматическую
+// раскладку частей.
+procedure AcadTableBreakManualPosEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  Table:PGDBObjAcadTable;
+  NewValue:Boolean;
+begin
+  Table:=PGDBObjAcadTable(ChangedData.PEntity);
+  NewValue:=PBoolean(pvardesk(pdata)^.data.Addr.Instance)^;
+  if Table^.BreakManualPosition=NewValue then
+    exit;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  Table^.BreakManualPosition:=NewValue;
+  if drawings.GetCurrentDWG<>nil then
+    Table^.YouChanged(drawings.GetCurrentDWG^);
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
 end;
 
 // Чтение признака ручной высоты разбиения (только чтение)
@@ -522,7 +548,9 @@ begin
     sysunit^.TypeName2PTD('Boolean'),
     MPCMisc,GDBAcadTableID,nil,0,0,
     OneVarDataMIPD,
-    TEntIterateProcsData.Create(nil,@AcadTableBreakManualPosEntIterateProc,nil));
+    TEntIterateProcsData.Create(
+      nil,@AcadTableBreakManualPosEntIterateProc,
+      @AcadTableBreakManualPosEntChangeProc));
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableBreakManualHeight','Manual height',
     sysunit^.TypeName2PTD('Boolean'),

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -194,6 +194,9 @@ type
     procedure SetBreakEnabled(AValue: Boolean);
     // Чтение/запись направления разрыва таблицы (issue #1315)
     procedure SetBreakDirection(AValue: TAcadTableBreakDirection);
+    // Чтение/запись ручного положения частей разорванной таблицы
+    // (issue #1320).
+    procedure SetBreakManualPosition(AValue: Boolean);
     // Чтение/запись интервала между частями и высоты разбиения (issue #1307)
     function GetBreakSpacing: Double;
     procedure SetBreakSpacing(AValue: Double);
@@ -326,7 +329,7 @@ type
     property BreakRepeatBottomLabels: Boolean
       read FBreakRepeatBottomLabels;
     property BreakManualPosition: Boolean
-      read FBreakManualPosition;
+      read FBreakManualPosition write SetBreakManualPosition;
     property BreakManualHeight: Boolean
       read FBreakManualHeight;
     // Интервал между частями разделённой таблицы (issue #1307). Чтение
@@ -1776,6 +1779,41 @@ var
 begin
   for PartIdx := 0 to High(FContinuationParts) do
     FContinuationParts[PartIdx].BreakManualPosition := AValue;
+end;
+
+procedure GDBObjAcadTable.SetBreakManualPosition(AValue: Boolean);
+begin
+  if AValue then
+  begin
+    if FBreakManualPosition and FBreakManualPositionExplicit then
+      Exit;
+
+    InvalidateRawDXFEntity;
+    FBreakManualPosition := True;
+    FBreakManualPositionExplicit := True;
+    SetBreakManualPositionForParts(True);
+    FGeometryBuilt := False;
+    programlog.LogOutFormatStr(
+      'AcadTable: model: SetBreakManualPosition=True parts=%d',
+      [Length(FContinuationParts)], LM_Info);
+    Exit;
+  end;
+
+  if (not FBreakManualPosition) and (not FBreakManualPositionExplicit) and
+     (not HasManualContinuationPositions) then
+    Exit;
+
+  InvalidateRawDXFEntity;
+  FBreakManualPosition := False;
+  FBreakManualPositionExplicit := False;
+  if Length(FContinuationParts) > 0 then
+    RepositionContinuationParts
+  else
+    SetBreakManualPositionForParts(False);
+  FGeometryBuilt := False;
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetBreakManualPosition=False parts=%d',
+    [Length(FContinuationParts)], LM_Info);
 end;
 
 function GDBObjAcadTable.HasManualContinuationPositions: Boolean;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -90,6 +90,9 @@ type
     // issue #1320: при ручном положении разорванной таблицы каждая часть-
     // продолжение должна иметь собственную ручку положения.
     procedure ManualBreakPositionAddsContinuationPartGrips;
+    // issue #1320: ручное положение должно включаться и отключаться через
+    // свойство, используемое инспектором объектов.
+    procedure TogglingBreakManualPositionUpdatesContinuationPartGrips;
     // issue #1309, часть 1: при загрузке разорванной таблицы признак повтора
     // верхних меток определяется по содержимому частей-продолжений.
     procedure DetectsBreakRepeatTopOnLoad;
@@ -1152,6 +1155,46 @@ begin
       CheckEquals(1 + AcadTable^.ContinuationPartCount,
         CountAcadTableControlPoints(AcadTable),
         'Ручное положение должно добавить ручку для каждой части-продолжения');
+    finally
+      Drawing.done;
+    end;
+  finally
+    DeleteFile(ManualDXF);
+  end;
+end;
+
+procedure TAcadTableStyleTest.TogglingBreakManualPositionUpdatesContinuationPartGrips;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  ManualDXF: String;
+begin
+  ManualDXF := CreateManualPositionAcadTableDXF;
+  try
+    LoadDrawingFromDXF(ManualDXF, Drawing);
+    try
+      AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+      AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+      CheckTrue(AcadTable^.BreakManualPosition,
+        'Тестовая таблица должна загрузиться в ручном режиме');
+      CheckEquals(1 + AcadTable^.ContinuationPartCount,
+        CountAcadTableControlPoints(AcadTable),
+        'Ручной режим должен показывать ручки частей-продолжений');
+
+      AcadTable^.BreakManualPosition := False;
+      CheckFalse(AcadTable^.BreakManualPosition,
+        'Отключение ручного режима должно вернуть автоматическое положение');
+      CheckEquals(1, CountAcadTableControlPoints(AcadTable),
+        'Автоматическое положение должно скрыть ручки частей-продолжений');
+      CheckFalse(AcadTable^.BreakManualPosition,
+        'Повторное определение не должно снова включить ручной режим');
+
+      AcadTable^.BreakManualPosition := True;
+      CheckTrue(AcadTable^.BreakManualPosition,
+        'Включение ручного режима должно сохраниться в модели');
+      CheckEquals(1 + AcadTable^.ContinuationPartCount,
+        CountAcadTableControlPoints(AcadTable),
+        'Включение ручного режима должно вернуть ручки частей-продолжений');
     finally
       Drawing.done;
     end;


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1320

## Summary
- Made `GDBObjAcadTable.BreakManualPosition` writable through a model setter.
- Wired `AcadTableBreakManualPosition` in the object inspector to a change procedure so it is editable.
- Turning manual mode off repositions continuation parts using `BreakDirection` and `BreakSpacing`; turning it on marks parts manual and shows per-part grips.
- Added regression coverage for toggling manual mode and continuation-part grip visibility.

## Reproduction / Verification
1. Load a split AcadTable whose continuation insert point is shifted away from the automatic layout.
2. Select it and toggle `Manual position` off, then on, in the object inspector.
3. Off returns parts to automatic layout and hides part grips; on restores part grips.

## Tests
- `git diff --check`
- `make -C cad_source/zengine/tests clean all` is blocked locally because `/home/box/lazarus/lazbuild` is not installed; the target exits before compilation.