### PR TITLE
AcadTable: enable style editing in object inspector

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T18:33:01.014Z for PR creation at branch issue-1336-9e3bbdee7026 for issue https://github.com/veb86/zcadvelecAI/issues/1336

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T18:33:01.014Z for PR creation at branch issue-1336-9e3bbdee7026 for issue https://github.com/veb86/zcadvelecAI/issues/1336

--- a/cad_source/zcad/register/uzcregacadtable.pas
+++ b/cad_source/zcad/register/uzcregacadtable.pas
@@ -40,6 +40,7 @@ procedure RegisterAcadTableProperties;
 implementation
 
 uses
+  SysUtils,
   uzcoimultiproperties,uzcoimultipropertiesutil,
   uzeacadtable_model,uzeacadtable_types,
   uzeconsts,uzegeometrytypes,
@@ -79,7 +80,7 @@ begin
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
 end;
 
-// Чтение имени стиля таблицы (только чтение)
+// Чтение имени стиля таблицы. Свойство редактируемое при наличии change-proc.
 procedure AcadTableStyleNameEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
   mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
   const f:TzeUnitsFormat);
@@ -93,6 +94,36 @@ begin
   v:=PGDBObjAcadTable(ChangedData.PEntity)^.TableStyleName;
   ChangedData.PGetDataInEtity:=@v;
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+end;
+
+// Запись имени DXF-стиля таблицы из инспектора объектов (issue #1336).
+// Имя резолвится в GDBObjAcadTable.SetTableStyleName через таблицу
+// DXF TABLESTYLE; при успешном изменении сохраняется новый хэндл группы 342.
+procedure AcadTableStyleNameEntChangeProc(var UMPlaced:boolean;
+  pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
+var
+  Table:PGDBObjAcadTable;
+  NewValue:String;
+begin
+  Table:=PGDBObjAcadTable(ChangedData.PEntity);
+  NewValue:=PString(pvardesk(pdata)^.data.Addr.Instance)^;
+  if SameText(Table^.TableStyleName, Trim(NewValue)) then
+    exit;
+  if drawings.GetCurrentDWG=nil then
+  begin
+    programlog.LogOutStr(
+      'AcadTable: register: SetTableStyleName — current drawing is nil',
+      LM_Info);
+    exit;
+  end;
+
+  PlaceUndoStartMarkerPropertyChangedIfNeed(UMPlaced);
+  if not Table^.SetTableStyleName(NewValue, drawings.GetCurrentDWG^) then
+    exit;
+  Table^.YouChanged(drawings.GetCurrentDWG^);
+
+  ProcessVariableAttributes(
+    pvardesk(pdata)^.attrib,0,vda_approximately or vda_different);
 end;
 
 // Чтение количества строк (только чтение, не редактируется)
@@ -514,12 +545,13 @@ begin
     OneVarDataMIPD,
     TEntIterateProcsData.Create(nil,@AcadTableHeightEntIterateProc,nil));
 
-  {AcadTable — основные свойства (только чтение)}
+  {AcadTable — основные свойства}
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableStyleName','Table style',sysunit^.TypeName2PTD('AnsiString'),
     MPCMisc,GDBAcadTableID,nil,0,0,
     OneVarDataMIPD,
-    TEntIterateProcsData.Create(nil,@AcadTableStyleNameEntIterateProc,nil));
+    TEntIterateProcsData.Create(nil,@AcadTableStyleNameEntIterateProc,
+      @AcadTableStyleNameEntChangeProc));
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableRowCount','Rows',sysunit^.TypeName2PTD('TArrayIndex'),
     MPCMisc,GDBAcadTableID,nil,0,0,

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -331,6 +331,8 @@ type
     // (issue #1307). Возвращает True.
     function SetTableBreakData(
       ASpacing, ABreakHeight: Double): Boolean; virtual;
+    function SetTableStyleName(
+      const AValue: String; var ADrawing: TDrawingDef): Boolean; virtual;
     procedure SetDXFRawEntityText(const ARawText: string); virtual;
 
     // Публичные свойства для инспектора объектов
@@ -445,6 +447,48 @@ end;
 function GDBObjAcadTable.GetTableStyleName: String;
 begin
   Result := FTableStyle.Name;
+end;
+
+function GDBObjAcadTable.SetTableStyleName(
+  const AValue: String; var ADrawing: TDrawingDef): Boolean;
+var
+  NewHandle: String;
+  PartIdx: Integer;
+  StyleName: String;
+begin
+  Result := False;
+  StyleName := Trim(AValue);
+  if StyleName = '' then
+  begin
+    programlog.LogOutStr(
+      'AcadTable: model: SetTableStyleName — empty style name',
+      LM_Info);
+    Exit;
+  end;
+
+  if SameText(FTableStyle.Name, StyleName) then
+  begin
+    Result := True;
+    Exit;
+  end;
+
+  if not uzeacadtable_stylemanager.ApplyDXFTableStyleByName(
+    FTableStyle, StyleName, ADrawing, NewHandle) then
+    Exit;
+
+  FTableStyleHandle := NewHandle;
+  for PartIdx := 0 to High(FContinuationParts) do
+  begin
+    FContinuationParts[PartIdx].TableStyle := FTableStyle;
+    FContinuationParts[PartIdx].TableStyleHandle := NewHandle;
+  end;
+  FGeometryBuilt := False;
+  InvalidateRawDXFEntity;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetTableStyleName="%s" handle=%s',
+    [FTableStyle.Name, FTableStyleHandle], LM_Info);
+  Result := True;
 end;
 
 function GDBObjAcadTable.GetCellTextLocal(

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_stylemanager.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_stylemanager.pas
@@ -44,6 +44,15 @@ procedure ApplyDXFTableStyle(
   const AStyleHandle: String;
   var ADrawing: TDrawingDef);
 
+// Применяет DXF-стиль таблицы по имени из инспектора объектов.
+// Возвращает хэндл найденного TABLESTYLE для записи обратно в ACAD_TABLE
+// (группа DXF 342).
+function ApplyDXFTableStyleByName(
+  var ATableStyle: TTableStyle;
+  const AStyleName: String;
+  var ADrawing: TDrawingDef;
+  out AStyleHandle: String): Boolean;
+
 // Резолвит указатель на текстовый стиль по имени
 // с fallback к Standard, затем к первому доступному.
 function ResolveTextStyle(
@@ -57,6 +66,66 @@ procedure FillCellStyleFromDXF(
   const ATextStyleName: String);
 
 implementation
+
+procedure ApplyDXFTableStyleData(
+  var ATableStyle: TTableStyle;
+  StylePtr: PTGDBDXFTableStyle;
+  const AStyleHandle: String);
+var
+  CellStylePtr: PTGDBDXFTableCellStyle;
+  CellFormatsIter: itrec;
+  CellIdx: Integer;
+begin
+  if StylePtr = nil then
+    Exit;
+
+  InitTableStyle(ATableStyle);
+  ATableStyle.Name := StylePtr^.Name;
+
+  // Порядок хранения в DXF (TABLESTYLE):
+  // 0=Data, 1=Title, 2=Header
+  CellIdx := 0;
+  CellStylePtr :=
+    StylePtr^.CellFormats.beginiterate(CellFormatsIter);
+  while (CellStylePtr <> nil) and (CellIdx < 3) do
+  begin
+    case CellIdx of
+      0:
+        begin
+          // Первый блок — стиль Data (данные)
+          FillCellStyleFromDXF(
+            ATableStyle.DataCell, CellStylePtr^,
+            StylePtr^.CellTextStyleName[0]);
+          // Data используется как базовый стиль
+          FillCellStyleFromDXF(
+            ATableStyle.DefaultCell, CellStylePtr^,
+            StylePtr^.CellTextStyleName[0]);
+        end;
+      1:
+        // Второй блок — стиль Title (название)
+        FillCellStyleFromDXF(
+          ATableStyle.TitleCell, CellStylePtr^,
+          StylePtr^.CellTextStyleName[1]);
+      2:
+        // Третий блок — стиль Header (заголовок)
+        FillCellStyleFromDXF(
+          ATableStyle.HeaderCell, CellStylePtr^,
+          StylePtr^.CellTextStyleName[2]);
+    end;
+    Inc(CellIdx);
+    CellStylePtr :=
+      StylePtr^.CellFormats.iterate(CellFormatsIter);
+  end;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: stylemanager: ApplyDXFTableStyleData OK ' +
+    'стиль="%s" хэндл=%s title_height=%.2f ' +
+    'header_height=%.2f data_height=%.2f',
+    [ATableStyle.Name, AStyleHandle,
+     ATableStyle.TitleCell.TextHeight,
+     ATableStyle.HeaderCell.TextHeight,
+     ATableStyle.DataCell.TextHeight], LM_Info);
+end;
 
 procedure FillCellStyleFromDXF(
   var CellStyle: TCellStyle;
@@ -102,9 +171,6 @@ var
   DXFStyleTable: PGDBDXFTableStyleArray;
   StylePtr: PTGDBDXFTableStyle;
   IterRec: itrec;
-  CellStylePtr: PTGDBDXFTableCellStyle;
-  CellFormatsIter: itrec;
-  CellIdx: Integer;
 begin
   DXFStyleTable := ADrawing.GetDXFTableStyleTable;
   if DXFStyleTable = nil then
@@ -142,51 +208,51 @@ begin
     'применяем стиль "%s" (хэндл=%s)',
     [StylePtr^.Name, AStyleHandle], LM_Info);
 
-  ATableStyle.Name := StylePtr^.Name;
+  ApplyDXFTableStyleData(ATableStyle, StylePtr, AStyleHandle);
+end;
 
-  // Порядок хранения в DXF (TABLESTYLE):
-  // 0=Data, 1=Title, 2=Header
-  CellIdx := 0;
-  CellStylePtr :=
-    StylePtr^.CellFormats.beginiterate(CellFormatsIter);
-  while (CellStylePtr <> nil) and (CellIdx < 3) do
+function ApplyDXFTableStyleByName(
+  var ATableStyle: TTableStyle;
+  const AStyleName: String;
+  var ADrawing: TDrawingDef;
+  out AStyleHandle: String): Boolean;
+var
+  DXFStyleTable: PGDBDXFTableStyleArray;
+  StylePtr: PTGDBDXFTableStyle;
+begin
+  Result := False;
+  AStyleHandle := '';
+
+  DXFStyleTable := ADrawing.GetDXFTableStyleTable;
+  if DXFStyleTable = nil then
   begin
-    case CellIdx of
-      0:
-        begin
-          // Первый блок — стиль Data (данные)
-          FillCellStyleFromDXF(
-            ATableStyle.DataCell, CellStylePtr^,
-            StylePtr^.CellTextStyleName[0]);
-          // Data используется как базовый стиль
-          FillCellStyleFromDXF(
-            ATableStyle.DefaultCell, CellStylePtr^,
-            StylePtr^.CellTextStyleName[0]);
-        end;
-      1:
-        // Второй блок — стиль Title (название)
-        FillCellStyleFromDXF(
-          ATableStyle.TitleCell, CellStylePtr^,
-          StylePtr^.CellTextStyleName[1]);
-      2:
-        // Третий блок — стиль Header (заголовок)
-        FillCellStyleFromDXF(
-          ATableStyle.HeaderCell, CellStylePtr^,
-          StylePtr^.CellTextStyleName[2]);
-    end;
-    Inc(CellIdx);
-    CellStylePtr :=
-      StylePtr^.CellFormats.iterate(CellFormatsIter);
+    programlog.LogOutStr(
+      'AcadTable: stylemanager: ApplyDXFTableStyleByName — ' +
+      'таблица DXF-стилей недоступна', LM_Info);
+    Exit;
   end;
 
-  programlog.LogOutFormatStr(
-    'AcadTable: stylemanager: ApplyDXFTableStyle OK ' +
-    'стиль="%s" title_height=%.2f ' +
-    'header_height=%.2f data_height=%.2f',
-    [ATableStyle.Name,
-     ATableStyle.TitleCell.TextHeight,
-     ATableStyle.HeaderCell.TextHeight,
-     ATableStyle.DataCell.TextHeight], LM_Info);
+  if DXFStyleTable^.count = 0 then
+  begin
+    programlog.LogOutStr(
+      'AcadTable: stylemanager: ApplyDXFTableStyleByName — ' +
+      'таблица DXF-стилей пуста', LM_Info);
+    Exit;
+  end;
+
+  StylePtr := PTGDBDXFTableStyle(DXFStyleTable^.getAddres(AStyleName));
+  if StylePtr = nil then
+  begin
+    programlog.LogOutFormatStr(
+      'AcadTable: stylemanager: ApplyDXFTableStyleByName — ' +
+      'стиль "%s" не найден',
+      [AStyleName], LM_Info);
+    Exit;
+  end;
+
+  AStyleHandle := StylePtr^.DXFHandle;
+  ApplyDXFTableStyleData(ATableStyle, StylePtr, AStyleHandle);
+  Result := True;
 end;
 
 function ResolveTextStyle(

--- a/test_issue1336_acadtable_style_inspector.py
+++ b/test_issue1336_acadtable_style_inspector.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1336 AcadTable style editing from object inspector.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+REGISTER_PAS = ROOT / "cad_source" / "zcad" / "register" / "uzcregacadtable.pas"
+MODEL_PAS = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_model.pas"
+)
+STYLEMANAGER_PAS = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_stylemanager.pas"
+)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split())
+
+
+def test_acadtable_style_property_has_edit_handler():
+    register_pas = read_text(REGISTER_PAS)
+    register_compact = compact(register_pas)
+
+    assert "procedure AcadTableStyleNameEntChangeProc" in register_pas
+    assert "SetTableStyleName" in register_pas
+    assert "YouChanged" in register_pas
+    assert (
+        "TEntIterateProcsData.Create("
+        "nil,@AcadTableStyleNameEntIterateProc,"
+        "@AcadTableStyleNameEntChangeProc)"
+    ) in register_compact
+
+
+def test_model_applies_style_name_through_dxf_table_styles():
+    model_pas = read_text(MODEL_PAS)
+    model_compact = compact(model_pas)
+
+    assert "function SetTableStyleName" in model_pas
+    assert "ApplyDXFTableStyleByName" in model_pas
+    assert "FTableStyleHandle:=NewHandle" in model_compact
+    assert "FContinuationParts[PartIdx].TableStyle:=FTableStyle" in model_compact
+    assert "FContinuationParts[PartIdx].TableStyleHandle:=NewHandle" in model_compact
+    assert "FGeometryBuilt:=False" in model_compact
+    assert "InvalidateRawDXFEntity;" in model_pas
+    assert ".TableStyleTable" not in model_pas
+
+
+def test_stylemanager_resolves_dxf_table_style_by_name():
+    stylemanager_pas = read_text(STYLEMANAGER_PAS)
+
+    assert "function ApplyDXFTableStyleByName" in stylemanager_pas
+    assert "getAddres(AStyleName)" in stylemanager_pas
+    assert "AStyleHandle := StylePtr^.DXFHandle" in stylemanager_pas
+    assert "ApplyDXFTableStyleData" in stylemanager_pas
+
+
+if __name__ == "__main__":
+    test_acadtable_style_property_has_edit_handler()
+    test_model_applies_style_name_through_dxf_table_styles()
+    test_stylemanager_resolves_dxf_table_style_by_name()
+    print("issue 1336 AcadTable style inspector checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1336.

## What changed
- Added an edit handler for `AcadTableStyleName` so the object inspector no longer marks the table style field read-only.
- Added `GDBObjAcadTable.SetTableStyleName` to resolve a style name through the DXF `TABLESTYLE` table, update the stored group 342 handle, invalidate raw DXF/geometry, and keep continuation parts in sync.
- Refactored DXF table-style application so loading by handle and changing by name reuse the same style-fill logic.
- Added regression coverage for the inspector registration and DXF-style update path.

## Reproduce
Before this change, `AcadTableStyleName` was registered with `TEntIterateProcsData.Create(..., @AcadTableStyleNameEntIterateProc, nil)`, so its iterator applied `vda_RO` and blocked edits in the object inspector.

## Verification
- `python3 test_issue1336_acadtable_style_inspector.py`
- `pytest -q test_issue*.py` (`25 passed`)

Pascal/Lazarus build was not run locally because `lazbuild`/Free Pascal are not installed in this container.
