### PR TITLE
AcadTable: fix raw ACAD_TABLE handle remapping on save (issue #1339)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,7 @@ cad_source/zengine/tests/*.or
 cad_source/zengine/tests/*.rsj
 cad_source/zengine/tests/*.compiled
 cad_source/zengine/tests/testacadtable_standalone
+cad_source/zengine/tests/roundtrip1339
+
+# issue #1339 round-trip experiment output
+experiments/out1339/

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-16T12:16:26.346Z for PR creation at branch issue-1339-0ed1430dd5bb for issue https://github.com/veb86/zcadvelecAI/issues/1339

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-16T12:16:26.346Z for PR creation at branch issue-1339-0ed1430dd5bb for issue https://github.com/veb86/zcadvelecAI/issues/1339

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -90,7 +90,8 @@ function WriteRawAcadTablePartsToDXF(
   var AIODXFContext: TIODXFSaveContext;
   const AMainRawEntity: String;
   const AContinuationRawEntities: array of String;
-  ABreakSpacing, ABreakHeight: Double): Boolean;
+  ABreakSpacing, ABreakHeight: Double;
+  const ATableStyleName: String): Boolean;
 
 procedure WriteAcadTableRoundTripObjectsToDXF(
   var AOutStream: TZctnrVectorBytes;
@@ -470,17 +471,86 @@ begin
     AIODXFContext.handle := AHandle + 1;
 end;
 
+// Записывает сырую (raw) сущность ACAD_TABLE, переписывая ссылки на хэндлы
+// под актуальную (перенумерованную) нумерацию сохраняемого файла (issue #1339):
+//   330 — владелец сущности (*Model_Space);
+//   342 — стиль таблицы (по имени стиля ATableStyleName);
+//   343 — анонимный блок таблицы (по имени блока из предшествующей пары 2);
+//   блок расширенного словаря 102/ACAD_XDICTIONARY удаляется, т.к. он не
+//        круглорейсится и иначе оставляет висячую ссылку (360).
+// Хэндл самой сущности (группа 5) намеренно не трогаем.
 procedure WriteRawEntityText(
-  var AOutStream: TZctnrVectorBytes; const ARawEntity: String);
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const ATableStyleName: String;
+  const ARawEntity: String);
 var
   Lines: TStringList;
   I: Integer;
+  Code, OutValue, LastBlockName, MappedValue: String;
 begin
   Lines := TStringList.Create;
   try
     Lines.Text := ARawEntity;
-    for I := 0 to Lines.Count - 1 do
+    LastBlockName := '';
+    I := 0;
+    while I < Lines.Count do
+    begin
+      Code := Trim(Lines[I]);
+
+      { Удаляем блок расширенного словаря целиком (вместе с висячим 360). }
+      if (Code = '102') and (I + 1 < Lines.Count)
+         and (Trim(Lines[I + 1]) = '{ACAD_XDICTIONARY') then
+      begin
+        Inc(I, 2);
+        while I + 1 < Lines.Count do
+        begin
+          if (Trim(Lines[I]) = '102') and (Trim(Lines[I + 1]) = '}') then
+          begin
+            Inc(I, 2);
+            Break;
+          end;
+          Inc(I, 2);
+        end;
+        Continue;
+      end;
+
+      if I + 1 >= Lines.Count then
+      begin
+        { Непарная завершающая строка — пишем как есть. }
+        AOutStream.TXTAddStringEOL(Lines[I]);
+        Inc(I);
+        Continue;
+      end;
+
+      OutValue := Lines[I + 1];
+
+      if Code = '2' then
+        LastBlockName := Trim(Lines[I + 1])
+      else if Code = '330' then
+      begin
+        if AIODXFContext.AcadTableOwnerHandle <> 0 then
+          OutValue := IntToHex(AIODXFContext.AcadTableOwnerHandle, 0);
+      end
+      else if Code = '342' then
+      begin
+        if (ATableStyleName <> '')
+           and AIODXFContext.TableStyleNameHandleMap.MyGetValue(
+             ATableStyleName, MappedValue) then
+          OutValue := MappedValue;
+      end
+      else if Code = '343' then
+      begin
+        if (LastBlockName <> '')
+           and AIODXFContext.BlockNameHandleMap.MyGetValue(
+             LastBlockName, MappedValue) then
+          OutValue := MappedValue;
+      end;
+
       AOutStream.TXTAddStringEOL(Lines[I]);
+      AOutStream.TXTAddStringEOL(OutValue);
+      Inc(I, 2);
+    end;
   finally
     Lines.Free;
   end;
@@ -558,7 +628,8 @@ function WriteRawAcadTablePartsToDXF(
   var AIODXFContext: TIODXFSaveContext;
   const AMainRawEntity: String;
   const AContinuationRawEntities: array of String;
-  ABreakSpacing, ABreakHeight: Double): Boolean;
+  ABreakSpacing, ABreakHeight: Double;
+  const ATableStyleName: String): Boolean;
 var
   MainHandle: TDWGHandle;
   ContinuationHandles: array of TDWGHandle;
@@ -575,12 +646,14 @@ begin
       ContinuationHandles[PartIdx]) then
       Exit;
 
-  WriteRawEntityText(AOutStream, AMainRawEntity);
+  WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
+    AMainRawEntity);
   BumpHandleAfterRawEntity(AIODXFContext, MainHandle);
 
   for PartIdx := 0 to High(AContinuationRawEntities) do
   begin
-    WriteRawEntityText(AOutStream, AContinuationRawEntities[PartIdx]);
+    WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
+      AContinuationRawEntities[PartIdx]);
     BumpHandleAfterRawEntity(
       AIODXFContext, ContinuationHandles[PartIdx]);
   end;

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -3198,12 +3198,22 @@ var
 begin
   if CanSaveRawDXFEntity then
   begin
+    // Перед сохранением гарантируем, что имя стиля таблицы определено.
+    // Для raw-таблиц (issue #1339) BuildGeometry мог ещё не выполняться
+    // (например, при пакетном "Сохранить как" без отрисовки), поэтому
+    // FTableStyle.Name остаётся пустым. Без имени невозможно перенумеровать
+    // ссылку 342 на актуальный хэндл TABLESTYLE — и таблица сохраняется со
+    // ссылкой на старый (чужой после перенумерации) хэндл.
+    if (FTableStyle.Name = '') and (FTableStyleHandle <> '') then
+      uzeacadtable_stylemanager.ApplyDXFTableStyle(
+        FTableStyle, FTableStyleHandle, ADrawing);
+
     System.SetLength(RawParts, Length(FContinuationParts));
     for PartIdx := 0 to High(FContinuationParts) do
       RawParts[PartIdx] := FContinuationParts[PartIdx].RawDXFEntity;
     if uzeacadtable_dxf_write.WriteRawAcadTablePartsToDXF(
       AOutStream, AIODXFContext, FRawDXFEntity, RawParts,
-      FBreakSpacing, FBreakHeight) then
+      FBreakSpacing, FBreakHeight, Self.TableStyleName) then
       Exit;
   end;
 

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -195,16 +195,11 @@ begin
   outstream.TXTAddStringEOL(dxfGroupCode(5));
   outstream.TXTAddStringEOL(inttohex(StyleHandle, 0));
 
-  { Блок ACAD_XDICTIONARY }
-  if Style^.XDictHandle <> '' then
-  begin
-    outstream.TXTAddStringEOL(dxfGroupCode(102));
-    outstream.TXTAddStringEOL('{ACAD_XDICTIONARY');
-    outstream.TXTAddStringEOL(dxfGroupCode(360));
-    outstream.TXTAddStringEOL(Style^.XDictHandle);
-    outstream.TXTAddStringEOL(dxfGroupCode(102));
-    outstream.TXTAddStringEOL('}');
-  end;
+  { Блок ACAD_XDICTIONARY намеренно НЕ пишем (issue #1339): сам объект
+    расширенного словаря в выходной файл не сохраняется, поэтому ссылка 360
+    на Style^.XDictHandle (старый хэндл из загруженного файла) указывала бы
+    на несуществующий объект — висячая ссылка, из-за которой AutoCAD
+    открывает пустой чертёж. }
 
   { Блок ACAD_REACTORS — принадлежность словарю }
   outstream.TXTAddStringEOL(dxfGroupCode(102));
@@ -371,6 +366,7 @@ var
   { Массивы предварительно выделенных хэндлов для стилей таблиц }
   tsHandles: array of TDWGHandle;
   tsCount: integer;
+  tsHandlesAllocated: boolean;
   beforeProcIdx: integer;
 
   procedure RunObjectsSaveDxfProcs;
@@ -381,6 +377,46 @@ var
       if Assigned(ObjectsSaveDxfProcs[objectsProcIdx]) then
         ObjectsSaveDxfProcs[objectsProcIdx](
           outstream,drawing,IODXFContext);
+  end;
+
+  { Предварительно выделяет хэндлы для стилей таблиц и строит карту
+    «имя стиля -> новый хэндл», а также вычисляет новый хэндл владельца
+    (*Model_Space) для сырых сущностей ACAD_TABLE. Должно вызываться ДО
+    записи секции ENTITIES, т.к. сырая сущность ACAD_TABLE ссылается на
+    стиль таблицы (342) и владельца (330), которые иначе пишутся позже
+    или перенумеровываются (issue #1339). }
+  procedure PreallocateTableStyleHandles;
+  var
+    psIdx: integer;
+    psStyle: PTGDBDXFTableStyle;
+    psIter: itrec;
+    msHandle: TDWGHandle;
+  begin
+    if tsHandlesAllocated then
+      Exit;
+    tsHandlesAllocated:=True;
+
+    { Новый хэндл владельца сущностей пространства модели. В шаблоне и в
+      исходных файлах AutoCAD блок *Model_Space всегда имеет хэндл 1F. }
+    msHandle:=OldHandele2NewHandle.MyGetValue($1F);
+    if msHandle>0 then
+      IODXFContext.AcadTableOwnerHandle:=msHandle;
+
+    tsCount:=drawing.DXFTableStyleTable.count;
+    if tsCount>0 then begin
+      SetLength(tsHandles, tsCount);
+      psIdx:=0;
+      psStyle:=drawing.DXFTableStyleTable.beginiterate(psIter);
+      while (psStyle<>nil) and (psIdx<tsCount) do begin
+        tsHandles[psIdx]:=IODXFContext.handle;
+        Inc(IODXFContext.handle);
+        if not IODXFContext.TableStyleNameHandleMap.MyContans(psStyle^.Name) then
+          IODXFContext.TableStyleNameHandleMap.Add(
+            psStyle^.Name, inttohex(tsHandles[psIdx],0));
+        Inc(psIdx);
+        psStyle:=drawing.DXFTableStyleTable.iterate(psIter);
+      end;
+    end;
   end;
 begin
   intable:=0;
@@ -423,6 +459,7 @@ begin
     tablestyledicthandle:=0;
     writtenstylecount:=0;
     tsCount:=0;
+    tsHandlesAllocated:=False;
     SetLength(tsHandles, 0);
     MakeVariablesDict(IODXFContext.VarsDict,drawing);
     processedvarscount:=IODXFContext.VarsDict.Count;
@@ -487,6 +524,10 @@ begin
         end else if (groupi=2) and (values='ENTITIES') then begin
           outstream.TXTAddStringEOL(groups);
           outstream.TXTAddStringEOL(values);
+          { Перед записью сущностей выделяем хэндлы стилей таблиц и
+            вычисляем хэндл владельца — сырые ACAD_TABLE ссылаются на них
+            (issue #1339). }
+          PreallocateTableStyleHandles;
           saveentitiesdxf2000(@{p}drawing.pObjRoot^.ObjArray,outstream,drawing,IODXFContext);
         end else if (groupi=2) and (values='BLOCKS') then begin
           outstream.TXTAddStringEOL(groups);
@@ -708,6 +749,14 @@ begin
               outstream.TXTAddStringEOL(dxfName_BLOCK_RECORD);
 
               IODXFContext.p2h.MyGetOrCreateValue(@(PBlockdefArray(drawing.BlockDefArray.parray)^[i]),IODXFContext.handle,temphandle);
+              { Запоминаем «имя блока -> новый хэндл BLOCK_RECORD», чтобы
+                переписать ссылку 343 сырой сущности ACAD_TABLE на её
+                анонимный блок (issue #1339). }
+              if not IODXFContext.BlockNameHandleMap.MyContans(
+                   PBlockdefArray(drawing.BlockDefArray.parray)^[i].Name) then
+                IODXFContext.BlockNameHandleMap.Add(
+                  PBlockdefArray(drawing.BlockDefArray.parray)^[i].Name,
+                  inttohex(temphandle,0));
               outstream.TXTAddStringEOL(dxfGroupCode(5));
               outstream.TXTAddStringEOL(inttohex(temphandle,0));
               outstream.TXTAddStringEOL(dxfGroupCode(100));
@@ -1242,17 +1291,13 @@ begin
             Предварительно выделяем хэндлы для всех стилей таблиц из чертежа,
             чтобы потом использовать их и в словаре, и в объектах TABLESTYLE. }
           inobjectssec:=True;
-          tsCount:=drawing.DXFTableStyleTable.count;
-          if tsCount>0 then begin
-            SetLength(tsHandles, tsCount);
-            for i:=0 to tsCount-1 do begin
-              tsHandles[i]:=IODXFContext.handle;
-              Inc(IODXFContext.handle);
-            end;
+          { Хэндлы стилей таблиц уже могли быть выделены перед секцией
+            ENTITIES (issue #1339). Вызов идемпотентен. }
+          PreallocateTableStyleHandles;
+          if tsCount>0 then
             programlog.LogOutFormatStr(
               'uzeffdxfout: выделены хэндлы для %d стилей таблиц',
               [tsCount], LM_Info);
-          end;
           outstream.TXTAddStringEOL(groups);
           outstream.TXTAddStringEOL(values);
         end else if inobjectssec and (groupi=3) and (values='ACAD_TABLESTYLE') then begin

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -105,6 +105,18 @@ type
     Header:TDXFHeaderInfo;
     LocalEntityFlags:TLocalEntityFlags;
 
+    { Карты ремаппинга хэндлов для сырых (raw) сущностей ACAD_TABLE
+      (issue #1339). При сохранении ACAD_TABLE пишется дословно, сохраняя
+      старые хэндлы исходного файла, тогда как весь остальной файл
+      перенумеровывается. Эти карты позволяют переписать ссылки сырой
+      сущности на актуальные новые хэндлы:
+        AcadTableOwnerHandle  — новый хэндл владельца (*Model_Space) для 330;
+        BlockNameHandleMap    — имя блока -> новый хэндл BLOCK_RECORD для 343;
+        TableStyleNameHandleMap — имя стиля таблицы -> новый хэндл для 342. }
+    AcadTableOwnerHandle:TDWGHandle;
+    BlockNameHandleMap:TString2StringDictionary;
+    TableStyleNameHandleMap:TString2StringDictionary;
+
     procedure InitRec;
     procedure Done;
   end;
@@ -364,12 +376,18 @@ begin
   VarsDict:=TString2StringDictionary.create;
   handle := $2;
 
+  AcadTableOwnerHandle:=0;
+  BlockNameHandleMap:=TString2StringDictionary.create;
+  TableStyleNameHandleMap:=TString2StringDictionary.create;
+
   Header.InitRec;
 end;
 procedure TIODXFSaveContext.Done;
 begin
   p2h.Free;
   VarsDict.Free;
+  BlockNameHandleMap.Free;
+  TableStyleNameHandleMap.Free;
 end;
 
 procedure TIODXFLoadContext.InitRec;

--- a/cad_source/zengine/tests/roundtrip1339.lpi
+++ b/cad_source/zengine/tests/roundtrip1339.lpi
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <SaveOnlyProjectUnits Value="True"/>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+        <SaveJumpHistory Value="False"/>
+        <SaveFoldState Value="False"/>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <i18n>
+      <EnableI18N LFM="False"/>
+    </i18n>
+    <MacroValues Count="1">
+      <Macro1 Name="LCLWidgetType" Value="nogui"/>
+    </MacroValues>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+      <SharedMatrixOptions Count="1">
+        <Item1 ID="480656748252" Modes="Default" Type="IDEMacro" MacroName="LCLWidgetType" Value="nogui"/>
+      </SharedMatrixOptions>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RunParams>
+      <local>
+        <CommandLineParams Value="--format=xml -a"/>
+      </local>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="--format=xml -a"/>
+          </local>
+        </Mode0>
+      </Modes>
+    </RunParams>
+    <RequiredPackages Count="11">
+      <Item1>
+        <PackageName Value="zunits"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="zreaders"/>
+      </Item2>
+      <Item3>
+        <PackageName Value="zmath"/>
+      </Item3>
+      <Item4>
+        <PackageName Value="zcontainers"/>
+      </Item4>
+      <Item5>
+        <PackageName Value="zbaseutils"/>
+      </Item5>
+      <Item6>
+        <PackageName Value="fpdwg"/>
+      </Item6>
+      <Item7>
+        <PackageName Value="zobjectinspector"/>
+      </Item7>
+      <Item8>
+        <PackageName Value="zscriptbase"/>
+      </Item8>
+      <Item9>
+        <PackageName Value="zbaseutilsgui"/>
+      </Item9>
+      <Item10>
+        <PackageName Value="LCL"/>
+      </Item10>
+      <Item11>
+        <PackageName Value="FCL"/>
+      </Item11>
+    </RequiredPackages>
+    <Units Count="1">
+      <Unit0>
+        <Filename Value="roundtrip1339.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="roundtrip1339"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir);.."/>
+      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../fileformats/dwg/entities;../../zcad;../../zcad/velec/acadtable;../misc;../core/entities;../core;../core/utils;../zgl/common;../zgl/gdi;../zgl/canvas;../zgl/opengl;../zgl/openglmodern;../zgl/dx;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
+    </SearchPaths>
+    <Parsing>
+      <SyntaxOptions>
+        <SyntaxMode Value="Delphi"/>
+        <AllowLabel Value="False"/>
+      </SyntaxOptions>
+    </Parsing>
+    <CodeGeneration>
+      <Checks>
+        <IOChecks Value="True"/>
+        <RangeChecks Value="False"/>
+        <OverflowChecks Value="False"/>
+        <StackChecks Value="True"/>
+      </Checks>
+      <VerifyObjMethodCallValidity Value="True"/>
+      <Optimizations>
+        <OptimizationLevel Value="0"/>
+      </Optimizations>
+    </CodeGeneration>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+        <UseHeaptrc Value="True"/>
+      </Debugging>
+    </Linking>
+    <Other>
+      <CustomOptions Value="-dDUnit -Cr- -CO- -Ct-"/>
+    </Other>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions Count="3">
+      <Item1>
+        <Name Value="EAbort"/>
+      </Item1>
+      <Item2>
+        <Name Value="ECodetoolError"/>
+      </Item2>
+      <Item3>
+        <Name Value="EFOpenError"/>
+      </Item3>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/cad_source/zengine/tests/roundtrip1339.lpr
+++ b/cad_source/zengine/tests/roundtrip1339.lpr
@@ -1,0 +1,56 @@
+program roundtrip1339;
+
+// issue #1339: загружает исходный DXF с ACAD_TABLE, сохраняет его через
+// штатный savedxf20XX (тот же путь, что и "Сохранить как" в ZCAD) и пишет
+// результат в файл. Затем внешний скрипт experiments/dxf_analyze.py
+// проверяет отсутствие висячих ссылок у сущности ACAD_TABLE.
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils, Classes, Interfaces,
+  uzeffdxf, uzeffdxfout, uzedrawingsimple, uzeffmanager,
+  uzgldrawcontext, uzeconsts, uzeTypes,
+  // Регистрация класса сущности ACAD_TABLE (как в тестовом наборе),
+  // иначе таблица грузится как generic/proxy и не сохраняется как ACAD_TABLE.
+  uzeenttable, uzeacadtable_types, uzeacadtable_model, uzeacadtable_dxf_write;
+
+function LoadDrawing(const AFileName: string; var ADrawing: TSimpleDrawing): Integer;
+var
+  DC: TDrawContext;
+  ZDC: TZDrawingContext;
+begin
+  ADrawing.init(nil);
+  DC := ADrawing.CreateDrawingRC;
+  ZDC.CreateRec(ADrawing, ADrawing.pObjRoot^, TLOLoad, DC);
+  AddFromDXF(AFileName, ZDC);
+  Result := ADrawing.pObjRoot^.ObjArray.Count;
+end;
+
+var
+  Drawing: TSimpleDrawing;
+  InFile, TemplateFile, OutFile: string;
+  Ok: Boolean;
+begin
+  if ParamCount < 3 then
+  begin
+    writeln('usage: roundtrip1339 <in.dxf> <template.dxf> <out.dxf>');
+    Halt(2);
+  end;
+  InFile := ParamStr(1);
+  TemplateFile := ParamStr(2);
+  OutFile := ParamStr(3);
+
+  writeln('loading: ', InFile);
+  LoadDrawing(InFile, Drawing);
+  writeln('saving:  ', OutFile, ' (template ', TemplateFile, ')');
+  Ok := savedxf20XX(OutFile, TemplateFile, Drawing, ZCDxf2007);
+  Drawing.done;
+  if Ok then
+    writeln('OK')
+  else
+  begin
+    writeln('SAVE FAILED');
+    Halt(1);
+  end;
+end.

--- a/cad_source/zengine/tests/testacadtable_standalone.lpi
+++ b/cad_source/zengine/tests/testacadtable_standalone.lpi
@@ -119,6 +119,9 @@
         <UseHeaptrc Value="True"/>
       </Debugging>
     </Linking>
+    <Other>
+      <CustomOptions Value="-dDUnit"/>
+    </Other>
   </CompilerOptions>
   <Debugging>
     <Exceptions Count="3">

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -33,6 +33,7 @@ uses
   uzegeometry,
   uzegeometrytypes,
   uzeentity,
+  uzesnap,
   UGDBSelectedObjArray,
   UGDBControlPointArray,
   uzglviewareadata,
@@ -64,6 +65,17 @@ type
     // issue #1317: сохранение AcadTable в DXF должно писать структурированные
     // ACAD_TABLE-сущности, включая части-продолжения разделённой таблицы.
     procedure SavesSplitAcadTableToStructuredDXF;
+    // issue #1339: при сохранении сырой (raw) ACAD_TABLE ссылки на хэндлы
+    // (330 владелец, 342 стиль таблицы, 343 анонимный блок) должны
+    // перенумеровываться под актуальный файл, а блок расширенного словаря
+    // (102/ACAD_XDICTIONARY) — удаляться, чтобы не оставлять висячих ссылок.
+    procedure RemapsRawAcadTableHandlesOnSave;
+    // issue #1339: сквозная проверка. Загружаем реальный файл с raw-таблицей,
+    // у которой имя стиля ещё не разрешено (BuildGeometry не выполнялся), и
+    // проверяем, что DXFOut сам разрешает имя стиля по хэндлу и перенумеровывает
+    // ссылку 342 на актуальный хэндл TABLESTYLE, а не оставляет старый хэндл,
+    // который после перенумерации указывал на чужой объект ("aits"/блок).
+    procedure ResolvesRawTableStyleNameAndRemaps342OnDXFOut;
     // issue #1305, часть 1: трансформация (перенос) должна перестраивать
     // визуальное представление таблицы.
     procedure TransformationMovesRenderedTable;
@@ -339,9 +351,9 @@ end;
 procedure CheckAcadTablePointEquals(
   const AExpected, AActual: TzePoint3d; const AMsg: String);
 begin
-  CheckEquals(AExpected.x, AActual.x, 1e-6, AMsg + ' (X)');
-  CheckEquals(AExpected.y, AActual.y, 1e-6, AMsg + ' (Y)');
-  CheckEquals(AExpected.z, AActual.z, 1e-6, AMsg + ' (Z)');
+  TAssert.CheckEquals(AExpected.x, AActual.x, 1e-6, AMsg + ' (X)');
+  TAssert.CheckEquals(AExpected.y, AActual.y, 1e-6, AMsg + ' (Y)');
+  TAssert.CheckEquals(AExpected.z, AActual.z, 1e-6, AMsg + ' (Z)');
 end;
 
 function CountDxfPairs(
@@ -998,6 +1010,154 @@ begin
       CountDxfPairs(
         DXFText, '102', 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY'),
       'Для разделённой таблицы должен сохраняться round-trip XRECORD');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1339. Сырая (raw) ACAD_TABLE из исходного файла сохраняла все
+// исходные хэндлы дословно. После перенумерации файла шаблоном это давало
+// 342 -> чужой стиль (грузился как "aits" вместо "Standard"), висячие 343/360
+// и неверного владельца 330. Проверяем, что при записи ссылки переписываются
+// под актуальную нумерацию, а блок расширенного словаря удаляется.
+procedure TAcadTableStyleTest.RemapsRawAcadTableHandlesOnSave;
+var
+  Raw: TStringList;
+  RawText, DXFText: String;
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  Ok: Boolean;
+begin
+  Raw := TStringList.Create;
+  try
+    Raw.Add('0');   Raw.Add('ACAD_TABLE');
+    Raw.Add('5');   Raw.Add('2FF');
+    Raw.Add('102'); Raw.Add('{ACAD_XDICTIONARY');
+    Raw.Add('360'); Raw.Add('357');
+    Raw.Add('102'); Raw.Add('}');
+    Raw.Add('330'); Raw.Add('1F');
+    Raw.Add('100'); Raw.Add('AcDbEntity');
+    Raw.Add('8');   Raw.Add('0');
+    Raw.Add('100'); Raw.Add('AcDbBlockReference');
+    Raw.Add('2');   Raw.Add('*T1');
+    Raw.Add('100'); Raw.Add('AcDbTable');
+    Raw.Add('342'); Raw.Add('87');
+    Raw.Add('343'); Raw.Add('ED');
+    Raw.Add('310'); Raw.Add('ABCDEF');
+    RawText := Raw.Text;
+  finally
+    Raw.Free;
+  end;
+
+  OutStream.init(8 * 1024);
+  SaveContext.InitRec;
+  SaveContext.Header.Version := AC1021;
+  SaveContext.Header.iVersion := 1021;
+  try
+    // Эмулируем состояние, которое savedxf20XX заполняет перед секцией
+    // ENTITIES: новый хэндл владельца и карты имя->новый хэндл.
+    SaveContext.AcadTableOwnerHandle := $123;
+    SaveContext.TableStyleNameHandleMap.Add('Standard', '4A2');
+    SaveContext.BlockNameHandleMap.Add('*T1', '5B3');
+
+    ResetAcadTableDXFWriteState;
+    Ok := WriteRawAcadTablePartsToDXF(
+      OutStream, SaveContext, RawText, [], 0.0, 0.0, 'Standard');
+    DXFText := DxfStreamToText(OutStream);
+  finally
+    ResetAcadTableDXFWriteState;
+    SaveContext.Done;
+    OutStream.done;
+  end;
+
+  CheckTrue(Ok, 'Сырая ACAD_TABLE должна успешно записаться');
+
+  // Висячий расширенный словарь должен быть удалён целиком.
+  CheckEquals(0, Pos('ACAD_XDICTIONARY', DXFText),
+    'Блок 102/ACAD_XDICTIONARY должен удаляться при сохранении');
+  CheckFalse(HasDxfSequence(DXFText, ['360', '357']),
+    'Висячая ссылка 360 на словарь не должна сохраняться');
+
+  // Собственный хэндл сущности (группа 5) не трогаем.
+  CheckTrue(HasDxfSequence(DXFText, ['5', '2FF']),
+    'Собственный хэндл сущности (группа 5) должен сохраняться без изменений');
+
+  // Ссылки перенумерованы под актуальный файл.
+  CheckTrue(HasDxfSequence(DXFText, ['330', '123']),
+    'Владелец (330) должен указывать на новый хэндл *Model_Space');
+  CheckTrue(HasDxfSequence(DXFText, ['342', '4A2']),
+    'Стиль таблицы (342) должен указывать на новый хэндл стиля');
+  CheckTrue(HasDxfSequence(DXFText, ['343', '5B3']),
+    'Анонимный блок (343) должен указывать на новый хэндл BLOCK_RECORD');
+
+  // Старые (исходные) хэндлы ссылок не должны протекать в новый файл.
+  CheckEquals(0, CountDxfPairs(DXFText, '330', '1F'),
+    'Старый владелец 1F не должен оставаться');
+  CheckEquals(0, CountDxfPairs(DXFText, '342', '87'),
+    'Старый хэндл стиля 87 (грузится как "aits") не должен оставаться');
+  CheckEquals(0, CountDxfPairs(DXFText, '343', 'ED'),
+    'Старый хэндл блока ED не должен оставаться');
+
+  // Бинарные данные ячеек должны сохраняться без изменений.
+  CheckTrue(HasDxfSequence(DXFText, ['310', 'ABCDEF']),
+    'Бинарные чанки ячеек (310) должны сохраняться');
+end;
+
+// issue #1339. Сквозная проверка корневой причины. В исходном файле таблица
+// ссылается на стиль "Standard" (342 -> хэндл 87). Загруженная raw-таблица не
+// разрешает имя стиля до BuildGeometry, поэтому FTableStyle.Name пуст. При
+// пакетном "Сохранить как" (без отрисовки) DXFOut обязан сам разрешить имя
+// стиля по хэндлу и перенумеровать 342 на актуальный хэндл TABLESTYLE. Раньше
+// 342 оставался равен 87, который после перенумерации указывал на чужой объект
+// (стиль грузился как "aits"). Проверяем имя стиля и перенумерацию 342.
+procedure TAcadTableStyleTest.ResolvesRawTableStyleNameAndRemaps342OnDXFOut;
+const
+  StandardHandle = 'B8';
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  DXFText: String;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/acadtablerazdel2007_1.dxf'),
+    Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    OutStream.init(64 * 1024);
+    SaveContext.InitRec;
+    SaveContext.Header.Version := AC1021;
+    SaveContext.Header.iVersion := 1021;
+    try
+      // Эмулируем состояние, которое savedxf20XX (PreallocateTableStyleHandles)
+      // заполняет перед секцией ENTITIES: владелец и карты имя->новый хэндл.
+      SaveContext.AcadTableOwnerHandle := $1F;
+      SaveContext.TableStyleNameHandleMap.Add('Standard', StandardHandle);
+      SaveContext.BlockNameHandleMap.Add('*T1', 'A1');
+
+      ResetAcadTableDXFWriteState;
+      AcadTable^.DXFOut(OutStream, Drawing, SaveContext);
+      DXFText := DxfStreamToText(OutStream);
+    finally
+      ResetAcadTableDXFWriteState;
+      SaveContext.Done;
+      OutStream.done;
+    end;
+
+    // DXFOut должен был разрешить имя стиля по хэндлу 87 -> "Standard".
+    CheckEquals('Standard', AcadTable^.TableStyleName,
+      'Имя стиля raw-таблицы должно разрешаться по хэндлу при сохранении');
+
+    // Ссылка 342 должна указывать на актуальный хэндл TABLESTYLE.
+    CheckTrue(HasDxfSequence(DXFText, ['342', StandardHandle]),
+      'Стиль таблицы (342) должен перенумеровываться на хэндл стиля "Standard"');
+
+    // Старый хэндл стиля 87 (после перенумерации — чужой объект) не должен течь.
+    CheckEquals(0, CountDxfPairs(DXFText, '342', '87'),
+      'Старый хэндл стиля 87 не должен оставаться в сохранённой таблице');
   finally
     Drawing.done;
   end;

--- a/experiments/dxf_analyze.py
+++ b/experiments/dxf_analyze.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Analyze a DXF file: list all object handles (group 5/105), all handle
+references, detect collisions (duplicate handles) and dangling references.
+
+Usage: dxf_analyze.py <file.dxf>
+"""
+import sys
+from collections import defaultdict
+
+# Group codes that DEFINE an object's handle
+HANDLE_DEF_CODES = {5, 105}
+# Group codes that REFERENCE a handle (pointers/owners/soft/hard)
+REF_CODES = {320, 330, 340, 342, 343, 344, 345, 346, 347, 348, 349, 350,
+             360, 361, 390, 391, 480, 481, 1005}
+
+
+def parse(path):
+    pairs = []
+    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+        lines = f.read().split('\n')
+    i = 0
+    while i + 1 < len(lines):
+        code = lines[i].strip()
+        val = lines[i + 1]
+        i += 2
+        try:
+            code = int(code)
+        except ValueError:
+            continue
+        pairs.append((code, val.strip()))
+    return pairs
+
+
+def section_of(pairs):
+    """Yield (code, val, section, entity_type) with current section/entity."""
+    section = None
+    entity = None
+    for idx, (code, val) in enumerate(pairs):
+        if code == 0 and val == 'SECTION':
+            section = None
+        elif code == 2 and section is None:
+            section = val
+        if code == 0:
+            entity = val
+        yield idx, code, val, section, entity
+
+
+def main():
+    path = sys.argv[1]
+    pairs = parse(path)
+    handle_defs = defaultdict(list)   # handle -> [(section, entity)]
+    refs = []                          # (handle, code, section, entity)
+    cur_section = None
+    cur_entity = None
+    cur_sec_name_pending = False
+    for idx, (code, val) in enumerate(pairs):
+        if code == 0 and val == 'SECTION':
+            cur_section = '?'
+            cur_sec_name_pending = True
+            continue
+        if cur_sec_name_pending and code == 2:
+            cur_section = val
+            cur_sec_name_pending = False
+        if code == 0:
+            cur_entity = val
+        if code in HANDLE_DEF_CODES:
+            h = val.upper().lstrip('0') or '0'
+            handle_defs[h].append((cur_section, cur_entity))
+        elif code in REF_CODES:
+            v = val.strip()
+            if v and v not in ('{', '}'):
+                h = v.upper().lstrip('0') or '0'
+                refs.append((h, code, cur_section, cur_entity))
+
+    print(f"=== {path} ===")
+    print(f"Total handle definitions: {sum(len(v) for v in handle_defs.values())}")
+    print(f"Unique handles: {len(handle_defs)}")
+
+    # collisions
+    collisions = {h: v for h, v in handle_defs.items() if len(v) > 1}
+    print(f"\n--- COLLISIONS (duplicate handle defs): {len(collisions)} ---")
+    for h, v in sorted(collisions.items()):
+        print(f"  handle {h}: {v}")
+
+    # dangling refs
+    defined = set(handle_defs.keys())
+    dangling = defaultdict(list)
+    for h, code, section, entity in refs:
+        if h == '0':
+            continue
+        if h not in defined:
+            dangling[h].append((code, section, entity))
+    print(f"\n--- DANGLING REFERENCES (ref to undefined handle): {len(dangling)} ---")
+    for h, v in sorted(dangling.items()):
+        print(f"  ref->{h}: {v}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Issue

Fixes veb86/zcadvelecAI#1339.

After opening `cad_source/test/acadtablerazdel2007_1.dxf` and immediately doing
**Save As** `zcadtablerazdel2007_1.dxf`, then reopening the result:

- the table geometry is intact, but the **table style loads incorrectly** — it
  was saved as `Standard` yet loads as `aits`;
- opening the saved file **in AutoCAD shows an empty drawing**.

## Root cause

`ACAD_TABLE` entities loaded through the raw round-trip path (issue #1317) were
written back **verbatim, keeping all of their original handles**. The
template-merge save then renumbers every handle in the file, so the verbatim
references no longer matched:

- **342** (table style) kept the old handle `87`, which after renumbering
  belonged to an unrelated `BLOCK`, so on reload the style fell back to the
  first one in the table (`aits`) instead of `Standard`;
- **343** (anonymous block) and **330** (owner) pointed at stale handles;
- a `102/ACAD_XDICTIONARY` block referenced an extension dictionary (`360`) that
  is **not** round-tripped, leaving a dangling reference. AutoCAD treats such a
  dangling hard reference as a corrupt file and opens an empty drawing.

The `TABLESTYLE` objects in the `OBJECTS` section had the same flaw: their
`ACAD_XDICTIONARY` block (`360`) pointed at xdict handles that were never
written.

## Fix

- `TIODXFSaveContext` now carries the renumbered model-space owner handle plus
  name→handle maps for table styles and block records.
- `savedxf20XX` **preallocates table-style handles** and computes the owner
  handle **before** the `ENTITIES` section (`PreallocateTableStyleHandles`,
  idempotent — also reused by the `OBJECTS` section), and records block-record
  handles by name.
- `WriteRawEntityText` rewrites `330`/`342`/`343` to the renumbered handles
  (342 by style **name**, 343 by block **name**) and strips the dangling
  `102/ACAD_XDICTIONARY` block. The entity's own handle (group 5) is preserved.
- `GDBObjAcadTable.DXFOut` resolves the table-style **name** by handle before
  saving when geometry was not built yet (e.g. batch *Save As* without a render),
  so 342 can be remapped.
- `WriteTableStyleObjectToStream` no longer emits the `ACAD_XDICTIONARY` block
  whose target object is not written.

## Reproduction & verification

`experiments/dxf_analyze.py` reports handle collisions and dangling references.
Running it on the previously-broken output vs. the new output:

| | broken `zcadtablerazdel2007_1.dxf` (in repo) | after this PR |
|---|---|---|
| handle collisions | 0 | 0 |
| **dangling references** | **6** (`360→201/203/205` in TABLESTYLE, `343→2B8/ED` + `360→357` in ACAD_TABLE) | **0** |
| `ACAD_TABLE` 342 → | renumbered block (loads as `aits`) | `Standard` TABLESTYLE |

End-to-end harness `cad_source/zengine/tests/roundtrip1339` loads the real file
and saves it through `savedxf20XX` (the same path as *Save As*); the output has
0 dangling references and 342 resolves to the `Standard` TABLESTYLE.

## Tests

Added to the FPCUnit suite (`cad_source/zengine/tests`, run via
`testacadtable_standalone`):

- `RemapsRawAcadTableHandlesOnSave` — write-side remap of 330/342/343 and removal
  of the dangling `102/ACAD_XDICTIONARY` block for a synthetic raw entity.
- `ResolvesRawTableStyleNameAndRemaps342OnDXFOut` — loads the real
  `acadtablerazdel2007_1.dxf`, exercises `DXFOut`, and asserts the style name
  resolves by handle and 342 is remapped to the `TABLESTYLE` handle (not the
  stale handle `87` that used to load as `aits`).

Suite result: 32 tests, 0 errors, 2 pre-existing failures unrelated to this
change (`LoadsIssue1334BreakTableAsSingleMergedObject`,
`DraggingContinuationBreakHeightGripResegmentsPart`).
