### PR TITLE
AcadTable: use fixed text style heights

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T08:22:26.967Z for PR creation at branch issue-1330-be74174e8ddb for issue https://github.com/veb86/zcadvelecAI/issues/1330

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T08:22:26.967Z for PR creation at branch issue-1330-be74174e8ddb for issue https://github.com/veb86/zcadvelecAI/issues/1330

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -773,6 +773,7 @@ var
   LineCount, TextCount: Integer;
   CellStyleLocal: TCellStyle;
   TextHeightLocal: Double;
+  ResolvedTextStyle: PGDBTextStyle;
   RenderSegments: array[0..255] of TAcadTableRenderSegment;
   SegmentOffsetX, SegmentOffsetY: Double;
   MergeRootPt: TPoint;
@@ -993,8 +994,20 @@ begin
           pointer(PMText) :=
             ConstObjArray.CreateInitObj(GDBMTextID, @Self);
           PMText^.Template := UTF8ToString(CellStr);
+          ResolvedTextStyle :=
+            uzeacadtable_stylemanager.ResolveTextStyle(
+              CellStyleLocal.TextStyle, ADrawing);
+          PMText^.TXTStyle := ResolvedTextStyle;
 
-          if CellStyleLocal.TextHeight > 0 then
+          // Nonzero STYLE group 40 is a fixed text height and must override
+          // the table cell height stored in TABLESTYLE.
+          if (ResolvedTextStyle <> nil) and
+             (CellStyleLocal.TextStyle <> '') and
+             SameText(ResolvedTextStyle^.Name, CellStyleLocal.TextStyle) and
+             (ResolvedTextStyle^.prop.size > 0) then
+            PMText^.textprop.size :=
+              ResolvedTextStyle^.prop.size
+          else if CellStyleLocal.TextHeight > 0 then
             PMText^.textprop.size :=
               CellStyleLocal.TextHeight
           else
@@ -1078,9 +1091,6 @@ begin
           end;
 
           PMText^.Local.P_insert.z := 0;
-          PMText^.TXTStyle :=
-            uzeacadtable_stylemanager.ResolveTextStyle(
-              CellStyleLocal.TextStyle, ADrawing);
           CopyVPto(PMText^);
           PMText^.FormatEntity(ADrawing, ADC);
           Inc(TextCount);

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -52,6 +52,9 @@ type
   TAcadTableStyleTest = class(TTestCase)
   published
     procedure LoadsCellTextStylesFromDXFTableStyle;
+    // issue #1330: fixed text height from the referenced text style should
+    // be used for imported AcadTable cells.
+    procedure LoadsFixedTextHeightFromDXFTextStyle;
     procedure LoadsBreakSettingsFromDXF;
     procedure LoadsBreakSettingsFromSecondSample;
     procedure RendersBrokenTableAsSeparatedFragments;
@@ -591,6 +594,46 @@ begin
   end;
 end;
 
+// Собирает диапазон высот MText для конкретного текстового стиля.
+procedure CollectMTextSizeRangeByStyle(var AArr: GDBObjEntityTreeArray;
+  const AStyleName: String; out AMinSize, AMaxSize: Double;
+  out ACount: Integer);
+var
+  IR: itrec;
+  PEntity: PGDBObjEntity;
+  PMText: PGDBObjMText;
+  Sz: Double;
+begin
+  AMinSize := 0;
+  AMaxSize := 0;
+  ACount := 0;
+  PEntity := AArr.beginiterate(IR);
+  while PEntity <> nil do
+  begin
+    if PEntity^.GetObjType = GDBMTextID then
+    begin
+      PMText := PGDBObjMText(PEntity);
+      if (PMText^.TXTStyle <> nil) and
+         SameText(PMText^.TXTStyle^.Name, AStyleName) then
+      begin
+        Sz := PMText^.textprop.size;
+        if ACount = 0 then
+        begin
+          AMinSize := Sz;
+          AMaxSize := Sz;
+        end
+        else
+        begin
+          if Sz < AMinSize then AMinSize := Sz;
+          if Sz > AMaxSize then AMaxSize := Sz;
+        end;
+        Inc(ACount);
+      end;
+    end;
+    PEntity := AArr.iterate(IR);
+  end;
+end;
+
 function FindMTextSizeByTemplate(var AArr: GDBObjEntityTreeArray;
   const ATemplate: String; out ASize: Double): Boolean;
 var
@@ -668,6 +711,46 @@ begin
     finally
       StyleNames.Free;
     end;
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.LoadsFixedTextHeightFromDXFTextStyle;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  MinTitleHeaderSize, MaxTitleHeaderSize: Double;
+  MinDataSize, MaxDataSize: Double;
+  TitleHeaderTextCount, DataTextCount: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tableheighttextbug.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    BuildTableGeometry(Drawing, AcadTable);
+
+    CollectMTextSizeRangeByStyle(
+      AcadTable^.ConstObjArray, '!!!VTableText_320',
+      MinTitleHeaderSize, MaxTitleHeaderSize, TitleHeaderTextCount);
+    CollectMTextSizeRangeByStyle(
+      AcadTable^.ConstObjArray, '!!!VTableText_220',
+      MinDataSize, MaxDataSize, DataTextCount);
+
+    Check(TitleHeaderTextCount > 0,
+      'Таблица должна отрисовать текст названия/шапки стилем !!!VTableText_320');
+    Check(DataTextCount > 0,
+      'Таблица должна отрисовать текст данных стилем !!!VTableText_220');
+    CheckEquals(320.0, MinTitleHeaderSize, 1e-6,
+      'Минимальная высота текста названия/шапки должна браться из стиля');
+    CheckEquals(320.0, MaxTitleHeaderSize, 1e-6,
+      'Максимальная высота текста названия/шапки должна браться из стиля');
+    CheckEquals(220.0, MinDataSize, 1e-6,
+      'Минимальная высота текста данных должна браться из стиля');
+    CheckEquals(220.0, MaxDataSize, 1e-6,
+      'Максимальная высота текста данных должна браться из стиля');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1330

## Summary
- Resolve the referenced table cell text style before choosing rendered MText height.
- Use the text style fixed height (STYLE group 40) when the resolved style matches the requested cell style and has nonzero size.
- Preserve existing table style/default height fallback for variable-height or missing styles.
- Added regression coverage for tableheighttextbug.dxf: `!!!VTableText_320` renders at 320 and `!!!VTableText_220` renders at 220.

## Reproduction / Verification
1. Load cad_source/test/tableheighttextbug.dxf.
2. Build the imported AcadTable geometry.
3. Before this fix, text styles were applied but rendered heights came from TABLESTYLE (3.5/2.5), leaving table text too small.
4. After this fix, fixed text style heights are applied: title/header 320 and data 220.

## Tests
- `git diff --check`
- `make -C cad_source/zengine/tests all` (blocked locally because `/home/box/lazarus/lazbuild` is not installed; the target exits before compilation)