### PR TITLE
AcadTable: fix break option loader hook

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-19T12:13:47.577Z for PR creation at branch issue-1342-055d62c3fb79 for issue https://github.com/veb86/zcadvelecAI/issues/1342

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-19T12:13:47.577Z for PR creation at branch issue-1342-055d62c3fb79 for issue https://github.com/veb86/zcadvelecAI/issues/1342

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -95,6 +95,10 @@ type
       чтобы свойства Break spacing/Break height отображались и
       редактировались в инспекторе объектов (issue #1307). }
     function SetTableBreakData(ASpacing,ABreakHeight:double):boolean;virtual;
+    { Passes explicit table break flags read from
+      ACAD_ROUNDTRIP_2008_TABLE_ENTITY. Base implementation does nothing;
+      table entities override it (issue #1339). }
+    procedure SetBreakOptionFlags(AManualPosition,AManualHeight:boolean);virtual;
     { Передаёт сущности исходный текст DXF-entity, если загрузчик сохранил
       его для round-trip экспорта. Базовая реализация ничего не делает. }
     procedure SetDXFRawEntityText(const ARawText:string);virtual;
@@ -467,6 +471,10 @@ end;
 function GDBObjEntity.SetTableBreakData(ASpacing,ABreakHeight:double):boolean;
 begin
   Result:=false;
+end;
+
+procedure GDBObjEntity.SetBreakOptionFlags(AManualPosition,AManualHeight:boolean);
+begin
 end;
 
 procedure GDBObjEntity.SetDXFRawEntityText(const ARawText:string);

--- a/test_issue1342_acadtable_compile_contract.py
+++ b/test_issue1342_acadtable_compile_contract.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1342 AcadTable DXF loader compile contract.
+"""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parent
+DXF_LOADER = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxf.pas"
+ENTITY_BASE = ROOT / "cad_source" / "zengine" / "core" / "entities" / "uzeentity.pas"
+ACADTABLE_MODEL = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_model.pas"
+)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def test_dxf_loader_calls_break_flags_through_base_entity():
+    dxf_loader = compact(read_text(DXF_LOADER))
+
+    assert "plastmaintable^.setbreakoptionflags(" in dxf_loader
+    assert "context.tablebreakmanualposition" in dxf_loader
+    assert "context.tablebreakmanualheight" in dxf_loader
+
+
+def test_base_entity_declares_break_flags_hook_for_loader_call():
+    entity_base = compact(read_text(ENTITY_BASE))
+
+    assert (
+        "proceduresetbreakoptionflags("
+        "amanualposition,amanualheight:boolean);virtual;"
+    ) in entity_base
+    assert (
+        "proceduregdbobjentity.setbreakoptionflags("
+        "amanualposition,amanualheight:boolean);"
+    ) in entity_base
+
+
+def test_acadtable_model_provides_specialized_break_flags_handler():
+    acadtable_model = read_text(ACADTABLE_MODEL)
+    acadtable_compact = compact(acadtable_model)
+
+    assert re.search(
+        r"procedure\s+SetBreakOptionFlags\s*\("
+        r"\s*AManualPosition,\s*AManualHeight:\s*Boolean\s*\)\s*;\s*virtual\s*;",
+        acadtable_model,
+        re.IGNORECASE,
+    )
+    assert (
+        "proceduregdbobjacadtable.setbreakoptionflags("
+        "amanualposition,amanualheight:boolean);"
+    ) in acadtable_compact
+    assert "fbreakflagsknown:=true" in acadtable_compact
+    assert "setbreakmanualpositionforparts(amanualposition)" in acadtable_compact
+    assert "setbreakmanualheightforparts(amanualheight)" in acadtable_compact
+
+
+if __name__ == "__main__":
+    test_dxf_loader_calls_break_flags_through_base_entity()
+    test_base_entity_declares_break_flags_hook_for_loader_call()
+    test_acadtable_model_provides_specialized_break_flags_handler()
+    print("issue 1342 AcadTable compile contract checks passed")


### PR DESCRIPTION
## Summary
- Add the missing `GDBObjEntity.SetBreakOptionFlags` virtual hook used by the DXF loader when applying AcadTable roundtrip BreakOption flags.
- Keep the base implementation as a no-op so non-table entities are unaffected, while `GDBObjAcadTable` continues to handle the flags.
- Add a source-level regression check for issue #1342 that verifies the loader/base/model compile contract.

## Reproduce
The issue reports Pascal compilation failing at `uzeffdxf.pas(836,29)` because `pLastMainTable` is typed as `PGDBObjEntity`, but the base entity did not declare `SetBreakOptionFlags`.

## Tests
- `python3 -m pytest test_*.py`
- `git diff --check`

Note: a full Pascal compile was not run locally because this environment does not have `fpc`, `ppcx64`, or `lazbuild` installed.

Fixes veb86/zcadvelecAI#1342