### PR TITLE
AcadTable: select table style from inspector combobox

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-15T19:55:39.787Z for PR creation at branch issue-1336-66b41a73b900 for issue https://github.com/veb86/zcadvelecAI/issues/1336

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-15T19:55:39.787Z for PR creation at branch issue-1336-66b41a73b900 for issue https://github.com/veb86/zcadvelecAI/issues/1336

--- a/cad_source/zcad/register/uzcregacadtable.pas
+++ b/cad_source/zcad/register/uzcregacadtable.pas
@@ -44,6 +44,7 @@ uses
   uzcoimultiproperties,uzcoimultipropertiesutil,
   uzeacadtable_model,uzeacadtable_types,
   uzeconsts,uzegeometrytypes,
+  uzestylestablesdxf,
   uzcdrawings,
   uzsbVarmanDef,Varman,uzbUnits,uzetypes,gzctnrVectorTypes,uzctnrVectorStrings,
   uzclog,uzbLogIntf;
@@ -80,33 +81,96 @@ begin
   GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
 end;
 
-// Чтение имени стиля таблицы. Свойство редактируемое при наличии change-proc.
+function AcadTableStyleNameToEnumIndex(EnumData:PTEnumData;
+  const StyleName:String):integer;
+var
+  i:integer;
+begin
+  result:=-1;
+  if EnumData=nil then
+    exit;
+  for i:=0 to EnumData^.Enums.Count-1 do
+    if SameText(pstring(EnumData^.Enums.getDataMutable(i))^,StyleName) then
+    begin
+      result:=i;
+      exit;
+    end;
+end;
+
+// Подготовка списка DXF-стилей таблиц для комбобокса инспектора объектов.
+function GetAcadTableStyleNameData(mp:TMultiProperty;pu:PTEntityUnit):Pointer;
+var
+  PVD:pvardesk;
+  t:PTEnumData;
+  StyleTable:PGDBDXFTableStyleArray;
+  StylePtr:PTGDBDXFTableStyle;
+  IterRec:itrec;
+begin
+  result:=GetTEnumData(mp,pu);
+  PVD:=PTOneVarData(result)^.VDAddr.Instance;
+  if PVD<>nil then
+  begin
+    t:=PVD^.data.Addr.Instance;
+    t^.Enums.Clear;
+    if drawings.GetCurrentDWG<>nil then
+    begin
+      StyleTable:=@drawings.GetCurrentDWG^.DXFTableStyleTable;
+      StylePtr:=StyleTable^.beginiterate(IterRec);
+      while StylePtr<>nil do
+      begin
+        if StylePtr^.Name<>'' then
+          t^.Enums.PushBackData(StylePtr^.Name);
+        StylePtr:=StyleTable^.iterate(IterRec);
+      end;
+    end;
+    t^.Selected:=0;
+  end;
+end;
+
+// Чтение имени стиля таблицы через список существующих DXF TABLESTYLE.
 procedure AcadTableStyleNameEntIterateProc(pdata:Pointer;ChangedData:TChangedData;
   mp:TMultiProperty;fistrun:boolean;ecp:TEntChangeProc;
   const f:TzeUnitsFormat);
 var
   PVD:pvardesk;
-  v:AnsiString;
+  EnumData:PTEnumData;
+  EnumIndex:integer;
 begin
   PVD:=PTOneVarData(pdata)^.VDAddr.Instance;
   if @ecp=nil then
     ProcessVariableAttributes(PVD^.attrib,vda_RO,0);
-  v:=PGDBObjAcadTable(ChangedData.PEntity)^.TableStyleName;
-  ChangedData.PGetDataInEtity:=@v;
-  GeneralEntIterateProc(pdata,ChangedData,mp,fistrun,ecp,f);
+  EnumData:=PTEnumData(PVD^.data.Addr.Instance);
+  EnumIndex:=AcadTableStyleNameToEnumIndex(
+    EnumData,PGDBObjAcadTable(ChangedData.PEntity)^.TableStyleName);
+  if EnumIndex<0 then
+  begin
+    ProcessVariableAttributes(PVD^.attrib,vda_different,0);
+    exit;
+  end;
+  if fistrun then
+    PTEnumData(PVD^.data.Addr.Instance)^.Selected:=EnumIndex
+  else
+    if PTEnumData(PVD^.data.Addr.Instance)^.Selected<>EnumIndex then
+      ProcessVariableAttributes(PVD^.attrib,vda_different,0);
 end;
 
-// Запись имени DXF-стиля таблицы из инспектора объектов (issue #1336).
+// Запись выбранного DXF-стиля таблицы из инспектора объектов (issue #1336).
 // Имя резолвится в GDBObjAcadTable.SetTableStyleName через таблицу
 // DXF TABLESTYLE; при успешном изменении сохраняется новый хэндл группы 342.
 procedure AcadTableStyleNameEntChangeProc(var UMPlaced:boolean;
   pu:PTEntityUnit;pdata:PVarDesk;ChangedData:TChangedData;mp:TMultiProperty);
 var
   Table:PGDBObjAcadTable;
+  EnumData:PTEnumData;
+  NewIndex:integer;
   NewValue:String;
 begin
   Table:=PGDBObjAcadTable(ChangedData.PEntity);
-  NewValue:=PString(pvardesk(pdata)^.data.Addr.Instance)^;
+  EnumData:=PTEnumData(pvardesk(pdata)^.data.Addr.Instance);
+  NewIndex:=EnumData^.Selected;
+  if (NewIndex<0)or(NewIndex>=EnumData^.Enums.Count) then
+    exit;
+  NewValue:=pstring(EnumData^.Enums.getDataMutable(NewIndex))^;
   if SameText(Table^.TableStyleName, Trim(NewValue)) then
     exit;
   if drawings.GetCurrentDWG=nil then
@@ -547,11 +611,13 @@ begin
 
   {AcadTable — основные свойства}
   MultiPropertiesManager.RegisterPhysMultiproperty(
-    'AcadTableStyleName','Table style',sysunit^.TypeName2PTD('AnsiString'),
+    'AcadTableStyleName','Table style',sysunit^.TypeName2PTD('TEnumData'),
     MPCMisc,GDBAcadTableID,nil,0,0,
-    OneVarDataMIPD,
+    TMainIterateProcsData.Create(
+      @GetAcadTableStyleNameData,@FreeTEnumData),
     TEntIterateProcsData.Create(nil,@AcadTableStyleNameEntIterateProc,
-      @AcadTableStyleNameEntChangeProc));
+      @AcadTableStyleNameEntChangeProc),
+    MPUM_AtLeastOneEntMatched);
   MultiPropertiesManager.RegisterPhysMultiproperty(
     'AcadTableRowCount','Rows',sysunit^.TypeName2PTD('TArrayIndex'),
     MPCMisc,GDBAcadTableID,nil,0,0,

--- a/test_issue1336_acadtable_style_inspector.py
+++ b/test_issue1336_acadtable_style_inspector.py
@@ -34,11 +34,25 @@ def compact(text: str) -> str:
     return "".join(text.split())
 
 
-def test_acadtable_style_property_has_edit_handler():
+def test_acadtable_style_property_uses_dxf_style_combobox():
     register_pas = read_text(REGISTER_PAS)
     register_compact = compact(register_pas)
 
+    assert "function GetAcadTableStyleNameData" in register_pas
+    assert "DXFTableStyleTable" in register_pas
+    assert "PTGDBDXFTableStyle" in register_pas
+    assert "sysunit^.TypeName2PTD('TEnumData')" in register_pas
+    assert (
+        "TMainIterateProcsData.Create("
+        "@GetAcadTableStyleNameData,@FreeTEnumData)"
+    ) in register_compact
+    assert (
+        "'AcadTableStyleName','Table style',"
+        "sysunit^.TypeName2PTD('AnsiString')"
+    ) not in register_compact
     assert "procedure AcadTableStyleNameEntChangeProc" in register_pas
+    assert "PTEnumData(PVD^.data.Addr.Instance)^.Selected" in register_pas
+    assert ".Enums.getDataMutable(NewIndex)" in register_pas
     assert "SetTableStyleName" in register_pas
     assert "YouChanged" in register_pas
     assert (
@@ -72,7 +86,7 @@ def test_stylemanager_resolves_dxf_table_style_by_name():
 
 
 if __name__ == "__main__":
-    test_acadtable_style_property_has_edit_handler()
+    test_acadtable_style_property_uses_dxf_style_combobox()
     test_model_applies_style_name_through_dxf_table_styles()
     test_stylemanager_resolves_dxf_table_style_by_name()
     print("issue 1336 AcadTable style inspector checks passed")


### PR DESCRIPTION
Fixes #1336

## What changed
- Changed `AcadTableStyleName` in the object inspector from a free text `AnsiString` editor to a `TEnumData` combobox.
- Populates the combobox from the current drawing `DXFTableStyleTable`, so users can choose an existing DXF TABLESTYLE instead of typing the style name manually.
- Keeps style application routed through `GDBObjAcadTable.SetTableStyleName`, preserving DXF handle resolution and table geometry invalidation.

## Reproduction
1. Open a drawing containing multiple DXF table styles.
2. Select an AcadTable entity.
3. In the object inspector, edit `AcadTableStyleName`.

Before this change the field required manually typing an exact style name. After this change it is a combobox of existing drawing table styles.

## Tests
- `python3 test_issue1336_acadtable_style_inspector.py`
- `pytest -q test_issue*.py`
- `git diff --check`

## Notes
- `pytest -q` for the whole repository is not usable in this checkout because collection enters non-UTF-8 DXF sample `.txt` files and experiment scripts with missing optional dependencies such as `numpy`; the full collection failure log was saved locally at `/tmp/gh-issue-solver-1781553321147-pytest-all.log`.
- Pascal compile tools (`fpc`, `lazbuild`) are not installed in this environment.