### PR TITLE
AcadTable: load 11-part broken table as one object

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T13:25:51.794Z for PR creation at branch issue-1334-78f72a6fd56e for issue https://github.com/veb86/zcadvelecAI/issues/1334

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T13:25:51.794Z for PR creation at branch issue-1334-78f72a6fd56e for issue https://github.com/veb86/zcadvelecAI/issues/1334

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -171,6 +171,26 @@ begin
     Result := Copy(Result, I, Length(Result) - I + 1);
 end;
 
+function TryReadDxfPair(const Lines: TStrings; AIndex: Integer;
+  out ACode: Integer; out AValue: string): Boolean;
+begin
+  Result := False;
+  AValue := '';
+  if (AIndex < 0) or (AIndex >= Lines.Count - 1) then
+    Exit;
+
+  if TryStrToInt(Trim(Lines[AIndex]), ACode) then
+  begin
+    AValue := Trim(Lines[AIndex + 1]);
+    Result := True;
+  end;
+end;
+
+function IsAcadTableRoundtripMarker(const Value: string): Boolean;
+begin
+  Result := UpperCase(Trim(Value)) = 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY';
+end;
+
 procedure StoreRawAcadTableEntity(
   RawEntities: TStringList; const Handle, RawText: string);
 var
@@ -275,9 +295,8 @@ procedure ScanTableContinuationHandles(const RawObjectsSection: string;
   ContinuationHandles: TStringList);
 var
   Lines: TStringList;
-  I, Code: Integer;
-  Value: string;
-  InXRecord, InRoundtripBlock: Boolean;
+  I, J, Code, BlockCode: Integer;
+  Value, BlockValue, Handle: string;
 begin
   if (RawObjectsSection = '') or (ContinuationHandles = nil) then
     Exit;
@@ -285,39 +304,39 @@ begin
   Lines := TStringList.Create;
   try
     Lines.Text := RawObjectsSection;
-    InXRecord := False;
-    InRoundtripBlock := False;
     I := 0;
     while I < Lines.Count - 1 do
     begin
-      if not TryStrToInt(Trim(Lines[I]), Code) then begin
-        Inc(I, 2);
-        Continue;
-      end;
-      Value := Trim(Lines[I + 1]);
-
-      if Code = 0 then
+      if TryReadDxfPair(Lines, I, Code, Value) and
+         (Code = 102) and IsAcadTableRoundtripMarker(Value) then
       begin
-        InXRecord := (UpperCase(Value) = 'XRECORD');
-        InRoundtripBlock := False;
-      end
-      else if InXRecord then
-      begin
-        { Маркер начала блока продолжений: группа 102
-          со значением ACAD_ROUNDTRIP_2008_TABLE_ENTITY }
-        if (Code = 102) and
-           (UpperCase(Value) = 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY') then
-          InRoundtripBlock := True
-        else if InRoundtripBlock then
+        { Маркер может находиться на другой чётности строк, чем начало
+          секции OBJECTS, поэтому ищем его построчно, а затем читаем пары
+          от локальной позиции самого маркера. }
+        J := I + 2;
+        while J < Lines.Count - 1 do
         begin
-          if Code = 330 then
-            ContinuationHandles.Add(NormalizeHandle(Value))
-          else if Code = 361 then
-            InRoundtripBlock := False;
+          if TryReadDxfPair(Lines, J, BlockCode, BlockValue) then
+          begin
+            if BlockCode = 0 then
+              Break
+            else if BlockCode = 330 then
+            begin
+              Handle := NormalizeHandle(BlockValue);
+              if Handle <> '' then
+                ContinuationHandles.Add(Handle);
+            end
+            else if BlockCode = 361 then
+              Break;
+
+            Inc(J, 2);
+          end
+          else
+            Inc(J);
         end;
       end;
 
-      Inc(I, 2);
+      Inc(I);
     end;
 
     if ContinuationHandles.Count > 0 then
@@ -343,10 +362,9 @@ procedure ScanTableBreakData(const RawObjectsSection: string;
   out ASpacing, ABreakHeight: Double; out AValid: Boolean);
 var
   Lines: TStringList;
-  I, Code, Found: Integer;
-  Value: string;
+  I, J, Code, BlockCode, Found: Integer;
+  Value, BlockValue: string;
   V: Extended;
-  InXRecord, InRoundtripBlock: Boolean;
 begin
   ASpacing := 0;
   ABreakHeight := 0;
@@ -357,50 +375,46 @@ begin
   Lines := TStringList.Create;
   try
     Lines.Text := RawObjectsSection;
-    InXRecord := False;
-    InRoundtripBlock := False;
-    Found := 0;
     I := 0;
-    while I < Lines.Count - 1 do
+    while (I < Lines.Count - 1) and (not AValid) do
     begin
-      if not TryStrToInt(Trim(Lines[I]), Code) then begin
-        Inc(I, 2);
-        Continue;
-      end;
-      Value := Trim(Lines[I + 1]);
-
-      if Code = 0 then
+      if TryReadDxfPair(Lines, I, Code, Value) and
+         (Code = 102) and IsAcadTableRoundtripMarker(Value) then
       begin
-        InXRecord := (UpperCase(Value) = 'XRECORD');
-        InRoundtripBlock := False;
-      end
-      else if InXRecord then
-      begin
-        if (Code = 102) and
-           (UpperCase(Value) = 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY') then
-          InRoundtripBlock := True
-        else if InRoundtripBlock then
+        Found := 0;
+        J := I + 2;
+        while J < Lines.Count - 1 do
         begin
-          if Code = 361 then
-            InRoundtripBlock := False
-          else if (Code = 40) and (Found < 2) then
+          if TryReadDxfPair(Lines, J, BlockCode, BlockValue) then
           begin
-            { DXF использует точку как десятичный разделитель }
-            if TextToFloat(PChar(Value), V, fvExtended) then
+            if (BlockCode = 0) or (BlockCode = 361) then
+              Break
+            else if (BlockCode = 40) and (Found < 2) then
             begin
-              if Found = 0 then
-                ASpacing := V
-              else
-                ABreakHeight := V;
-              Inc(Found);
-              if Found >= 2 then
-                AValid := True;
+              { DXF использует точку как десятичный разделитель }
+              if TextToFloat(PChar(BlockValue), V, fvExtended) then
+              begin
+                if Found = 0 then
+                  ASpacing := V
+                else
+                  ABreakHeight := V;
+                Inc(Found);
+                if Found >= 2 then
+                begin
+                  AValid := True;
+                  Break;
+                end;
+              end;
             end;
+
+            Inc(J, 2);
           end;
-        end;
+          else
+            Inc(J);
+        end
       end;
 
-      Inc(I, 2);
+      Inc(I);
     end;
 
     if AValid then

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -59,6 +59,7 @@ type
     procedure LoadsBreakSettingsFromSecondSample;
     procedure RendersBrokenTableAsSeparatedFragments;
     procedure LoadsSplitTableAsSingleMergedObject;
+    procedure LoadsIssue1334BreakTableAsSingleMergedObject;
     procedure AppliesTableStyleToContinuationParts;
     // issue #1317: сохранение AcadTable в DXF должно писать структурированные
     // ACAD_TABLE-сущности, включая части-продолжения разделённой таблицы.
@@ -860,6 +861,31 @@ begin
     AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
     CheckEquals(2, AcadTable^.ContinuationPartCount,
       'В главную таблицу должны быть поглощены две части-продолжения');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// Разорванная на 11 частей таблица (bugbreaktable.dxf) хранит список
+// продолжений в OBJECTS/XRECORD. Эти части должны загружаться как один
+// логический AcadTable (issue #1334).
+procedure TAcadTableStyleTest.LoadsIssue1334BreakTableAsSingleMergedObject;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  TableCount: Integer;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/bugbreaktable.dxf'), Drawing);
+  try
+    TableCount := CountAcadTables(Drawing.pObjRoot);
+    CheckEquals(1, TableCount,
+      'Одиннадцать частей разорванной таблицы должны загружаться как один объект AcadTable');
+
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(10, AcadTable^.ContinuationPartCount,
+      'В главную таблицу должны быть поглощены десять частей-продолжений');
   finally
     Drawing.done;
   end;

--- a/experiments/test_issue1334_breaktable_handles.py
+++ b/experiments/test_issue1334_breaktable_handles.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+Inspect issue #1334 DXF table continuation metadata.
+
+The bug file contains one logical ACAD_TABLE split into 11 physical
+ACAD_TABLE entities. This script compares the table handles found in
+ENTITIES with continuation handles found in OBJECTS round-trip XRECORDs.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+DXF_PATH = ROOT / "cad_source/test/bugbreaktable.dxf"
+ROUNDTRIP_MARKER = "ACAD_ROUNDTRIP_2008_TABLE_ENTITY"
+
+
+def normalize_handle(value: str) -> str:
+    value = value.strip().upper()
+    return value.lstrip("0") or "0"
+
+
+def read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="latin-1").splitlines()
+
+
+def try_pair(lines: list[str], index: int) -> tuple[int, str] | None:
+    if index < 0 or index >= len(lines) - 1:
+        return None
+    try:
+        code = int(lines[index].strip())
+    except ValueError:
+        return None
+    return code, lines[index + 1].strip()
+
+
+def extract_section_lines(lines: list[str], section_name: str) -> list[str]:
+    index = 0
+    while index < len(lines) - 3:
+        pair = try_pair(lines, index)
+        name_pair = try_pair(lines, index + 2)
+        if (
+            pair == (0, "SECTION")
+            and name_pair is not None
+            and name_pair[0] == 2
+            and name_pair[1].upper() == section_name
+        ):
+            start = index + 4
+            end = start
+            while end < len(lines) - 1:
+                end_pair = try_pair(lines, end)
+                if end_pair == (0, "ENDSEC"):
+                    return lines[start:end]
+                end += 1
+            return lines[start:]
+        index += 1
+    return []
+
+
+def iter_acad_table_entities(section: list[str]) -> list[list[tuple[int, str]]]:
+    tables: list[list[tuple[int, str]]] = []
+    index = 0
+    while index < len(section) - 1:
+        pair = try_pair(section, index)
+        if pair == (0, "ACAD_TABLE"):
+            body: list[tuple[int, str]] = []
+            cursor = index + 2
+            while cursor < len(section) - 1:
+                next_pair = try_pair(section, cursor)
+                if next_pair is None:
+                    cursor += 1
+                    continue
+                if next_pair[0] == 0:
+                    break
+                body.append(next_pair)
+                cursor += 2
+            tables.append(body)
+            index = cursor
+            continue
+        index += 1
+    return tables
+
+
+def scan_roundtrip_blocks(section: list[str]) -> list[list[str]]:
+    blocks: list[list[str]] = []
+    index = 0
+    while index < len(section) - 1:
+        pair = try_pair(section, index)
+        if pair is not None and pair[0] == 102 and pair[1].upper() == ROUNDTRIP_MARKER:
+            handles: list[str] = []
+            cursor = index + 2
+            while cursor < len(section) - 1:
+                next_pair = try_pair(section, cursor)
+                if next_pair is None:
+                    cursor += 1
+                    continue
+                code, value = next_pair
+                if code in (0, 361):
+                    break
+                if code == 330:
+                    handles.append(normalize_handle(value))
+                cursor += 2
+            if handles:
+                blocks.append(handles)
+            index = cursor
+            continue
+        index += 1
+    return blocks
+
+
+def extract_table_info(table: list[tuple[int, str]]) -> dict[str, object]:
+    handle = ""
+    insert_x = 0.0
+    insert_y = 0.0
+    row_count = 0
+    col_count = 0
+    in_block_ref = False
+    in_table = False
+
+    for code, value in table:
+        text = value.strip()
+        if code == 5 and not handle:
+            handle = normalize_handle(text)
+        elif code == 100 and text == "AcDbBlockReference":
+            in_block_ref = True
+            in_table = False
+        elif code == 100 and text == "AcDbTable":
+            in_block_ref = False
+            in_table = True
+        elif in_block_ref and code == 10:
+            insert_x = float(text)
+        elif in_block_ref and code == 20:
+            insert_y = float(text)
+        elif in_table and code == 91 and row_count == 0:
+            row_count = int(text)
+        elif in_table and code == 92 and col_count == 0:
+            col_count = int(text)
+
+    return {
+        "handle": handle,
+        "x": insert_x,
+        "y": insert_y,
+        "rows": row_count,
+        "cols": col_count,
+    }
+
+
+def main() -> int:
+    lines = read_lines(DXF_PATH)
+    entities = extract_section_lines(lines, "ENTITIES")
+    objects = extract_section_lines(lines, "OBJECTS")
+
+    tables = [extract_table_info(t) for t in iter_acad_table_entities(entities)]
+    continuation_blocks = scan_roundtrip_blocks(objects)
+    continuation_handles = {
+        handle for block in continuation_blocks for handle in block
+    }
+
+    print(f"DXF: {DXF_PATH}")
+    print(f"ACAD_TABLE entities: {len(tables)}")
+    for index, table in enumerate(tables):
+        marker = "continuation" if table["handle"] in continuation_handles else "main"
+        print(
+            "  table[{index:02d}] handle={handle} rows={rows} cols={cols} "
+            "insert=({x:.4f}, {y:.4f}) {marker}".format(
+                index=index, marker=marker, **table
+            )
+        )
+
+    print(f"Round-trip continuation blocks: {len(continuation_blocks)}")
+    for index, block in enumerate(continuation_blocks):
+        print(f"  block[{index:02d}] handles={','.join(block)}")
+
+    table_handles = {str(table["handle"]) for table in tables}
+    missing = sorted(continuation_handles - table_handles)
+    main_count = sum(1 for table in tables if table["handle"] not in continuation_handles)
+    continuation_count = sum(
+        1 for table in tables if table["handle"] in continuation_handles
+    )
+
+    print(f"Main tables by metadata: {main_count}")
+    print(f"Continuation tables by metadata: {continuation_count}")
+    print(f"Continuation handles missing from ENTITIES: {missing}")
+
+    ok = (
+        len(tables) == 11
+        and main_count == 1
+        and continuation_count == 10
+        and not missing
+    )
+    print("RESULT:", "PASS" if ok else "FAIL")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #1334

## What changed
- Fixed the DXF OBJECTS round-trip scanner so it finds `102/ACAD_ROUNDTRIP_2008_TABLE_ENTITY` by local code/value pairs instead of assuming the whole section has one fixed line parity.
- Read continuation handles and break spacing/height from the marker's local pair offset.
- Added a regression for `cad_source/test/bugbreaktable.dxf`: 11 physical `ACAD_TABLE` entities must load as one `AcadTable` with 10 continuation parts.
- Added `experiments/test_issue1334_breaktable_handles.py` to inspect the fixture metadata and confirm the continuation handles are present.

## Verification
- `python3 experiments/test_issue1334_breaktable_handles.py` -> PASS; finds 11 ACAD_TABLE entities, 1 main table, 10 continuation tables, and no missing handles.
- `make -C cad_source/zengine/tests all` could not run locally because `/home/box/lazarus/lazbuild` is not installed in this environment.
