### PR TITLE
AcadTable: fix continuation break height grips

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-14T21:40:57.132Z for PR creation at branch issue-1321-553736bacd2a for issue https://github.com/veb86/zcadvelecAI/issues/1321

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-14T21:40:57.132Z for PR creation at branch issue-1321-553736bacd2a for issue https://github.com/veb86/zcadvelecAI/issues/1321

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -94,6 +94,8 @@ type
     RawDXFEntityValid: Boolean;
   end;
 
+  TAcadTableBreakHeightArray = array of Double;
+
   // Сущность ACAD_TABLE — таблица AutoCAD из формата DXF.
   // Хранит геометрию таблицы и текстовое содержимое ячеек.
   // При форматировании строит визуальное представление из линий и текста.
@@ -212,6 +214,12 @@ type
     // Пересегментирует объединённую главную часть по высоте разбиения,
     // вынося хвостовые строки в новые части-продолжения (issue #1307).
     procedure SplitMainTableByBreakHeight(AThreshold: Double);
+    procedure SplitMainTableByBreakHeights(
+      const ABreakHeights: TAcadTableBreakHeightArray);
+    function BreakHeightForPart(
+      const ABreakHeights: TAcadTableBreakHeightArray;
+      APartNumber: Integer): Double;
+    procedure ResplitByCurrentBreakHeights;
     // Копирует диапазон строк [AStart..AEnd] исходной части в целевую часть.
     procedure SlicePartFromPart(const ASource: TAcadTablePart;
       AStart, AEnd: Integer; var ADest: TAcadTablePart);
@@ -1664,13 +1672,43 @@ end;
 // Число частей определяется автоматически (issue #1307).
 procedure GDBObjAcadTable.SplitMainTableByBreakHeight(AThreshold: Double);
 var
+  BreakHeights: TAcadTableBreakHeightArray;
+begin
+  if AThreshold <= 0 then
+    Exit;
+
+  System.SetLength(BreakHeights, 1);
+  BreakHeights[0] := AThreshold;
+  SplitMainTableByBreakHeights(BreakHeights);
+end;
+
+function GDBObjAcadTable.BreakHeightForPart(
+  const ABreakHeights: TAcadTableBreakHeightArray;
+  APartNumber: Integer): Double;
+begin
+  Result := FBreakHeight;
+  if (APartNumber >= 0) and
+     (APartNumber < Length(ABreakHeights)) and
+     AcadTableBreakHeightHasValue(ABreakHeights[APartNumber]) then
+    Result := ABreakHeights[APartNumber];
+
+  if not AcadTableBreakHeightHasValue(Result) then
+    Result := CAcadTableBreakHeightTolerance;
+end;
+
+procedure GDBObjAcadTable.SplitMainTableByBreakHeights(
+  const ABreakHeights: TAcadTableBreakHeightArray);
+var
   FullData, TmpPart: TAcadTablePart;
   SegStart, SegEnd: array of Integer;
   SegCount, StartRow, EndRow, PartIdx, RepeatRows, RowIdx: Integer;
-  CurHeight, NextHeight, RepeatHeight: Double;
+  CurHeight, NextHeight, RepeatHeight, PartBreakHeight: Double;
+  ManualHeight: Boolean;
 begin
-  if (FRowCount <= 0) or (AThreshold <= 0) then
+  if FRowCount <= 0 then
     Exit;
+
+  ManualHeight := FBreakManualHeight;
 
   // Снимок текущей (объединённой) главной части
   CaptureTableDataToPart(Self, FullData);
@@ -1694,6 +1732,7 @@ begin
     begin
       EndRow := StartRow;
       CurHeight := 0;
+      PartBreakHeight := BreakHeightForPart(ABreakHeights, SegCount);
       if (SegCount > 0) and (RepeatRows > 0) then
         CurHeight := RepeatHeight;
       while EndRow < FullData.RowCount do
@@ -1701,7 +1740,7 @@ begin
         NextHeight := CurHeight +
           uzeacadtable_layout.GetRowHeight(EndRow, FullData.RowHeights);
         if (EndRow > StartRow) and
-           (NextHeight > AThreshold + 1e-9) then
+           (NextHeight > PartBreakHeight + 1e-9) then
           Break;
         CurHeight := NextHeight;
         Inc(EndRow);
@@ -1730,6 +1769,9 @@ begin
     begin
       SlicePartFromPart(FullData, SegStart[PartIdx], SegEnd[PartIdx],
         FContinuationParts[PartIdx - 1]);
+      FContinuationParts[PartIdx - 1].BreakHeight :=
+        BreakHeightForPart(ABreakHeights, PartIdx);
+      FContinuationParts[PartIdx - 1].BreakManualHeight := ManualHeight;
       if RepeatRows > 0 then
         PrependTopLabelsToPart(RepeatRows, FContinuationParts[PartIdx - 1]);
     end;
@@ -1738,12 +1780,40 @@ begin
     // данными с собой (точка вставки главной части сохраняется).
     SlicePartFromPart(FullData, SegStart[0], SegEnd[0], TmpPart);
     SwapTableData(TmpPart);
+    FBreakHeight := BreakHeightForPart(ABreakHeights, 0);
+    FBreakManualHeight := ManualHeight;
     ClearPart(TmpPart);
 
     RepositionContinuationParts;
   finally
     ClearPart(FullData);
   end;
+end;
+
+procedure GDBObjAcadTable.ResplitByCurrentBreakHeights;
+var
+  BreakHeights: TAcadTableBreakHeightArray;
+  PartIdx, L: Integer;
+begin
+  if not GetBreakEnabled then
+    Exit;
+
+  System.SetLength(BreakHeights, Length(FContinuationParts) + 1);
+  BreakHeights[0] := FBreakHeight;
+  for PartIdx := 0 to High(FContinuationParts) do
+    BreakHeights[PartIdx + 1] := FContinuationParts[PartIdx].BreakHeight;
+
+  FBreakEnabled := True;
+  FBreakManualHeight := True;
+  L := 0;
+  if FBreakRepeatTopLabels then
+    L := EffectiveRepeatTopRowCount;
+  if L > 0 then
+    RemoveTopLabelsFromParts(L);
+  MergeAllContinuationPartsIntoMain;
+  SplitMainTableByBreakHeights(BreakHeights);
+  FBreakManualHeight := True;
+  SetBreakManualHeightForParts(True);
 end;
 
 // Пересчитывает точки вставки частей-продолжений из текущего интервала
@@ -2662,7 +2732,7 @@ begin
           FContinuationParts[PartIdx].BreakHeight := NewHeight;
       end;
       FBreakManualHeight := True;
-      SetBreakManualHeightForParts(True);
+      ResplitByCurrentBreakHeights;
       FGeometryBuilt := False;
       Exit;
     end;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -101,6 +101,9 @@ type
     // issue #1321: ручное управление высотой должно включаться и
     // отключаться через свойство инспектора объектов.
     procedure TogglingBreakManualHeightUpdatesPartGrips;
+    // issue #1321: перетаскивание ручки высоты части-продолжения должно
+    // перераспределять строки этой части, а не только менять сохранённое поле.
+    procedure DraggingContinuationBreakHeightGripResegmentsPart;
     // issue #1309, часть 1: при загрузке разорванной таблицы признак повтора
     // верхних меток определяется по содержимому частей-продолжений.
     procedure DetectsBreakRepeatTopOnLoad;
@@ -285,6 +288,42 @@ begin
     CAcadTableBreakHeightGripVertexBase,
     CAcadTableBreakHeightGripVertexBase +
       AAcadTable^.ContinuationPartCount);
+end;
+
+function FindAcadTableControlPoint(
+  AAcadTable: PGDBObjAcadTable; AVertex: Integer;
+  out APoint: controlpointdesc): Boolean;
+var
+  Desc: SelectedObjDesc;
+  Point: pcontrolpointdesc;
+  I: Integer;
+begin
+  Result := False;
+  FillChar(APoint, SizeOf(APoint), 0);
+  FillChar(Desc, SizeOf(Desc), 0);
+  Desc.objaddr := PGDBObjEntity(AAcadTable);
+  GetMem(Pointer(Desc.pcontrolpoint), SizeOf(GDBControlPointArray));
+  try
+    AAcadTable^.CalcObjMatrix;
+    AAcadTable^.addcontrolpoints(@Desc);
+    if Desc.pcontrolpoint^.Count > 0 then
+    begin
+      Point := Desc.pcontrolpoint^.GetParrayAsPointer;
+      for I := 0 to Desc.pcontrolpoint^.Count - 1 do
+      begin
+        if (Point^.pointtype = os_polymin) and
+           (Point^.vertexnum = AVertex) then
+        begin
+          APoint := Point^;
+          Exit(True);
+        end;
+        Inc(Point);
+      end;
+    end;
+  finally
+    Desc.pcontrolpoint^.done;
+    FreeMem(Pointer(Desc.pcontrolpoint));
+  end;
 end;
 
 function CountDxfPairs(
@@ -1364,6 +1403,47 @@ begin
       'Отключение ручной высоты должно сохраниться в модели');
     CheckEquals(1, CountAcadTableBreakHeightControlPoints(AcadTable),
       'Отключение ручной высоты должно оставить только ручку первой части');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.DraggingContinuationBreakHeightGripResegmentsPart;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  Grip: controlpointdesc;
+  RTMod: TRTModifyData;
+  PartRowsBefore: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(2, AcadTable^.ContinuationPartCount,
+      'Тестовый DXF должен содержать две части-продолжения');
+
+    AcadTable^.BreakManualHeight := True;
+    CheckTrue(
+      FindAcadTableControlPoint(
+        AcadTable, CAcadTableBreakHeightGripVertexBase + 1, Grip),
+      'Ручка высоты первой части-продолжения должна существовать');
+    PartRowsBefore := AcadTable^.ContinuationPartRowCount(0);
+    CheckTrue(PartRowsBefore > 0,
+      'Первая часть-продолжение должна содержать строки до перетаскивания');
+
+    FillChar(RTMod, SizeOf(RTMod), 0);
+    RTMod.point := Grip;
+    RTMod.dist := CreateVertex(0, AcadTable^.BreakHeight + 10.0, 0);
+    RTMod.wc := VertexAdd(Grip.worldcoord, RTMod.dist);
+    AcadTable^.rtmodifyonepoint(RTMod);
+
+    CheckTrue(AcadTable^.BreakManualHeight,
+      'Перетаскивание ручки продолжения должно оставить ручную высоту включённой');
+    CheckTrue(AcadTable^.ContinuationPartRowCount(0) < PartRowsBefore,
+      'Перетаскивание ручки высоты продолжения должно пересегментировать ' +
+      'строки этой части');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1321

Summary:
- Re-split AcadTable rows using the current per-part AcadTableBreakHeight values when a manual break-height grip is dragged.
- Preserve manual-height mode and continuation part break heights while rebuilding the split table segments.
- Add regression coverage for dragging a continuation part's break-height grip so it changes the segment rows instead of only updating metadata.

Reproduction:
- Load cad_source/test/tablerazdel.dxf, select the split AcadTable, enable AcadTableBreakManualHeight, then drag the bottom-center break-height grip on a continuation part.
- Before this change, only one split part could control the break height; dragging another part's height grip updated the saved value but did not change that part's rows/height.
- After this change, dragging a continuation part's height grip resegments the split table from the current per-part heights.

Tests:
- git diff --check
- make -C cad_source/zengine/tests all (blocked in this container: /home/box/lazarus/lazbuild is not installed; the saved log showed /bin/sh: 1: /home/box/lazarus/lazbuild: not found)