### PR TITLE
AcadTable: исправлено столкновение хэндлов при сохранении разделённых таблиц (issue #1344)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-19T21:17:45.902Z for PR creation at branch issue-1344-655100527f3b for issue https://github.com/veb86/zcadvelecAI/issues/1344

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-19T21:17:45.902Z for PR creation at branch issue-1344-655100527f3b for issue https://github.com/veb86/zcadvelecAI/issues/1344

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -474,35 +474,31 @@ begin
   end;
 end;
 
-procedure BumpHandleAfterRawEntity(
-  var AIODXFContext: TIODXFSaveContext; AHandle: TDWGHandle);
-begin
-  if AHandle >= AIODXFContext.handle then
-    AIODXFContext.handle := AHandle + 1;
-end;
-
 // Записывает сырую (raw) сущность ACAD_TABLE, переписывая ссылки на хэндлы
 // под актуальную (перенумерованную) нумерацию сохраняемого файла (issue #1339):
+//   5   — хэндл самой сущности (перенумеровывается в ANewHandle, issue #1344);
 //   330 — владелец сущности (*Model_Space);
 //   342 — стиль таблицы (по имени стиля ATableStyleName);
 //   343 — анонимный блок таблицы (по имени блока из предшествующей пары 2);
 //   блок расширенного словаря 102/ACAD_XDICTIONARY удаляется, т.к. он не
 //        круглорейсится и иначе оставляет висячую ссылку (360).
-// Хэндл самой сущности (группа 5) намеренно не трогаем.
 procedure WriteRawEntityText(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
   const ATableStyleName: String;
-  const ARawEntity: String);
+  const ARawEntity: String;
+  ANewHandle: TDWGHandle);
 var
   Lines: TStringList;
   I: Integer;
   Code, OutValue, LastBlockName, MappedValue: String;
+  HandleRewritten: Boolean;
 begin
   Lines := TStringList.Create;
   try
     Lines.Text := ARawEntity;
     LastBlockName := '';
+    HandleRewritten := False;
     I := 0;
     while I < Lines.Count do
     begin
@@ -537,6 +533,20 @@ begin
 
       if Code = '2' then
         LastBlockName := Trim(Lines[I + 1])
+      else if (Code = '5') and (not HandleRewritten) then
+      begin
+        { Перенумеровываем хэндл самой сущности (группа 5) под актуальную
+          нумерацию сохраняемого файла (issue #1344). Исходный хэндл из
+          файла AutoCAD может совпасть с хэндлом, который уже был выдан
+          анонимному блоку таблицы при записи секции BLOCKS (там хэндлы
+          назначаются заново, последовательно). При совпадении AutoCAD
+          сообщает «Неверная метка <handle>: уже используется» и
+          отказывается открывать файл. Свежий хэндл из общего счётчика
+          документа исключает это столкновение. Переписываем только первый
+          код 5 (хэндл сущности), значения ячеек (302="5") не затрагиваем. }
+        OutValue := IntToHex(ANewHandle, 0);
+        HandleRewritten := True;
+      end
       else if Code = '330' then
       begin
         if AIODXFContext.AcadTableOwnerHandle <> 0 then
@@ -648,6 +658,11 @@ var
   PartIdx: Integer;
 begin
   Result := False;
+  { Валидируем raw-сущности: у каждой части должен быть исходный хэндл
+    (группа 5). Если нет — это не пригодная для round-trip сущность, и
+    управление возвращается обычному (модельному) сохранению. Сами
+    исходные значения хэндлов далее не используются — каждая часть
+    получает свежий хэндл (issue #1344). }
   if not RawAcadTableHandle(AMainRawEntity, MainHandle) then
     Exit;
 
@@ -658,16 +673,20 @@ begin
       ContinuationHandles[PartIdx]) then
       Exit;
 
+  { Выдаём свежие хэндлы из общего счётчика документа. К моменту записи
+    секции ENTITIES счётчик уже прошёл секцию BLOCKS, поэтому новые хэндлы
+    гарантированно не сталкиваются с хэндлами анонимных блоков таблицы
+    (issue #1344). Эти же значения попадают в round-trip XRECORD (360/330/
+    361), оставаясь согласованными с группой 5 сущностей. }
+  MainHandle := NextAnonymousHandle(AIODXFContext);
   WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
-    AMainRawEntity);
-  BumpHandleAfterRawEntity(AIODXFContext, MainHandle);
+    AMainRawEntity, MainHandle);
 
   for PartIdx := 0 to High(AContinuationRawEntities) do
   begin
+    ContinuationHandles[PartIdx] := NextAnonymousHandle(AIODXFContext);
     WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
-      AContinuationRawEntities[PartIdx]);
-    BumpHandleAfterRawEntity(
-      AIODXFContext, ContinuationHandles[PartIdx]);
+      AContinuationRawEntities[PartIdx], ContinuationHandles[PartIdx]);
   end;
 
   AddRoundTripRecord(MainHandle, ContinuationHandles,

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -137,6 +137,12 @@ type
     procedure ClearingBreakRepeatTopKeepsDataRowFormatting;
     // issue #1309: неразорванная таблица не имеет повтора верхних меток.
     procedure NonBrokenTableHasNoBreakRepeatTop;
+    // issue #1344: исходный хэндл сущности raw-таблицы (группа 5) может
+    // совпасть с хэндлом, уже выданным анонимному блоку таблицы при записи
+    // секции BLOCKS. При сохранении таблица и все её части-продолжения
+    // должны получать свежие хэндлы из общего счётчика документа, а
+    // round-trip XRECORD (360/361/330) — ссылаться на эти же новые хэндлы.
+    procedure RenumbersRawAcadTableEntityHandlesToAvoidCollision;
   end;
 
 implementation
@@ -1078,9 +1084,13 @@ begin
   CheckFalse(HasDxfSequence(DXFText, ['360', '357']),
     'Висячая ссылка 360 на словарь не должна сохраняться');
 
-  // Собственный хэндл сущности (группа 5) не трогаем.
-  CheckTrue(HasDxfSequence(DXFText, ['5', '2FF']),
-    'Собственный хэндл сущности (группа 5) должен сохраняться без изменений');
+  // Собственный хэндл сущности (группа 5) перенумеровывается под актуальную
+  // нумерацию файла (issue #1344). SaveContext.InitRec выставляет счётчик в $2,
+  // поэтому первая (главная) raw-таблица получает хэндл 2.
+  CheckTrue(HasDxfSequence(DXFText, ['5', '2']),
+    'Собственный хэндл сущности (группа 5) должен перенумеровываться в свежий');
+  CheckEquals(0, CountDxfPairs(DXFText, '5', '2FF'),
+    'Старый хэндл сущности 2FF не должен оставаться (issue #1344)');
 
   // Ссылки перенумерованы под актуальный файл.
   CheckTrue(HasDxfSequence(DXFText, ['330', '123']),
@@ -2005,6 +2015,111 @@ begin
   finally
     Drawing.done;
   end;
+end;
+
+// issue #1344. Таблица AutoCAD хранит отрисованную графику в анонимном блоке
+// (*T1, *T2, ...). При сохранении ZCAD заново и последовательно нумерует
+// хэндлы секции BLOCKS, а raw-сущность ACAD_TABLE раньше сохраняла свой
+// исходный хэндл (группа 5) дословно. Для разделённых таблиц с большим
+// объёмом графики (файл №4: ручная высота разбиения) исходный хэндл таблицы
+// совпадал с хэндлом, уже выданным MTEXT внутри анонимного блока. AutoCAD при
+// открытии сообщал «Неверная метка <handle>: уже используется» и отказывался
+// импортировать чертёж. Проверяем, что и главная таблица, и её части-
+// продолжения получают свежие хэндлы из общего счётчика документа, исходные
+// (потенциально конфликтующие) хэндлы не протекают в файл, а round-trip
+// XRECORD (360/361/330) ссылается на эти же новые хэндлы.
+procedure TAcadTableStyleTest.RenumbersRawAcadTableEntityHandlesToAvoidCollision;
+var
+  MainRaw, ContRaw: TStringList;
+  MainText, ContText, DXFText: String;
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  Drawing: TSimpleDrawing;
+  Ok: Boolean;
+begin
+  MainRaw := TStringList.Create;
+  ContRaw := TStringList.Create;
+  try
+    // Главная часть: исходный хэндл EB (в реальном файле №4 он совпадал с
+    // хэндлом MTEXT внутри блока *T7).
+    MainRaw.Add('0');   MainRaw.Add('ACAD_TABLE');
+    MainRaw.Add('5');   MainRaw.Add('EB');
+    MainRaw.Add('330'); MainRaw.Add('26');
+    MainRaw.Add('100'); MainRaw.Add('AcDbEntity');
+    MainRaw.Add('8');   MainRaw.Add('0');
+    MainRaw.Add('100'); MainRaw.Add('AcDbBlockReference');
+    MainRaw.Add('2');   MainRaw.Add('*T7');
+    MainRaw.Add('100'); MainRaw.Add('AcDbTable');
+    MainRaw.Add('342'); MainRaw.Add('FE');
+    MainRaw.Add('343'); MainRaw.Add('32');
+    MainText := MainRaw.Text;
+
+    // Часть-продолжение: исходный хэндл 54C.
+    ContRaw.Add('0');   ContRaw.Add('ACAD_TABLE');
+    ContRaw.Add('5');   ContRaw.Add('54C');
+    ContRaw.Add('330'); ContRaw.Add('26');
+    ContRaw.Add('100'); ContRaw.Add('AcDbEntity');
+    ContRaw.Add('8');   ContRaw.Add('0');
+    ContRaw.Add('100'); ContRaw.Add('AcDbBlockReference');
+    ContRaw.Add('2');   ContRaw.Add('*T8');
+    ContRaw.Add('100'); ContRaw.Add('AcDbTable');
+    ContRaw.Add('342'); ContRaw.Add('FE');
+    ContRaw.Add('343'); ContRaw.Add('33');
+    ContText := ContRaw.Text;
+  finally
+    MainRaw.Free;
+    ContRaw.Free;
+  end;
+
+  OutStream.init(8 * 1024);
+  SaveContext.InitRec;
+  SaveContext.Header.Version := AC1021;
+  SaveContext.Header.iVersion := 1021;
+  try
+    SaveContext.AcadTableOwnerHandle := $123;
+    SaveContext.TableStyleNameHandleMap.Add('Standard', '4A2');
+    // Эмулируем счётчик, который к началу секции ENTITIES уже прошёл BLOCKS:
+    // следующий свободный хэндл — 100. Именно из него (а не из исходного EB)
+    // должна нумероваться таблица.
+    SaveContext.handle := $100;
+
+    ResetAcadTableDXFWriteState;
+    Ok := WriteRawAcadTablePartsToDXF(
+      OutStream, SaveContext, MainText, [ContText],
+      0.99, 2.05, False, True, 'Standard');
+    WriteAcadTableRoundTripObjectsToDXF(OutStream, Drawing, SaveContext);
+    DXFText := DxfStreamToText(OutStream);
+  finally
+    ResetAcadTableDXFWriteState;
+    SaveContext.Done;
+    OutStream.done;
+  end;
+
+  CheckTrue(Ok, 'Сырые части ACAD_TABLE должны успешно записаться');
+
+  // Свежие хэндлы из счётчика: главная — 100, продолжение — 101.
+  CheckTrue(HasDxfSequence(DXFText, ['5', '100']),
+    'Главная таблица должна получить свежий хэндл 100');
+  CheckTrue(HasDxfSequence(DXFText, ['5', '101']),
+    'Часть-продолжение должна получить свежий хэндл 101');
+
+  // Исходные (потенциально конфликтующие) хэндлы не должны протекать в файл.
+  CheckEquals(0, CountDxfPairs(DXFText, '5', 'EB'),
+    'Исходный хэндл главной таблицы EB не должен оставаться (issue #1344)');
+  CheckEquals(0, CountDxfPairs(DXFText, '5', '54C'),
+    'Исходный хэндл продолжения 54C не должен оставаться (issue #1344)');
+
+  // Round-trip XRECORD должен ссылаться на новые хэндлы.
+  CheckTrue(HasDxfSequence(DXFText, ['360', '100']),
+    'Round-trip 360 должен указывать на новый хэндл главной таблицы');
+  CheckTrue(HasDxfSequence(DXFText, ['361', '100']),
+    'Round-trip 361 должен указывать на новый хэндл главной таблицы');
+  CheckTrue(HasDxfSequence(DXFText, ['330', '101']),
+    'Round-trip 330 должен указывать на новый хэндл продолжения');
+  CheckEquals(0, CountDxfPairs(DXFText, '360', 'EB'),
+    'Round-trip не должен ссылаться на исходный хэндл EB');
+  CheckEquals(0, CountDxfPairs(DXFText, '330', '54C'),
+    'Round-trip не должен ссылаться на исходный хэндл продолжения 54C');
 end;
 
 begin

--- a/experiments/check_dup_handles.py
+++ b/experiments/check_dup_handles.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Detect duplicate entity handles (DXF group 5) in a DXF file.
+
+Used to investigate issue #1344: after ZCAD resaved
+acadtablerazdel2007_4.dxf, AutoCAD refused to open it with
+"Неверная метка EB: уже используется" (handle EB already in use).
+
+A valid DXF must have every object handle (group 5) unique. This script
+reports any group-5 value that appears more than once, with the line of
+each occurrence and the entity type that owns it.
+
+Usage:
+    python3 check_dup_handles.py <file.dxf> [<file.dxf> ...]
+
+Exit code is 1 if any file has a duplicate handle, else 0.
+"""
+import sys
+
+
+def scan(path):
+    """Return dict handle -> list of (line_no, owner_type)."""
+    with open(path, 'r', encoding='utf-8', errors='replace') as f:
+        lines = [ln.rstrip('\n').rstrip('\r') for ln in f]
+
+    # An object's handle is the FIRST group 5 emitted after its "0 / <TYPE>"
+    # marker. Group code 5 (and code 0) also appear deeper inside object data
+    # (ACAD_TABLE raw data, MTEXT cache, table style/cell records) where they
+    # are NOT structural markers. Those embedded values produce false
+    # positives, so we only treat a group 5 as a handle when:
+    #   * it is the first 5 after a 0/<TYPE> marker, and
+    #   * the <TYPE> looks like a real DXF entity/object name (starts with a
+    #     letter) rather than embedded numeric data.
+    handles = {}
+    last_entity = '?'
+    handle_taken = True
+    i = 0
+    n = len(lines)
+    while i < n - 1:
+        code = lines[i].strip()
+        val = lines[i + 1].strip()
+        if code == '0':
+            last_entity = val
+            handle_taken = False
+        elif (code == '5' and not handle_taken
+              and last_entity[:1].isalpha()):
+            handles.setdefault(val, []).append((i + 2, last_entity))
+            handle_taken = True
+        i += 1
+    return handles
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 2
+    overall_ok = True
+    for path in argv[1:]:
+        handles = scan(path)
+        dups = {h: locs for h, locs in handles.items() if len(locs) > 1}
+        total = sum(len(v) for v in handles.values())
+        print(f'{path}: {len(handles)} unique handles, {total} group-5 entries')
+        if dups:
+            overall_ok = False
+            for h, locs in sorted(dups.items()):
+                where = ', '.join(f'line {ln} ({owner})' for ln, owner in locs)
+                print(f'  DUPLICATE handle {h}: {where}')
+        else:
+            print('  OK: no duplicate handles')
+    return 0 if overall_ok else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
## Summary

Fixes the regression reported after PR #1346: the split table file
`zcadtablerazdel2007_4.dxf` (`AcadTableBreakEnabled=true`,
`AcadTableBreakManualPosition=false`, `AcadTableBreakManualHeight=true`)
could not be opened in AutoCAD after ZCAD re-saved it. AutoCAD aborted the
import with:

> Неверная метка EB: уже используется. При чтении из ACAD_TABLE … Ожидался
> разделитель классов для класса AcDbEntity. Испорченный или неполный
> входной DXF-файл — импорт чертежа не выполнен.

Files 1–3 opened fine; only file 4 was affected.

## Root cause

A valid DXF requires every object handle (group 5) to be globally unique.

When ZCAD saves a drawing it **renumbers all handles sequentially** while
writing the `BLOCKS` section (anonymous table blocks `*T1…*Tn` and their
contents — lines, MTEXT, etc. — each get a fresh handle from the document
counter). The raw `ACAD_TABLE` round-trip path, however, re-emitted the
table entity's **original** group-5 handle from the source AutoCAD file
*verbatim* (handle `EB` in file 4).

For a large split table with manual break height the graphics block is big
enough that the sequential renumbering reached `EB` and assigned it to an
`MTEXT` inside the anonymous block. The saved DXF then contained two objects
with handle `EB` (the MTEXT at line 9112 and the ACAD_TABLE at line 9818),
which AutoCAD rejects.

Files 1–3 simply had smaller graphics blocks, so the counter never reached
the table's original handle and no collision occurred.

## Fix

`cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas`

- `WriteRawAcadTablePartsToDXF` now allocates a **fresh handle** from the
  document counter (`NextAnonymousHandle`) for the main table and for each
  continuation part, instead of preserving the original handles. By the time
  the `ENTITIES` section is written the counter has already advanced past the
  whole `BLOCKS` section, so the new handles cannot collide with block
  content.
- `WriteRawEntityText` takes the new handle and rewrites the entity's first
  group-5 value (only the entity handle; cell data `302`/`5` pairs are left
  untouched).
- The same new handles are threaded into the round-trip XRECORD
  (`360`/`361`/`330`) so the preserved round-trip data stays consistent with
  the entities.
- Removed the now-unused `BumpHandleAfterRawEntity` helper.

The change is confined to the raw ACAD_TABLE save path and does not alter
loading or geometry, so it does not affect the already-working files.

## Reproduction & verification

- `experiments/check_dup_handles.py` scans the four sample outputs and
  confirms `EB` is the **only** duplicate handle, present **only** in file 4
  (files 1–3 are clean):

  ```
  zcadtablerazdel2007_1.dxf: 212 unique handles … OK: no duplicate handles
  zcadtablerazdel2007_2.dxf: 212 unique handles … OK: no duplicate handles
  zcadtablerazdel2007_3.dxf: 248 unique handles … OK: no duplicate handles
  zcadtablerazdel2007_4.dxf: 283 unique handles …
    DUPLICATE handle EB: line 9112 (MTEXT), line 9818 (ACAD_TABLE)
  ```

- New unit test
  `TAcadTableStyleTest.RenumbersRawAcadTableEntityHandlesToAvoidCollision`
  reproduces the `EB` collision at the exact function boundary: it feeds a raw
  main table (handle `EB`) plus a continuation (handle `54C`) with the save
  counter positioned at `$100`, then asserts both parts receive fresh handles
  (`100`/`101`), the original handles do not leak into the file, and the
  round-trip XRECORD references the new handles.
- The existing `RemapsRawAcadTableHandlesOnSave` test was updated to expect
  the renumbered handle.

Test suite result on this branch: **33 run, 0 errors, 7 failures** — the 7
failures are pre-existing and unrelated (they concern break-manual-position
*loading* detection, not the save path); the count matches the baseline
before this change, i.e. no regressions.

Fixes veb86/zcadvelecAI#1344
