### PR TITLE
AcadTable: fix cell text not displaying in AutoCAD (issue #1344)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ cad_source/zengine/tests/*.or
 cad_source/zengine/tests/*.rsj
 cad_source/zengine/tests/*.compiled
 cad_source/zengine/tests/testacadtable_standalone
+cad_source/zengine/tests/testmtext1344_standalone
 cad_source/zengine/tests/roundtrip1339
 
 # issue #1339 round-trip experiment output

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-19T20:01:53.498Z for PR creation at branch issue-1344-522b681ea23d for issue https://github.com/veb86/zcadvelecAI/issues/1344

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-19T20:01:53.498Z for PR creation at branch issue-1344-522b681ea23d for issue https://github.com/veb86/zcadvelecAI/issues/1344

--- a/cad_source/zengine/core/entities/uzeentmtext.pas
+++ b/cad_source/zengine/core/entities/uzeentmtext.pas
@@ -799,6 +799,7 @@ var
   ul:boolean;
   quotedcontent:TDXFEntsInternalStringType;
   ASourcesCounter:TSPFSourceSet;
+  effectivetemplate:TDXFEntsInternalStringType;
 begin
   ul:=False;
   SaveToDXFObjPrefix(outStream,'MTEXT','AcDbMText',IODXFContext);
@@ -806,19 +807,30 @@ begin
   dxfDoubleout(outStream,40,textprop.size);
   dxfDoubleout(outStream,41,Width);
   dxfIntegerout(outStream,71,j2b[textprop.justify]);
+  //Если шаблон ещё не сформирован (template=''), но текст уже загружен в
+  //Content — берём Content. Так бывает у MTEXT внутри блоков, которые
+  //загрузились из DXF, но не проходили FormatContent: например анонимный
+  //блок *T таблицы ACAD_TABLE. Без этого группа 1 при пересохранении
+  //писалась пустой, и AutoCAD не показывал текст в ячейках таблицы до
+  //трансформации (перемещение/поворот/масштаб), т.к. кэш графики таблицы
+  //(этот блок) оставался без текста (issue #1344). Логика повторяет
+  //FormatContent: «if template='' then template:=content».
+  effectivetemplate:=template;
+  if effectivetemplate='' then
+    effectivetemplate:=Content;
   //проверяем есть ли в шаблоне управляющие последовательности
   //отсутствующие в dxf
-  s:=TxtFormatAndCountSrcs(template,SPFSources.GetFull,ASourcesCounter,@Self);
+  s:=TxtFormatAndCountSrcs(effectivetemplate,SPFSources.GetFull,ASourcesCounter,@Self);
   if (ASourcesCounter and (not SPFSdxf))<>0 then begin
     //шаблон dxf НЕсовместим, разворачиваем всё кроме dxf последовательностей
     //пишем dxf совместимое содержимое, шаблом сохраним отдельно
-    quotedcontent:=TxtFormatAndCountSrcs(template,SPFSources.GetFull and
+    quotedcontent:=TxtFormatAndCountSrcs(effectivetemplate,SPFSources.GetFull and
       (not SPFSdxf),ASourcesCounter,@Self);
     s:=UTF8Encode(quotedcontent);
   end else begin
     //шаблон dxf совместим, пишем сразу его,
     //отдельно его дописывать в расширенные данные ненадо
-    s:=UTF8Encode(template);
+    s:=UTF8Encode(effectivetemplate);
     IODXFContext.LocalEntityFlags:=IODXFContext.LocalEntityFlags or
       CLEFNotNeedSaveTemplate;
   end;

--- a/cad_source/zengine/tests/testmtext1344_standalone.lpi
+++ b/cad_source/zengine/tests/testmtext1344_standalone.lpi
@@ -1,0 +1,139 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<CONFIG>
+  <ProjectOptions>
+    <Version Value="12"/>
+    <General>
+      <Flags>
+        <SaveOnlyProjectUnits Value="True"/>
+        <MainUnitHasCreateFormStatements Value="False"/>
+        <MainUnitHasTitleStatement Value="False"/>
+        <MainUnitHasScaledStatement Value="False"/>
+        <SaveJumpHistory Value="False"/>
+        <SaveFoldState Value="False"/>
+        <CompatibilityMode Value="True"/>
+      </Flags>
+      <SessionStorage Value="InProjectDir"/>
+      <UseAppBundle Value="False"/>
+      <ResourceType Value="res"/>
+    </General>
+    <i18n>
+      <EnableI18N LFM="False"/>
+    </i18n>
+    <MacroValues Count="1">
+      <Macro1 Name="LCLWidgetType" Value="nogui"/>
+    </MacroValues>
+    <BuildModes Count="1">
+      <Item1 Name="Default" Default="True"/>
+      <SharedMatrixOptions Count="1">
+        <Item1 ID="480656748252" Modes="Default" Type="IDEMacro" MacroName="LCLWidgetType" Value="nogui"/>
+      </SharedMatrixOptions>
+    </BuildModes>
+    <PublishOptions>
+      <Version Value="2"/>
+    </PublishOptions>
+    <RunParams>
+      <local>
+        <CommandLineParams Value="--format=xml -a"/>
+      </local>
+      <FormatVersion Value="2"/>
+      <Modes Count="1">
+        <Mode0 Name="default">
+          <local>
+            <CommandLineParams Value="--format=xml -a"/>
+          </local>
+        </Mode0>
+      </Modes>
+    </RunParams>
+    <RequiredPackages Count="11">
+      <Item1>
+        <PackageName Value="zunits"/>
+      </Item1>
+      <Item2>
+        <PackageName Value="zreaders"/>
+      </Item2>
+      <Item3>
+        <PackageName Value="zmath"/>
+      </Item3>
+      <Item4>
+        <PackageName Value="zcontainers"/>
+      </Item4>
+      <Item5>
+        <PackageName Value="zbaseutils"/>
+      </Item5>
+      <Item6>
+        <PackageName Value="fpdwg"/>
+      </Item6>
+      <Item7>
+        <PackageName Value="zobjectinspector"/>
+      </Item7>
+      <Item8>
+        <PackageName Value="zscriptbase"/>
+      </Item8>
+      <Item9>
+        <PackageName Value="zbaseutilsgui"/>
+      </Item9>
+      <Item10>
+        <PackageName Value="LCL"/>
+      </Item10>
+      <Item11>
+        <PackageName Value="FCL"/>
+      </Item11>
+    </RequiredPackages>
+    <Units Count="1">
+      <Unit0>
+        <Filename Value="testmtext1344_standalone.lpr"/>
+        <IsPartOfProject Value="True"/>
+      </Unit0>
+    </Units>
+  </ProjectOptions>
+  <CompilerOptions>
+    <Version Value="11"/>
+    <Target>
+      <Filename Value="testmtext1344_standalone"/>
+    </Target>
+    <SearchPaths>
+      <IncludeFiles Value="$(ProjOutDir);.."/>
+      <OtherUnitFiles Value="..;../containers;../fileformats;../fileformats/dwg;../fileformats/dwg/entities;../../zcad;../../zcad/velec/acadtable;../misc;../core/entities;../core;../core/utils;../zgl/common;../zgl/gdi;../zgl/canvas;../zgl/opengl;../zgl/openglmodern;../zgl/dx;../core/drawings;../core/objects;../styles;../fonts;../geomlib"/>
+    </SearchPaths>
+    <Parsing>
+      <SyntaxOptions>
+        <SyntaxMode Value="Delphi"/>
+        <AllowLabel Value="False"/>
+      </SyntaxOptions>
+    </Parsing>
+    <CodeGeneration>
+      <Checks>
+        <IOChecks Value="True"/>
+        <RangeChecks Value="True"/>
+        <OverflowChecks Value="True"/>
+        <StackChecks Value="True"/>
+      </Checks>
+      <VerifyObjMethodCallValidity Value="True"/>
+      <Optimizations>
+        <OptimizationLevel Value="0"/>
+      </Optimizations>
+    </CodeGeneration>
+    <Linking>
+      <Debugging>
+        <DebugInfoType Value="dsDwarf3"/>
+        <UseHeaptrc Value="True"/>
+      </Debugging>
+    </Linking>
+    <Other>
+      <CustomOptions Value="-dDUnit"/>
+    </Other>
+  </CompilerOptions>
+  <Debugging>
+    <Exceptions Count="3">
+      <Item1>
+        <Name Value="EAbort"/>
+      </Item1>
+      <Item2>
+        <Name Value="ECodetoolError"/>
+      </Item2>
+      <Item3>
+        <Name Value="EFOpenError"/>
+      </Item3>
+    </Exceptions>
+  </Debugging>
+</CONFIG>

--- a/cad_source/zengine/tests/testmtext1344_standalone.lpr
+++ b/cad_source/zengine/tests/testmtext1344_standalone.lpr
@@ -1,0 +1,16 @@
+program testmtext1344_standalone;
+
+{$mode objfpc}{$H+}
+
+uses
+  Classes, consoletestrunner, uzctmtextcontentsave;
+
+var
+  Application: TTestRunner;
+
+begin
+  Application := TTestRunner.Create(nil);
+  Application.Initialize;
+  Application.Run;
+  Application.Free;
+end.

--- a/cad_source/zengine/tests/testzengine.lpr
+++ b/cad_source/zengine/tests/testzengine.lpr
@@ -9,6 +9,7 @@ uses
   uzctEntityArc, uzctmtextwrap, uzctenttextjustify, uzctacadtable, uzctentproxy,
   uzctentpolyfacemesh, uzctentleader, uzctdwgblockreserve, uzctdwgentleader,
   uzctenttextnilstyle,
+  uzctmtextcontentsave,
   uzctenttransformscalars;
 
 var

--- a/cad_source/zengine/tests/uzctmtextcontentsave.pas
+++ b/cad_source/zengine/tests/uzctmtextcontentsave.pas
@@ -1,0 +1,160 @@
+unit uzctmtextcontentsave;
+{$Codepage UTF8}
+{$Mode delphi}{$H+}
+
+{ Issue #1344 regression test.
+
+  Текст внутри таблиц ACAD_TABLE не отображался в AutoCAD: сетка таблицы
+  рисовалась, а текст ячеек был пустой до тех пор, пока пользователь не
+  выполнял трансформацию (перенос/поворот/масштаб).
+
+  Корень проблемы — в кэш-графике таблицы. AutoCAD хранит отрисованную
+  таблицу в анонимном блоке (*T1, *T2, ...), где текст ячеек лежит в виде
+  MTEXT. ZCAD загружает эти блоки штатным DXF-загрузчиком: GDBObjMText.
+  LoadFromDXF кладёт текст в поле Content, но оставляет поле template
+  пустым (template заполняется только при форматировании в FormatContent).
+  При пересохранении GDBObjMText.SaveToDXF писал группу 1 из template и,
+  поскольку template был пустым, в DXF попадала пустая строка — текст
+  ячеек терялся в кэш-графике, и AutoCAD показывал пустые ячейки, пока
+  трансформация не помечала таблицу "грязной" и не перестраивала её.
+
+  Исправление: SaveToDXF берёт Content, если template пустой (та же
+  логика, что и в FormatContent: «if template='' then template:=content»).
+
+  Тест воспроизводит ровно состояние загруженного из блока MTEXT
+  (Content задан, template пуст) и проверяет, что SaveToDXF пишет
+  непустую группу 1 с текстом ячейки. }
+
+interface
+
+uses
+  SysUtils,
+  Classes,
+  fpcunit,
+  testregistry,
+  Interfaces,
+  uzeTypes,
+  uzeenttext,
+  uzeentmtext,
+  uzedrawingsimple,
+  uzestylestexts,
+  uzctnrVectorBytesStream,
+  uzeffdxfsupport;
+
+type
+  TMTextContentSaveTest = class(TTestCase)
+  private
+    function SaveMTextToDXFText(AMText: PGDBObjMText;
+      var ADrawing: TSimpleDrawing): String;
+  published
+    // Loaded-from-block state: Content set, template empty -> group 1 must
+    // carry the text (the actual #1344 bug).
+    procedure SavesContentWhenTemplateEmpty;
+    // Control: when template is set it must still be written (no regression
+    // for the normal path).
+    procedure SavesTemplateWhenPresent;
+  end;
+
+implementation
+
+function EnsureStandardStyle(var ADrawing: TSimpleDrawing): PGDBTextStyle;
+var
+  Prop: GDBTextStyleProp;
+begin
+  Result := ADrawing.GetTextStyleTable^.FindStyle('Standard', False);
+  if Result = nil then
+  begin
+    Prop.size := 2.5;
+    Prop.oblique := 0;
+    Prop.wfactor := 1;
+    Result := ADrawing.GetTextStyleTable^.addstyle(
+      'Standard', '', '', Prop, False);
+  end;
+end;
+
+function TMTextContentSaveTest.SaveMTextToDXFText(AMText: PGDBObjMText;
+  var ADrawing: TSimpleDrawing): String;
+var
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  FileName: String;
+  Lines: TStringList;
+begin
+  OutStream.init(8 * 1024);
+  SaveContext.InitRec;
+  SaveContext.Header.Version := AC1021;
+  SaveContext.Header.iVersion := 1021;
+  try
+    AMText^.SaveToDXF(OutStream, ADrawing, SaveContext);
+    FileName := IncludeTrailingPathDelimiter(GetTempDir(False)) +
+      'zcad_mtext_content_save_test.dxf';
+    if OutStream.SaveToFile(FileName) < 0 then
+      raise Exception.Create('Не удалось сохранить временный DXF-поток');
+    Lines := TStringList.Create;
+    try
+      Lines.LoadFromFile(FileName);
+      Result := Lines.Text;
+    finally
+      Lines.Free;
+      DeleteFile(FileName);
+    end;
+  finally
+    SaveContext.Done;
+    OutStream.done;
+  end;
+end;
+
+procedure TMTextContentSaveTest.SavesContentWhenTemplateEmpty;
+var
+  Drawing: TSimpleDrawing;
+  MText: PGDBObjMText;
+  DXFText: String;
+begin
+  Drawing.init(nil);
+  try
+    MText := GDBObjMText.CreateInstance;
+    MText^.TXTStyle := EnsureStandardStyle(Drawing);
+    // Состояние MTEXT после GDBObjMText.LoadFromDXF: текст в Content,
+    // template пуст (как у MTEXT из анонимного блока *T таблицы).
+    MText^.Content := 'Zagolovok';
+    MText^.Template := '';
+
+    DXFText := SaveMTextToDXFText(MText, Drawing);
+
+    // До исправления группа 1 писалась из пустого template, и текст
+    // терялся. Теперь SaveToDXF подставляет Content.
+    CheckTrue(Pos('Zagolovok', DXFText) > 0,
+      'SaveToDXF должен писать текст ячейки даже когда template пуст ' +
+      '(issue #1344). DXF: ' + DXFText);
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TMTextContentSaveTest.SavesTemplateWhenPresent;
+var
+  Drawing: TSimpleDrawing;
+  MText: PGDBObjMText;
+  DXFText: String;
+begin
+  Drawing.init(nil);
+  try
+    MText := GDBObjMText.CreateInstance;
+    MText^.TXTStyle := EnsureStandardStyle(Drawing);
+    MText^.Content := '';
+    MText^.Template := 'Podpis';
+
+    DXFText := SaveMTextToDXFText(MText, Drawing);
+
+    CheckTrue(Pos('Podpis', DXFText) > 0,
+      'SaveToDXF должен писать текст из template, когда он задан. DXF: ' +
+      DXFText);
+  finally
+    Drawing.done;
+  end;
+end;
+
+initialization
+  RegisterTest(TMTextContentSaveTest);
+
+end.


### PR DESCRIPTION
## Fixes veb86/zcadvelecAI#1344 — AcadTable cell text not displaying in AutoCAD

### Symptom
When a ZCAD-saved DXF table is opened in AutoCAD, the table grid draws
correctly but the **cell text is missing**. Performing any transformation
(move / rotate / scale) on the table makes the text appear immediately.
AutoCAD's `Regen` does **not** help — only a transformation does.

### Root cause
AutoCAD stores a table's rendered graphics in an **anonymous block**
(`*T1`, `*T2`, …). Inside that block each cell's text is an `MTEXT` entity
(this is the "cached graphics" AutoCAD shows before it regenerates the
table from the cell data).

ZCAD loads those blocks with the standard DXF loader:

- `GDBObjMText.LoadFromDXF` puts the text into the **`Content`** field and
  leaves **`template`** empty (`template` is only filled later, by
  `FormatContent`).
- `GDBObjMText.SaveToDXF` wrote DXF **group 1** from `template`.

For these loaded-but-never-formatted block MTEXT, `template` is empty, so
ZCAD wrote an **empty group 1** — the cell text was dropped from the cached
table graphics. AutoCAD therefore displays empty cells until a transform
marks the table dirty and regenerates it from the cell data, which is
exactly the reported behaviour.

Empirical confirmation — `cad_source/test/acadtablerazdel2007_1.dxf` (an
AutoCAD original) contains `*T1..*T5` blocks with 55 MTEXT whose group 1
holds the cell text (`Zagolovok`, `A`, `B`, …). After a ZCAD resave those
group-1 values came out empty.

### Fix
`GDBObjMText.SaveToDXF` now falls back to `Content` when `template` is
empty, mirroring the existing `FormatContent` logic
(`if template='' then template:=content`):

```pascal
effectivetemplate:=template;
if effectivetemplate='' then
  effectivetemplate:=Content;
```

The change is a **local, read-only fallback inside a single method**. It
does not mutate entity state and only affects entities that currently lose
their text, so it cannot regress entities that already save correctly. This
is intentionally minimal and unrelated to the previously reverted PR #1345
(which touched 7 files and broke table opening) — only one production file
is changed here, by a few lines.

### How to reproduce / test
A regression test (`uzctmtextcontentsave`) recreates the loaded block-MTEXT
state (`Content` set, `template` empty) and asserts `SaveToDXF` writes a
non-empty group 1 with the cell text.

Verification:
- **Without** the fix: `SavesContentWhenTemplateEmpty` fails (group 1 empty).
- **With** the fix: both tests pass.
- The existing `testacadtable_standalone` suite shows the **same 7
  pre-existing failures with and without this change** (break-table *load*
  tests, unrelated to MTEXT save) — i.e. this change introduces no
  regressions.

The test is registered in `testzengine.lpr` and also provided as a
standalone runner (`testmtext1344_standalone`, mirroring the existing
`testacadtable_standalone`) because the full `testzengine` suite currently
cannot build in this environment due to a pre-existing unrelated compile
error in `uzctmtextwrap.pas`.

### Files changed
- `cad_source/zengine/core/entities/uzeentmtext.pas` — the fix.
- `cad_source/zengine/tests/uzctmtextcontentsave.pas` — regression test.
- `cad_source/zengine/tests/testzengine.lpr` — register the test.
- `cad_source/zengine/tests/testmtext1344_standalone.{lpr,lpi}` — standalone runner.
- `.gitignore` — ignore the standalone binary.
