### PR TITLE
AcadTable: корректный round-trip разделённых таблиц — флаги BreakOption (#1339)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-19T09:57:13.246Z for PR creation at branch issue-1339-48a63bf6a565 for issue https://github.com/veb86/zcadvelecAI/issues/1339

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-19T09:57:13.246Z for PR creation at branch issue-1339-48a63bf6a565 for issue https://github.com/veb86/zcadvelecAI/issues/1339

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -91,6 +91,7 @@ function WriteRawAcadTablePartsToDXF(
   const AMainRawEntity: String;
   const AContinuationRawEntities: array of String;
   ABreakSpacing, ABreakHeight: Double;
+  ABreakManualPosition, ABreakManualHeight: Boolean;
   const ATableStyleName: String): Boolean;
 
 procedure WriteAcadTableRoundTripObjectsToDXF(
@@ -109,6 +110,12 @@ type
     ContinuationHandles: array of TDWGHandle;
     BreakSpacing: Double;
     BreakHeight: Double;
+    { Признаки ручного управления разрывами (issue #1339). Влияют на
+      BreakOption-флаг (первая группа 90) в ACAD_ROUNDTRIP_2008_TABLE_ENTITY:
+        8  (AllowManualPositions) <- BreakManualPosition,
+        16 (AllowManualHeights)   <- BreakManualHeight. }
+    BreakManualPosition: Boolean;
+    BreakManualHeight: Boolean;
   end;
 
 var
@@ -409,7 +416,8 @@ end;
 procedure AddRoundTripRecord(
   AMainHandle: TDWGHandle;
   const AContinuationHandles: array of TDWGHandle;
-  ABreakSpacing, ABreakHeight: Double);
+  ABreakSpacing, ABreakHeight: Double;
+  ABreakManualPosition, ABreakManualHeight: Boolean);
 var
   RecIdx, HandleIdx: Integer;
 begin
@@ -421,6 +429,8 @@ begin
   RoundTripRecords[RecIdx].MainHandle := AMainHandle;
   RoundTripRecords[RecIdx].BreakSpacing := ABreakSpacing;
   RoundTripRecords[RecIdx].BreakHeight := ABreakHeight;
+  RoundTripRecords[RecIdx].BreakManualPosition := ABreakManualPosition;
+  RoundTripRecords[RecIdx].BreakManualHeight := ABreakManualHeight;
   System.SetLength(
     RoundTripRecords[RecIdx].ContinuationHandles,
     Length(AContinuationHandles));
@@ -620,7 +630,8 @@ begin
   end;
 
   AddRoundTripRecord(MainHandle, ContinuationHandles,
-    AMainPart.BreakSpacing, AMainPart.BreakHeight);
+    AMainPart.BreakSpacing, AMainPart.BreakHeight,
+    AMainPart.BreakManualPosition, AMainPart.BreakManualHeight);
 end;
 
 function WriteRawAcadTablePartsToDXF(
@@ -629,6 +640,7 @@ function WriteRawAcadTablePartsToDXF(
   const AMainRawEntity: String;
   const AContinuationRawEntities: array of String;
   ABreakSpacing, ABreakHeight: Double;
+  ABreakManualPosition, ABreakManualHeight: Boolean;
   const ATableStyleName: String): Boolean;
 var
   MainHandle: TDWGHandle;
@@ -659,7 +671,8 @@ begin
   end;
 
   AddRoundTripRecord(MainHandle, ContinuationHandles,
-    ABreakSpacing, ABreakHeight);
+    ABreakSpacing, ABreakHeight,
+    ABreakManualPosition, ABreakManualHeight);
   Result := True;
 end;
 
@@ -667,11 +680,26 @@ procedure WriteRoundTripRecordToDXF(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
   const ARecord: TAcadTableRoundTripRecord);
+const
+  { Базовые биты BreakOption: EnableBreaks(1) + RepeatTopLabels(2) = 3. }
+  cTableBreakBaseFlags = 3;
+  cTableBreakAllowManualPositions = 8;
+  cTableBreakAllowManualHeights = 16;
 var
   ObjectHandle: TDWGHandle;
   HandleIdx: Integer;
+  BreakOptionFlags: Integer;
 begin
   ObjectHandle := NextAnonymousHandle(AIODXFContext);
+
+  { Восстанавливаем BreakOption-флаг из признаков ручного управления
+    разрывами (issue #1339). Раньше здесь была жёстко зашита 3, из-за чего
+    при пересохранении терялись AllowManualPositions/AllowManualHeights. }
+  BreakOptionFlags := cTableBreakBaseFlags;
+  if ARecord.BreakManualPosition then
+    BreakOptionFlags := BreakOptionFlags or cTableBreakAllowManualPositions;
+  if ARecord.BreakManualHeight then
+    BreakOptionFlags := BreakOptionFlags or cTableBreakAllowManualHeights;
 
   dxfStringWithoutEncodeOut(AOutStream, 0, 'XRECORD');
   dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(ObjectHandle, 0));
@@ -683,7 +711,7 @@ begin
   dxfStringWithoutEncodeOut(AOutStream, 360,
     IntToHex(ARecord.MainHandle, 0));
   dxfIntegerout(AOutStream, 70, 1);
-  dxfIntegerout(AOutStream, 90, 3);
+  dxfIntegerout(AOutStream, 90, BreakOptionFlags);
   dxfIntegerout(AOutStream, 90, 1);
   dxfDoubleout(AOutStream, 40, ARecord.BreakSpacing);
   dxfIntegerout(AOutStream, 90, 2);

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -128,6 +128,11 @@ type
     FBreakManualPosition: Boolean;
     FBreakManualPositionExplicit: Boolean;
     FBreakManualHeight: Boolean;
+    // True, когда признаки ручного позиционирования/высоты заданы явно
+    // из roundtrip-данных DXF (BreakOption, issue #1339). В этом случае
+    // эвристики DetectBreakManualPosition/DetectBreakManualHeight не должны
+    // переопределять значения, полученные из файла.
+    FBreakFlagsKnown: Boolean;
     FBreakSpacing: Double;
     // Высота разбиения (break height): после какой суммарной высоты строк
     // строки начинают переноситься в следующую часть разделённой таблицы.
@@ -331,6 +336,11 @@ type
     // (issue #1307). Возвращает True.
     function SetTableBreakData(
       ASpacing, ABreakHeight: Double): Boolean; virtual;
+    // Задаёт явные признаки ручного позиционирования/высоты разбиения,
+    // прочитанные из BreakOption (XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY,
+    // issue #1339). Имеют приоритет над эвристиками Detect*.
+    procedure SetBreakOptionFlags(
+      AManualPosition, AManualHeight: Boolean); virtual;
     function SetTableStyleName(
       const AValue: String; var ADrawing: TDrawingDef): Boolean; virtual;
     procedure SetDXFRawEntityText(const ARawText: string); virtual;
@@ -526,6 +536,7 @@ begin
   FBreakManualPosition := False;
   FBreakManualPositionExplicit := False;
   FBreakManualHeight := False;
+  FBreakFlagsKnown := False;
   FBreakSpacing := 0;
   FBreakHeight := 0;
   // Трансформация по умолчанию: единичный масштаб, без поворота (issue #1305)
@@ -2115,6 +2126,9 @@ var
   PartIdx: Integer;
   ManualPosition: Boolean;
 begin
+  { Явные флаги из roundtrip-данных DXF приоритетнее эвристики (issue #1339). }
+  if FBreakFlagsKnown then
+    Exit;
   if Length(FContinuationParts) = 0 then
     Exit;
 
@@ -2133,6 +2147,9 @@ var
   ReferenceHeight, PartHeight: Double;
   HasReference, ManualHeight: Boolean;
 begin
+  { Явные флаги из roundtrip-данных DXF приоритетнее эвристики (issue #1339). }
+  if FBreakFlagsKnown then
+    Exit;
   ManualHeight := FBreakManualHeight;
   HasReference := False;
   ReferenceHeight := 0;
@@ -2667,6 +2684,20 @@ begin
     [FBreakSpacing, FBreakHeight, Ord(FBreakManualPosition),
      Ord(FBreakManualHeight)], LM_Info);
   Result := True;
+end;
+
+procedure GDBObjAcadTable.SetBreakOptionFlags(
+  AManualPosition, AManualHeight: Boolean);
+begin
+  FBreakFlagsKnown := True;
+  FBreakManualPositionExplicit := AManualPosition;
+  FBreakManualPosition := AManualPosition;
+  FBreakManualHeight := AManualHeight;
+  SetBreakManualPositionForParts(AManualPosition);
+  SetBreakManualHeightForParts(AManualHeight);
+  programlog.LogOutFormatStr(
+    'AcadTable: model: SetBreakOptionFlags manualpos=%d manualheight=%d',
+    [Ord(FBreakManualPosition), Ord(FBreakManualHeight)], LM_Info);
 end;
 
 procedure GDBObjAcadTable.SetDXFRawEntityText(const ARawText: string);
@@ -3211,9 +3242,14 @@ begin
     System.SetLength(RawParts, Length(FContinuationParts));
     for PartIdx := 0 to High(FContinuationParts) do
       RawParts[PartIdx] := FContinuationParts[PartIdx].RawDXFEntity;
+    // Признаки ручного управления разрывами должны попасть в roundtrip-запись
+    // (issue #1339), иначе при пересохранении BreakOption теряет манульные биты.
+    DetectBreakManualPosition;
+    DetectBreakManualHeight;
     if uzeacadtable_dxf_write.WriteRawAcadTablePartsToDXF(
       AOutStream, AIODXFContext, FRawDXFEntity, RawParts,
-      FBreakSpacing, FBreakHeight, Self.TableStyleName) then
+      FBreakSpacing, FBreakHeight,
+      FBreakManualPosition, FBreakManualHeight, Self.TableStyleName) then
       Exit;
   end;
 

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -357,18 +357,33 @@ end;
   (issue #1307).
 
   ASpacing/ABreakHeight получают найденные значения, AValid=True,
-  если в блоке найдено хотя бы две группы 40. }
+  если в блоке найдено хотя бы две группы 40.
+
+  Дополнительно из первой группы 90 (BreakOption) извлекаются признаки
+  ручного позиционирования (бит 8) и ручной высоты разбиения (бит 16).
+  AManualPosition/AManualHeight получают эти значения, AFlagsValid=True,
+  если группа 90 найдена (issue #1339). Эвристика по геометрии частей
+  ненадёжна (для acadtablerazdel2007_1 ложно даёт ManualHeight=true),
+  поэтому явные флаги из roundtrip-данных имеют приоритет. }
+const
+  cTableBreakAllowManualPositions = 8;
+  cTableBreakAllowManualHeights   = 16;
+
 procedure ScanTableBreakData(const RawObjectsSection: string;
-  out ASpacing, ABreakHeight: Double; out AValid: Boolean);
+  out ASpacing, ABreakHeight: Double; out AValid: Boolean;
+  out AManualPosition, AManualHeight, AFlagsValid: Boolean);
 var
   Lines: TStringList;
-  I, J, Code, BlockCode, Found: Integer;
+  I, J, Code, BlockCode, Found, Found90, Flags: Integer;
   Value, BlockValue: string;
   V: Extended;
 begin
   ASpacing := 0;
   ABreakHeight := 0;
   AValid := False;
+  AManualPosition := False;
+  AManualHeight := False;
+  AFlagsValid := False;
   if RawObjectsSection = '' then
     Exit;
 
@@ -382,6 +397,7 @@ begin
          (Code = 102) and IsAcadTableRoundtripMarker(Value) then
       begin
         Found := 0;
+        Found90 := 0;
         J := I + 2;
         while J < Lines.Count - 1 do
         begin
@@ -389,6 +405,17 @@ begin
           begin
             if (BlockCode = 0) or (BlockCode = 361) then
               Break
+            else if (BlockCode = 90) and (Found90 = 0) then
+            begin
+              { Первая группа 90 — флаги BreakOption. }
+              Flags := StrToIntDef(Trim(BlockValue), 0);
+              AManualPosition :=
+                (Flags and cTableBreakAllowManualPositions) <> 0;
+              AManualHeight :=
+                (Flags and cTableBreakAllowManualHeights) <> 0;
+              AFlagsValid := True;
+              Inc(Found90);
+            end
             else if (BlockCode = 40) and (Found < 2) then
             begin
               { DXF использует точку как десятичный разделитель }
@@ -417,10 +444,12 @@ begin
       Inc(I);
     end;
 
-    if AValid then
+    if AValid or AFlagsValid then
       programlog.LogOutFormatStr(
-        'uzeffdxf: ScanTableBreakData: spacing=%g breakheight=%g',
-        [ASpacing, ABreakHeight], LM_Info);
+        'uzeffdxf: ScanTableBreakData: spacing=%g breakheight=%g ' +
+        'manualPos=%d manualHeight=%d flagsValid=%d',
+        [ASpacing, ABreakHeight, Ord(AManualPosition),
+         Ord(AManualHeight), Ord(AFlagsValid)], LM_Info);
   finally
     Lines.Free;
   end;
@@ -800,6 +829,13 @@ begin
           if context.TableBreakDataValid then
             pLastMainTable^.SetTableBreakData(
               context.TableBreakSpacing, context.TableBreakHeight);
+          { Явные флаги ручного позиционирования/высоты из roundtrip-данных
+            имеют приоритет над эвристикой по геометрии частей (issue #1339).
+            Вызывается после SetTableBreakData, т.к. тот запускает эвристику. }
+          if context.TableBreakFlagsValid then
+            pLastMainTable^.SetBreakOptionFlags(
+              context.TableBreakManualPosition,
+              context.TableBreakManualHeight);
         end;
         if not(IsObjectIt(TypeOf(owner^),TypeOf(GDBObjBlockdef))) then begin
           if PGDBObjEntity(pobj)^.DXFDelayedBuildGeometry then begin
@@ -1750,7 +1786,10 @@ begin
           dwgCtx.PDrawing^.RawObjectsSection,
           fileCtx.TableBreakSpacing,
           fileCtx.TableBreakHeight,
-          fileCtx.TableBreakDataValid);
+          fileCtx.TableBreakDataValid,
+          fileCtx.TableBreakManualPosition,
+          fileCtx.TableBreakManualHeight,
+          fileCtx.TableBreakFlagsValid);
 
         lph:=lps.StartLongProcess(rsLoadDXFFile,@rdr,rdr.Size,LPSOSilent);
         case fileCtx.Header.Version of

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -161,6 +161,15 @@ type
     TableBreakHeight:double;
     TableBreakDataValid:boolean;
 
+    { Флаг BreakOption из того же XRECORD (первая группа 90). Биты:
+      8  (AllowManualPositions) -> AcadTableBreakManualPosition,
+      16 (AllowManualHeights)   -> AcadTableBreakManualHeight.
+      Эти признаки нельзя надёжно вычислить эвристикой по геометрии частей
+      (issue #1339), поэтому читаем их явно из roundtrip-данных. }
+    TableBreakManualPosition:boolean;
+    TableBreakManualHeight:boolean;
+    TableBreakFlagsValid:boolean;
+
     procedure InitRec;
     procedure Done;
   end;
@@ -412,6 +421,9 @@ begin
   TableBreakSpacing:=0;
   TableBreakHeight:=0;
   TableBreakDataValid:=False;
+  TableBreakManualPosition:=False;
+  TableBreakManualHeight:=False;
+  TableBreakFlagsValid:=False;
 end;
 
 procedure TDXFHeaderInfo.InitRec;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -1062,7 +1062,7 @@ begin
 
     ResetAcadTableDXFWriteState;
     Ok := WriteRawAcadTablePartsToDXF(
-      OutStream, SaveContext, RawText, [], 0.0, 0.0, 'Standard');
+      OutStream, SaveContext, RawText, [], 0.0, 0.0, False, False, 'Standard');
     DXFText := DxfStreamToText(OutStream);
   finally
     ResetAcadTableDXFWriteState;

--- a/experiments/issue1339_breakflags.py
+++ b/experiments/issue1339_breakflags.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Issue #1339 — verify decoding of the AcDbTableBreakData "BreakOption" flag
+stored in the ACAD_ROUNDTRIP_2008_TABLE_ENTITY XRECORD.
+
+Hypothesis (confirmed empirically below):
+  flag bit 3 (value 8)  = AllowManualPositions  -> AcadTableBreakManualPosition
+  flag bit 4 (value 16) = AllowManualHeights    -> AcadTableBreakManualHeight
+
+The flag is the FIRST group-90 value inside the roundtrip block (after the
+group 70). The first group-40 is the break spacing; the second group-40 is the
+first break-range height.
+"""
+import sys, os
+
+EXPECTED = {
+    1: dict(manual_pos=False, manual_h=False),
+    2: dict(manual_pos=True,  manual_h=False),
+    3: dict(manual_pos=True,  manual_h=True),
+    4: dict(manual_pos=False, manual_h=True),
+}
+
+def read_pairs(path):
+    with open(path, 'r', errors='replace') as f:
+        lines = [l.rstrip('\n').rstrip('\r') for l in f]
+    i = 0
+    while i + 1 < len(lines):
+        yield lines[i].strip(), lines[i+1]
+        i += 2
+
+def scan_break(path):
+    """Return (flags, spacing, breakheight) parsed from the roundtrip xrecord."""
+    pairs = list(read_pairs(path))
+    in_block = False
+    flags = None
+    spacing = None
+    breakheight = None
+    found40 = 0
+    found90 = 0
+    for code, value in pairs:
+        if code == '102' and value.strip() == 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY':
+            in_block = True
+            continue
+        if in_block:
+            if code in ('0', '361'):
+                break
+            if code == '90':
+                found90 += 1
+                if found90 == 1:
+                    flags = int(value.strip())
+            elif code == '40':
+                v = float(value.strip())
+                if found40 == 0:
+                    spacing = v
+                elif found40 == 1:
+                    breakheight = v
+                found40 += 1
+    return flags, spacing, breakheight
+
+def main():
+    base = os.path.join(os.path.dirname(__file__), '..', 'cad_source', 'test')
+    ok = True
+    for n in (1, 2, 3, 4):
+        path = os.path.join(base, f'acadtablerazdel2007_{n}.dxf')
+        flags, spacing, bh = scan_break(path)
+        manual_pos = bool(flags & 8)
+        manual_h = bool(flags & 16)
+        exp = EXPECTED[n]
+        good = (manual_pos == exp['manual_pos'] and manual_h == exp['manual_h'])
+        ok = ok and good
+        print(f"file {n}: flags={flags} (bin {flags:05b}) spacing={spacing} bh={bh} "
+              f"-> manualPos={manual_pos} manualHeight={manual_h} "
+              f"{'OK' if good else 'MISMATCH exp='+str(exp)}")
+    print("ALL OK" if ok else "FAILURES")
+    sys.exit(0 if ok else 1)
+
+if __name__ == '__main__':
+    main()

--- a/experiments/issue1339_bug2_analysis.md
+++ b/experiments/issue1339_bug2_analysis.md
@@ -1,0 +1,86 @@
+# Issue #1339 — Bug 2 root cause: table cell text invisible in AutoCAD until regen
+
+## Symptom (reported)
+After ZCAD re-saves a split (`AcadTableBreakEnabled=true`) ACAD_TABLE and the
+file is reopened in AutoCAD, the table grid draws correctly but **cell text is
+not displayed**. Any transform (move / rotate / scale) forces a regen and the
+text appears immediately. So the data loads, but the initial display is empty.
+
+## Empirically confirmed root cause
+Comparing the AutoCAD-saved originals against the ZCAD re-saved files (all
+present in `cad_source/test/`, `acadtablerazdel2007_N.dxf` vs
+`zcadtablerazdel2007_N.dxf`):
+
+| object        | AutoCAD original | ZCAD re-saved |
+|---------------|------------------|---------------|
+| `TABLECONTENT`| 1                | **0 (dropped)** |
+| `TABLEGEOMETRY`| 1               | **0 (dropped)** |
+| `XRECORD`     | 3                | 1             |
+| `DICTIONARY`  | 17               | 10            |
+| `MTEXT`       | 55               | 55 (kept)     |
+
+ZCAD drops the ACAD_TABLE entity's **extension-dictionary content subtree**:
+
+```
+ACAD_TABLE (entity, handle EB)
+  └─ 360 xdict ─▶ DICTIONARY (357)
+                    └─ ACAD_XREC_ROUNDTRIP ─▶ XRECORD (358)
+                                                └─ TABLECONTENT (2B5)   ← AcDbTableContent: the cell data AutoCAD renders
+                    (and)                       TABLEGEOMETRY (2B6)      ← AcDbTableGeometry: cached cell geometry
+```
+
+AutoCAD 2010+ renders table cell content from `AcDbTableContent`. With that
+object missing, AutoCAD has the grid (from the entity / anonymous block) but no
+content object to render text from on initial open; a regen rebuilds the
+display and the text appears. This matches the reported symptom exactly.
+
+`uzeacadtable_dxf_write.WriteRawEntityText` currently **deletes** the entity's
+`{ACAD_XDICTIONARY ... 360 ... }` block on save (see comment at the proc:
+"блок расширенного словаря ... удаляется ... иначе оставляет висячую ссылку"),
+precisely because the subtree it points to is not round-tripped. Fixing Bug 2
+means round-tripping that subtree instead of dropping it.
+
+Reproduce: `python3 experiments/issue1339_bug2_subtree.py` (asserts the
+AutoCAD files contain the subtree and the ZCAD files currently drop it).
+
+## Scope of the subtree (measured on `acadtablerazdel2007_1.dxf`)
+- 4 objects: `DICTIONARY(357)`, `XRECORD(358)`, `TABLECONTENT(2B5, ~7117 groups)`,
+  `TABLEGEOMETRY(2B6, ~806 groups)`.
+- **No binary (group 310) data** anywhere in the subtree — pure text DXF.
+- External handle references that must be remapped on save:
+
+| code | target | meaning | count | remap on save |
+|------|--------|---------|-------|---------------|
+| 330  | EB / 2B7 / 307 | owner backptrs to the 3 ACAD_TABLE entities | 3 | **identity** — ZCAD already preserves these entity handles |
+| 340  | 11 | text `STYLE "Standard"` | 5 | new text-style handle (ZCAD renumbers styles) |
+| 340  | 87 | `TABLESTYLE "Standard"` | 1 | new table-style handle (`TableStyleNameHandleMap` already exists) |
+
+- Internal handles `357 / 358 / 2B5 / 2B6` and the entity's `360` link must be
+  remapped consistently to fresh anonymous handles (or preserved if collision
+  with ZCAD's renumbering is provably avoided).
+
+## Proposed fix (needs compile + AutoCAD verification — see PR request)
+1. **Read** (`uzeffdxf` / model): capture the subtree text for each ACAD_TABLE
+   from `RawObjectsSection` by following the entity's `360` xdict, store it on
+   `GDBObjAcadTable` (e.g. `FRawExtDictSubtree` + original xdict handle).
+2. **Save context** (`uzeffdxfsupport` / `uzeffdxfout`): add a text-style
+   *name→new-handle* map, populated the same way
+   `PreallocateTableStyleHandles` populates `TableStyleNameHandleMap`.
+3. **Write** (`uzeacadtable_dxf_write`):
+   - In `WriteRawEntityText`, **keep** the `360` xdict and remap it to the new
+     `DICTIONARY` handle (instead of deleting the block).
+   - In `WriteAcadTableRoundTripObjectsToDXF`, after the roundtrip XRECORD,
+     emit the captured subtree with all handles remapped:
+     internal `357/358/2B5/2B6` → fresh; `340→11` → new text-style handle;
+     `340→87` → `TableStyleNameHandleMap["Standard"]`; `330→EB/2B7/307`
+     identity.
+   - **Fail-safe:** only emit (and keep the entity's `360`) when capture
+     succeeded *and* every required style handle resolves; otherwise fall back
+     to today's drop behavior so the result is never worse than current.
+
+## Why this is being requested rather than committed blind
+No FPC/Lazarus compiler is available in this environment and AutoCAD cannot be
+run here, so a handle-remapping mistake in the ~8000-group subtree would
+produce a file that looks plausible but is silently broken, with no way to
+detect it locally. The diagnosis above is verified against real files; the
+implementation needs a build + an AutoCAD open-test to confirm.

--- a/experiments/issue1339_bug2_subtree.py
+++ b/experiments/issue1339_bug2_subtree.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Issue #1339 (Bug 2) — prove the cause of "table text invisible in AutoCAD
+until a transform forces a regen".
+
+We compare the original AutoCAD-saved DXF against the ZCAD re-saved DXF
+(both present in cad_source/test/) and show that ZCAD drops the table's
+extension-dictionary content subtree:
+
+    ACAD_TABLE (entity, handle EB)
+      └─ 360 xdict ─▶ DICTIONARY (357)
+                        └─ ACAD_XREC_ROUNDTRIP ─▶ XRECORD (358)
+                                                    └─ TABLECONTENT (2B5)   <- cell data AutoCAD renders
+                        (and)                       TABLEGEOMETRY (2B6)      <- cached geometry
+
+AutoCAD 2010+ renders table cell text from the AcDbTableContent object. When
+it is missing, AutoCAD draws the grid but no text until a regen (triggered by
+move/rotate/scale) rebuilds the display — exactly the reported symptom.
+
+The subtree carries NO binary (group 310) data and only three kinds of
+external handle references:
+  * 330 -> ACAD_TABLE entities (handles ZCAD already preserves: EB/2B7/307)
+  * 340 -> text STYLE  "Standard"   (renumbered by ZCAD on save)
+  * 340 -> TABLESTYLE  "Standard"   (renumbered by ZCAD on save)
+so preserving it through round-trip is a bounded, well-specified change.
+
+This script asserts the *current* (buggy) state: the AutoCAD file has the
+subtree, the ZCAD file does not. Once the fix lands and a real ZCAD build
+re-saves the file, re-running this against the new output should show the
+subtree preserved (flip EXPECT_PRESERVED to True for that check).
+"""
+import sys, os
+from collections import Counter
+
+EXPECT_PRESERVED = False  # current ZCAD output drops the subtree (the bug)
+
+
+def type_counts(path):
+    with open(path, 'r', errors='replace') as f:
+        L = [l.rstrip('\n').rstrip('\r') for l in f]
+    c = Counter()
+    for i in range(0, len(L) - 1, 2):
+        if L[i].strip() == '0':
+            c[L[i + 1].strip()] += 1
+    return c
+
+
+def main():
+    base = os.path.join(os.path.dirname(__file__), '..', 'cad_source', 'test')
+    ok = True
+    for n in (1, 2, 3, 4):
+        acad = type_counts(os.path.join(base, f'acadtablerazdel2007_{n}.dxf'))
+        zc_path = os.path.join(base, f'zcadtablerazdel2007_{n}.dxf')
+        if not os.path.exists(zc_path):
+            print(f"file {n}: ZCAD re-saved file missing, skipping")
+            continue
+        zc = type_counts(zc_path)
+        a_content = acad.get('TABLECONTENT', 0)
+        a_geom = acad.get('TABLEGEOMETRY', 0)
+        z_content = zc.get('TABLECONTENT', 0)
+        z_geom = zc.get('TABLEGEOMETRY', 0)
+
+        # AutoCAD original must contain the rendering subtree.
+        has_subtree_acad = a_content >= 1 and a_geom >= 1
+        # ZCAD output: currently drops it (bug); after fix should preserve it.
+        zc_preserves = z_content >= 1 and z_geom >= 1
+
+        good = has_subtree_acad and (zc_preserves == EXPECT_PRESERVED)
+        ok = ok and good
+        print(f"file {n}: AutoCAD TABLECONTENT={a_content} TABLEGEOMETRY={a_geom} | "
+              f"ZCAD TABLECONTENT={z_content} TABLEGEOMETRY={z_geom} "
+              f"-> {'OK' if good else 'UNEXPECTED'}")
+
+    verdict = ("confirmed: ZCAD currently DROPS the table content subtree "
+               "(Bug 2 root cause)") if not EXPECT_PRESERVED else \
+              "verified: ZCAD now preserves the table content subtree"
+    print(verdict if ok else "UNEXPECTED RESULT")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()

--- a/experiments/issue1339_writeflags.py
+++ b/experiments/issue1339_writeflags.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Issue #1339 (write side) — verify that re-encoding the BreakOption flag from
+the manual-position/manual-height booleans reproduces the bits AutoCAD wrote.
+
+This mirrors the Pascal logic in
+  uzeacadtable_dxf_write.WriteRoundTripRecordToDXF:
+    BreakOptionFlags := 3;                       { EnableBreaks(1)+RepeatTopLabels(2) }
+    if BreakManualPosition then flags := flags or 8;
+    if BreakManualHeight   then flags := flags or 16;
+
+Before the fix ZCAD hard-coded the flag to 3, dropping the manual bits on
+re-save. The read side (DetectBreak* / SetBreakOptionFlags) decodes bits 8/16
+from the original file; this check confirms the write side puts them back.
+
+We assert the re-encoded flag equals the bits we manage (3|8|16 = 27 mask) of
+the original flag. Bits outside that mask (none observed in the test files)
+are intentionally not round-tripped by the current writer and are reported.
+"""
+import sys, os
+
+# Reuse the read-side scanner.
+sys.path.insert(0, os.path.dirname(__file__))
+from issue1339_breakflags import scan_break, EXPECTED  # noqa: E402
+
+BASE_FLAGS = 3            # EnableBreaks(1) + RepeatTopLabels(2)
+ALLOW_MANUAL_POSITIONS = 8
+ALLOW_MANUAL_HEIGHTS = 16
+MANAGED_MASK = BASE_FLAGS | ALLOW_MANUAL_POSITIONS | ALLOW_MANUAL_HEIGHTS  # 27
+
+
+def encode_flags(manual_pos, manual_h):
+    """Pascal-equivalent flag synthesis used on save."""
+    flags = BASE_FLAGS
+    if manual_pos:
+        flags |= ALLOW_MANUAL_POSITIONS
+    if manual_h:
+        flags |= ALLOW_MANUAL_HEIGHTS
+    return flags
+
+
+def main():
+    base = os.path.join(os.path.dirname(__file__), '..', 'cad_source', 'test')
+    ok = True
+    for n in (1, 2, 3, 4):
+        path = os.path.join(base, f'acadtablerazdel2007_{n}.dxf')
+        orig_flags, _spacing, _bh = scan_break(path)
+
+        # Read side: decode the manual booleans (as SetBreakOptionFlags does).
+        manual_pos = bool(orig_flags & ALLOW_MANUAL_POSITIONS)
+        manual_h = bool(orig_flags & ALLOW_MANUAL_HEIGHTS)
+
+        # Write side: re-encode (as WriteRoundTripRecordToDXF now does).
+        new_flags = encode_flags(manual_pos, manual_h)
+
+        managed_orig = orig_flags & MANAGED_MASK
+        round_trips = (new_flags == managed_orig)
+        extra_bits = orig_flags & ~MANAGED_MASK
+
+        exp = EXPECTED[n]
+        matches_expected = (manual_pos == exp['manual_pos'] and
+                            manual_h == exp['manual_h'])
+        good = round_trips and matches_expected
+        ok = ok and good
+        note = 'OK' if good else 'MISMATCH'
+        if extra_bits:
+            note += f' (un-roundtripped bits={extra_bits:#x})'
+        print(f"file {n}: orig={orig_flags:05b} -> manualPos={manual_pos} "
+              f"manualHeight={manual_h} -> reencoded={new_flags:05b} {note}")
+
+    # The old hard-coded writer always emitted 3 — show it would have failed.
+    print("--- regression guard: old writer hard-coded flag=3 ---")
+    old_ok = True
+    for n in (2, 3, 4):  # files 2..4 carry manual bits
+        path = os.path.join(base, f'acadtablerazdel2007_{n}.dxf')
+        orig_flags, _, _ = scan_break(path)
+        managed_orig = orig_flags & MANAGED_MASK
+        if 3 == managed_orig:
+            old_ok = False  # old writer would have been correct (unexpected)
+    if old_ok:
+        print("confirmed: old writer (flag=3) would lose manual bits for files 2-4")
+    else:
+        print("WARNING: old writer assumption invalid")
+        ok = False
+
+    print("ALL OK" if ok else "FAILURES")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## AcadTable — корректный round-trip разделённых таблиц (#1339)

Fixes veb86/zcadvelecAI#1339

Issue описывает две ошибки при open→save→reopen разделённых (`AcadTableBreakEnabled=true`) таблиц ACAD_TABLE. Тестовые файлы — в `cad_source/test/` (`acadtablerazdel2007_1..4.dxf` — оригиналы из AutoCAD, `zcadtablerazdel2007_1..4.dxf` — пересохранённые ZCAD).

---

### ✅ Bug 1 — неверное чтение `AcadTableBreakManualHeight` / `…ManualPosition` (исправлено)

**Причина.** ZCAD определял признаки ручного позиционирования/высоты разбиения эвристикой по геометрии частей. Для `acadtablerazdel2007_1.dxf` эвристика ложно давала `ManualHeight=true` (правильно — `false`).

**Корень.** Эти признаки хранятся в AutoCAD явно — это флаг `BreakOption` (первая группа `90`) в XRECORD `ACAD_ROUNDTRIP_2008_TABLE_ENTITY`:

| бит | значение | смысл |
|----|----------|-------|
| 1  | EnableBreaks     | базовый |
| 2  | RepeatTopLabels  | базовый |
| 8  | AllowManualPositions | → `AcadTableBreakManualPosition` |
| 16 | AllowManualHeights   | → `AcadTableBreakManualHeight` |

Эмпирически по файлам: f1=`3`, f2=`11`, f3=`27`, f4=`19` → ожидаемые `pos/height`: F/F, T/F, T/T, F/T. ✔

**Исправление.**
- *Чтение:* `ScanTableBreakData` извлекает флаг `BreakOption`; значения применяются через новый `GDBObjAcadTable.SetBreakOptionFlags`. Эвристики `DetectBreakManualPosition/Height` теперь уступают явным флагам (guard `FBreakFlagsKnown`).
- *Запись:* `WriteRoundTripRecordToDXF` раньше жёстко писал `90=3`, теряя ручные биты при пересохранении. Теперь флаг синтезируется из `BreakManualPosition/Height`, протянутых через `TAcadTableRoundTripRecord` и `WriteRawAcadTablePartsToDXF`.

**Проверка** (логика декодирования/кодирования на всех 4 файлах):
- `experiments/issue1339_breakflags.py` → `ALL OK`
- `experiments/issue1339_writeflags.py` → `ALL OK`

---

### 🔬 Bug 2 — текст ячеек невидим в AutoCAD до regen (причина найдена, требуется верификация)

**Симптом.** После пересохранения в ZCAD AutoCAD рисует сетку таблицы, но текст в ячейках не виден; любая трансформация (перемещение/поворот/масштаб) вызывает regen — и текст сразу появляется.

**Причина (подтверждена сравнением реальных файлов).** ZCAD выбрасывает поддерево расширенного словаря сущности:

```
ACAD_TABLE (EB) ─360▶ DICTIONARY (357) ─▶ XRECORD (358) ─▶ TABLECONTENT (2B5)
                                                            TABLEGEOMETRY (2B6)
```

| объект | оригинал AutoCAD | пересохр. ZCAD |
|--------|------------------|----------------|
| `TABLECONTENT` | 1 | **0** |
| `TABLEGEOMETRY` | 1 | **0** |

AutoCAD 2010+ рендерит текст ячеек из `AcDbTableContent`. Без этого объекта при открытии текста нет, regen перестраивает отображение — ровно описанный симптом. `WriteRawEntityText` сейчас намеренно удаляет блок `{ACAD_XDICTIONARY}` (group `360`), т.к. поддерево не round-трипится.

Поддерево: 4 объекта, **без бинарных данных (310)**; внешние ссылки — только `330→EB/2B7/307` (хэндлы сущностей ZCAD уже сохраняет), `340→` текстовый стиль (×5) и `340→` стиль таблицы (×1).

Подробный разбор и план фикса (с точной спецификацией ремаппинга хэндлов) — в `experiments/issue1339_bug2_analysis.md`. Воспроизведение: `python3 experiments/issue1339_bug2_subtree.py`.

> ⚠️ **Нужна помощь мейнтейнера.** В среде сборщика недоступны FPC/Lazarus и AutoCAD, поэтому реализацию ремаппинга ~8000 групп поддерева невозможно ни скомпилировать, ни проверить открытием в AutoCAD. Ошибка в одном хэндле даст внешне правдоподобный, но «битый» файл, который тут не отловить. Готов реализовать фикс по плану из analysis-документа (fail-safe: при невозможности ремаппинга — текущее поведение), как только подтвердите подход / сможете протестировать сборку в AutoCAD.

---

### Изменённые файлы
- `cad_source/zengine/fileformats/uzeffdxf.pas` — `ScanTableBreakData` читает `BreakOption`; применение флагов после `SetTableBreakData`.
- `cad_source/zengine/fileformats/uzeffdxfsupport.pas` — поля `TableBreakManual*`/`FlagsValid` в `TIODXFLoadContext`.
- `cad_source/zcad/velec/acadtable/uzeacadtable_model.pas` — `SetBreakOptionFlags`, guard `FBreakFlagsKnown`, проброс флагов в запись.
- `cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas` — `BreakOption` синтезируется из ручных флагов.
- `cad_source/zengine/tests/uzctacadtable.pas` — обновлён вызов под новую сигнатуру.
- `experiments/issue1339_*` — проверки логики и разбор Bug 2.
