### PR TITLE
AcadTable: keep interactive preview at table position

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T12:00:30.682Z for PR creation at branch issue-1332-38992214f6fd for issue https://github.com/veb86/zcadvelecAI/issues/1332

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T12:00:30.682Z for PR creation at branch issue-1332-38992214f6fd for issue https://github.com/veb86/zcadvelecAI/issues/1332

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -3211,6 +3211,9 @@ begin
     NewTable^.FCellTexts[Idx] := FCellTexts[Idx];
 
   NewTable^.FTableStyle := FTableStyle;
+  NewTable^.Local := Local;
+  NewTable^.objMatrix := objMatrix;
+  NewTable^.P_insert_in_WCS := P_insert_in_WCS;
 
   System.SetLength(NewTable^.FRows, Length(FRows));
   for Idx := 0 to High(FRows) do

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -66,6 +66,9 @@ type
     // issue #1305, часть 1: трансформация (перенос) должна перестраивать
     // визуальное представление таблицы.
     procedure TransformationMovesRenderedTable;
+    // issue #1332: временный клон для интерактивного редактирования должен
+    // начинать отрисовку в текущем положении таблицы, а не в начале координат.
+    procedure ClonedPreviewKeepsRenderedTableAtSourceLocation;
     // issue #1305, часть 2b: снятие признака разрыва объединяет
     // части-продолжения в единую непрерывную таблицу.
     procedure ClearingBreakMergesContinuationParts;
@@ -1013,6 +1016,57 @@ begin
       '(issue #1305, часть 1)');
     CheckEquals(MaxX1 + Shift, MaxX2, 1e-6,
       'Правая граница перенесённой таблицы должна сдвинуться на ту же величину');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.ClonedPreviewKeepsRenderedTableAtSourceLocation;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable, PreviewTable: PGDBObjAcadTable;
+  DC: TDrawContext;
+  SrcMinX, SrcMaxX, SrcMinY, SrcMaxY: Double;
+  CloneMinX, CloneMaxX, CloneMinY, CloneMaxY: Double;
+  HasLines: Boolean;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    DC := Drawing.CreateDrawingRC;
+    AcadTable^.FormatEntity(Drawing, DC);
+    CollectLineBounds2D(AcadTable^.ConstObjArray,
+      SrcMinX, SrcMaxX, SrcMinY, SrcMaxY, HasLines);
+    CheckTrue(HasLines, 'Исходная таблица должна отрисовать линии в WCS');
+
+    PreviewTable := PGDBObjAcadTable(AcadTable^.Clone(nil));
+    AssertNotNull(
+      'AcadTable.Clone должен вернуть временный объект предпросмотра',
+      PreviewTable);
+    try
+      PreviewTable^.bp.ListPos.Owner := AcadTable^.bp.ListPos.Owner;
+      PreviewTable^.FormatFast(Drawing, DC);
+      PreviewTable^.BuildGeometry(Drawing);
+      CollectLineBounds2D(PreviewTable^.ConstObjArray,
+        CloneMinX, CloneMaxX, CloneMinY, CloneMaxY, HasLines);
+      CheckTrue(HasLines,
+        'Клон предпросмотра должен отрисовать линии в WCS');
+
+      CheckEquals(SrcMinX, CloneMinX, 1e-6,
+        'Клон предпросмотра не должен смещать таблицу в начало координат (MinX)');
+      CheckEquals(SrcMaxX, CloneMaxX, 1e-6,
+        'Клон предпросмотра должен сохранить правую границу таблицы');
+      CheckEquals(SrcMinY, CloneMinY, 1e-6,
+        'Клон предпросмотра должен сохранить нижнюю границу таблицы');
+      CheckEquals(SrcMaxY, CloneMaxY, 1e-6,
+        'Клон предпросмотра должен сохранить верхнюю границу таблицы');
+    finally
+      PreviewTable^.done;
+      FreeMem(Pointer(PreviewTable));
+    end;
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
## Summary
- Copy AcadTable runtime coordinate state into preview clones: `Local`, `objMatrix`, and `P_insert_in_WCS`.
- Add regression coverage that formats a non-origin table, clones it like the realtime preview path, and compares rendered WCS line bounds.
- Remove the scaffold `.gitkeep` placeholder from the branch.

Fixes veb86/zcadvelecAI#1332

## Reproduction
1. Load `cad_source/test/tablerazdel.dxf`.
2. Start an interactive operation on the ACAD_TABLE, such as move, rotate, or split-height editing.
3. Before this fix, the temporary preview clone rebuilt geometry from default origin-local state and rendered near `(0,0,0)` during the edit.

## Verification
- Added `TAcadTableStyleTest.ClonedPreviewKeepsRenderedTableAtSourceLocation`.
- `git diff --check`
- `make -C cad_source/zengine/tests all` is blocked in this environment because `/home/box/lazarus/lazbuild` is missing (`Error 127`).