### PR TITLE
uzvfspellchecker. Добавление нового слова в словарь

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-20T17:47:58.028Z for PR creation at branch issue-1296-0f45a98411d6 for issue https://github.com/veb86/zcadvelecAI/issues/1296

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-20T17:47:58.028Z for PR creation at branch issue-1296-0f45a98411d6 for issue https://github.com/veb86/zcadvelecAI/issues/1296

--- a/cad_source/zcad/misc/uzcspeller.pas
+++ b/cad_source/zcad/misc/uzcspeller.pas
@@ -29,14 +29,23 @@ uses
   uHunspell,uSpeller,
   uzbPaths,
   uzcLog,uzbLog,uzbLogTypes,
-  uzcSysParams,
+  uzcSysParams,uzcFileStructure,
   uzelongprocesssupport;
+
+const
+  // Имя пользовательского словаря, в который добавляются новые слова.
+  // Хранится в той же папке (writable config), что и сохранённые панели.
+  CUserDictionaryFile='userwords.dic';
 
 var
   SpellChecker:TSpeller;
 
 procedure CreateSpellChecker;
 procedure DestroySpellChecker;
+procedure ReloadSpellChecker;
+
+// Путь к пользовательскому словарю в writable config (см. SaveLayout).
+function GetUserDictionaryPath:string;
 
 implementation
 
@@ -58,19 +67,37 @@ begin
   end;
 end;
 
+function GetUserDictionaryPath:string;
+begin
+  Result:=GetWritableFilePath(CFSdictionariesDir,CUserDictionaryFile);
+end;
+
 procedure CreateSpellChecker;
 var
   lph:TLPSHandle;
+  UserDict:string;
 begin
   lph:=LPS.StartLongProcess('SpellChecker.Create and LoadDictionaries',nil);
   SpellChecker.CreateRec(@SpellLogCallBack);
   SpellChecker.LoadDictionaries(ExpandPath(ZCSysParams.saved.DictionariesPath));
+  // Подключить пользовательский словарь, если он уже создан
+  UserDict:=GetUserDictionaryPath;
+  if FileExists(UserDict) then
+    SpellChecker.LoadDictionary(UserDict);
   LPS.EndLongProcess(lph);
 end;
 
 procedure DestroySpellChecker;
 begin
   SpellChecker.DestroyRec;
+end;
+
+// Пересоздать SpellChecker, чтобы вновь добавленные в пользовательский
+// словарь слова сразу учитывались в текущей сессии (см. issue #1296).
+procedure ReloadSpellChecker;
+begin
+  DestroySpellChecker;
+  CreateSpellChecker;
 end;
 
 initialization

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.lfm
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.lfm
@@ -33,6 +33,13 @@ object SpellCheckerForm: TSpellCheckerForm
       Caption = 'Применить'
       ImageIndex = 1
     end
+    object AddToDictionaryButton: TToolButton
+      Left = 165
+      Top = 2
+      Action = AddToDictionaryAction
+      Caption = 'В словарь'
+      ImageIndex = 2
+    end
   end
   object SentenceLabel: TLabel
     Left = 0
@@ -113,6 +120,11 @@ object SpellCheckerForm: TSpellCheckerForm
     object ApplySuggestionAction: TAction
       Caption = 'Применить'
       OnExecute = ApplySuggestionActionExecute
+    end
+    object AddToDictionaryAction: TAction
+      Caption = 'В словарь'
+      Hint = 'Добавить выбранное слово в пользовательский словарь'
+      OnExecute = AddToDictionaryActionExecute
     end
   end
 end

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas
@@ -44,6 +44,8 @@ type
   { TSpellCheckerForm }
   TSpellCheckerForm = class(TForm)
     ActionList: TActionList;
+    AddToDictionaryAction: TAction;
+    AddToDictionaryButton: TToolButton;
     ApplySuggestionAction: TAction;
     ApplySuggestionButton: TToolButton;
     ErrorsTree: TLazVirtualStringTree;
@@ -60,6 +62,7 @@ type
     procedure ErrorsTreeGetText(Sender: TBaseVirtualTree; Node: PVirtualNode;
       Column: TColumnIndex; TextType: TVSTTextType; var CellText: string);
     procedure ApplySuggestionActionExecute(Sender: TObject);
+    procedure AddToDictionaryActionExecute(Sender: TObject);
     procedure MainPanelResize(Sender: TObject);
     procedure RefreshActionExecute(Sender: TObject);
     procedure SuggestionsTreeDblClick(Sender: TObject);
@@ -122,7 +125,8 @@ implementation
 uses
   gzctnrVectorTypes,
   uzcdrawing, uzcdrawings, uzcutils, uzeconsts, uzeentity, uzeenttext,
-  uzetypes, uzgldrawcontext, uzvfspellzoom, zUndoCmdSaveEntityState;
+  uzetypes, uzgldrawcontext, uzvfspellzoom, uzvfspelluserdict,
+  zUndoCmdSaveEntityState;
 
 {$R *.lfm}
 
@@ -147,6 +151,8 @@ const
   STR_NO_TEXT_ENTITIES = 'В чертеже нет примитивов TEXT/MTEXT';
   // Сообщение при пустом тексте в найденных примитивах
   STR_NO_TEXT_CONTENT = 'В текстовых примитивах нет текста';
+  // Сообщение при отсутствии выбранного слова для добавления в словарь
+  STR_NO_WORD_SELECTED = 'Выберите слово с ошибкой для добавления в словарь';
 
 function IsSpellTextEntity(EntityPtr: PGDBObjEntity): boolean;
 begin
@@ -697,6 +703,35 @@ end;
 procedure TSpellCheckerForm.ApplySuggestionActionExecute(Sender: TObject);
 begin
   ApplySelectedSuggestion;
+end;
+
+// Обработчик действия "Добавить в словарь":
+// добавить выбранное слово с ошибкой в пользовательский словарь
+procedure TSpellCheckerForm.AddToDictionaryActionExecute(Sender: TObject);
+var
+  errorPtr: PSpellError;
+begin
+  errorPtr := GetFocusedError;
+
+  if not Assigned(errorPtr) then begin
+    SentenceLabel.Caption := STR_NO_WORD_SELECTED;
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.AddToDictionaryActionExecute: no word selected',
+      [], LM_Info);
+    Exit;
+  end;
+
+  if AddWordToUserDictionary(errorPtr^.ErrorWord) then begin
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.AddToDictionaryActionExecute: added "%s"',
+      [errorPtr^.ErrorWord], LM_Info);
+    // Перепроверить чертёж: добавленное слово больше не будет ошибкой
+    CheckCurrentDrawing;
+  end
+  else
+    programlog.LogOutFormatStr(
+      'TSpellCheckerForm.AddToDictionaryActionExecute: failed to add "%s"',
+      [errorPtr^.ErrorWord], LM_Info);
 end;
 
 // Обработчик изменения размера рабочей области

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspelluserdict.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspelluserdict.pas
@@ -1,0 +1,190 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+{
+@author(Vladimir Bobrov)
+}
+
+// Работа с пользовательским словарём орфографии (issue #1296):
+// добавление нового слова в словарь и его создание при необходимости.
+// Словарь хранится в формате hunspell (.dic: первая строка - количество
+// слов, далее сами слова) рядом с парным пустым файлом .aff, как у abbrv.
+
+unit uzvfspelluserdict;
+
+{$mode objfpc}{$H+}
+{$Codepage UTF8}
+
+interface
+
+// Добавить слово в пользовательский словарь. Создаёт словарь, если его нет,
+// и перезагружает SpellChecker, чтобы слово сразу учитывалось.
+// Возвращает True, если слово добавлено (или уже присутствовало).
+function AddWordToUserDictionary(const AWord: string): boolean;
+
+implementation
+
+uses
+  Classes, SysUtils,
+  uzclog,
+  uzcSpeller;
+
+// Прочитать файл как «сырые» байты без перекодировки (словарь в UTF-8).
+// Байты помечаются как UTF-8, чтобы сравнение слов было побайтовым и не
+// зависело от системной кодировки.
+function ReadFileRaw(const AFileName: string): RawByteString;
+var
+  fs: TFileStream;
+begin
+  Result := '';
+  fs := TFileStream.Create(AFileName, fmOpenRead or fmShareDenyWrite);
+  try
+    SetLength(Result, fs.Size);
+    if fs.Size > 0 then
+      fs.ReadBuffer(Result[1], fs.Size);
+  finally
+    fs.Free;
+  end;
+  SetCodePage(Result, CP_UTF8, False);
+end;
+
+// Записать текст в файл как «сырые» байты UTF-8 без BOM.
+procedure WriteFileRaw(const AFileName, AContent: string);
+var
+  fs: TFileStream;
+begin
+  fs := TFileStream.Create(AFileName, fmCreate);
+  try
+    if AContent <> '' then
+      fs.WriteBuffer(AContent[1], Length(AContent));
+  finally
+    fs.Free;
+  end;
+end;
+
+// Является ли строка только цифрами (строка-счётчик в начале .dic).
+function IsAllDigits(const AStr: string): boolean;
+var
+  i: integer;
+begin
+  Result := AStr <> '';
+  for i := 1 to Length(AStr) do
+    if not (AStr[i] in ['0'..'9']) then
+      Exit(False);
+end;
+
+// Загрузить слова из существующего .dic в список (без строки-счётчика,
+// аффиксов после '/' и BOM).
+procedure LoadUserWords(AList: TStringList; const ADicPath: string);
+var
+  src: TStringList;
+  i, slashPos: integer;
+  line: string;
+begin
+  src := TStringList.Create;
+  try
+    src.Text := ReadFileRaw(ADicPath);
+    for i := 0 to src.Count - 1 do begin
+      line := src[i];
+      // Убрать UTF-8 BOM в начале первой строки, если он есть
+      if (i = 0) and (Length(line) >= 3) and (line[1] = #$EF) and
+         (line[2] = #$BB) and (line[3] = #$BF) then
+        Delete(line, 1, 3);
+      line := Trim(line);
+      if line = '' then
+        Continue;
+      // Пропустить строку с количеством слов (первая строка hunspell .dic)
+      if (i = 0) and IsAllDigits(line) then
+        Continue;
+      // Отбросить аффиксы вида слово/FLAGS
+      slashPos := Pos('/', line);
+      if slashPos > 0 then
+        line := Trim(Copy(line, 1, slashPos - 1));
+      if (line <> '') and (AList.IndexOf(line) < 0) then
+        AList.Add(line);
+    end;
+  finally
+    src.Free;
+  end;
+end;
+
+// Сохранить слова в .dic в формате hunspell (счётчик + слова).
+procedure SaveUserWords(AList: TStringList; const ADicPath: string);
+var
+  content: string;
+  i: integer;
+begin
+  content := IntToStr(AList.Count) + LineEnding;
+  for i := 0 to AList.Count - 1 do
+    content := content + AList[i] + LineEnding;
+  WriteFileRaw(ADicPath, content);
+end;
+
+// Создать парный пустой файл .aff, если его нет (требуется hunspell).
+procedure EnsureAffFile(const ADicPath: string);
+var
+  affPath: string;
+begin
+  affPath := ChangeFileExt(ADicPath, '.aff');
+  if not FileExists(affPath) then
+    WriteFileRaw(affPath, '');
+end;
+
+function AddWordToUserDictionary(const AWord: string): boolean;
+var
+  word, dicPath: string;
+  words: TStringList;
+begin
+  Result := False;
+
+  word := Trim(AWord);
+  if word = '' then begin
+    programlog.LogOutStr(
+      'AddWordToUserDictionary: empty word, nothing to add', LM_Warning);
+    Exit;
+  end;
+
+  dicPath := GetUserDictionaryPath;
+  words := TStringList.Create;
+  try
+    words.CaseSensitive := True;
+
+    if FileExists(dicPath) then
+      LoadUserWords(words, dicPath);
+
+    if words.IndexOf(word) >= 0 then begin
+      programlog.LogOutFormatStr(
+        'AddWordToUserDictionary: word "%s" already in dictionary',
+        [word], LM_Info);
+      Result := True;
+      Exit;
+    end;
+
+    words.Add(word);
+    SaveUserWords(words, dicPath);
+    EnsureAffFile(dicPath);
+
+    // Перезагрузить словари, чтобы слово сразу считалось корректным
+    ReloadSpellChecker;
+
+    programlog.LogOutFormatStr(
+      'AddWordToUserDictionary: added word "%s" to "%s"',
+      [word, dicPath], LM_Info);
+    Result := True;
+  finally
+    words.Free;
+  end;
+end;
+
+end.

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspellzoom.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspellzoom.pas
@@ -41,6 +41,10 @@ uses
 
 const
   WORD_VOLUME_PADDING_FACTOR = 0.35;
+  // Коэффициент увеличения размера слова перед зуммированием.
+  // Слово зуммируется так, будто оно в WORD_ZOOM_ENLARGE_FACTOR раз больше,
+  // чтобы зум не был слишком близким (см. issue #1296).
+  WORD_ZOOM_ENLARGE_FACTOR = 3;
 
 function IsZoomTextEntity(EntityPtr: PGDBObjEntity): boolean;
 begin
@@ -146,6 +150,27 @@ begin
     Volume.RTF.y := Point.y;
   if Point.z > Volume.RTF.z then
     Volume.RTF.z := Point.z;
+end;
+
+// Увеличить объём слова относительно его центра в Factor раз,
+// чтобы зум был не таким близким (см. issue #1296).
+procedure EnlargeVolume(var Volume: TBoundingBox; Factor: double);
+var
+  center: TzePoint3d;
+begin
+  if Factor <= 1 then
+    Exit;
+
+  center.x := (Volume.LBN.x + Volume.RTF.x) / 2;
+  center.y := (Volume.LBN.y + Volume.RTF.y) / 2;
+  center.z := (Volume.LBN.z + Volume.RTF.z) / 2;
+
+  Volume.LBN.x := center.x + (Volume.LBN.x - center.x) * Factor;
+  Volume.LBN.y := center.y + (Volume.LBN.y - center.y) * Factor;
+  Volume.LBN.z := center.z + (Volume.LBN.z - center.z) * Factor;
+  Volume.RTF.x := center.x + (Volume.RTF.x - center.x) * Factor;
+  Volume.RTF.y := center.y + (Volume.RTF.y - center.y) * Factor;
+  Volume.RTF.z := center.z + (Volume.RTF.z - center.z) * Factor;
 end;
 
 procedure PadVolume(var Volume: TBoundingBox; Padding: double);
@@ -393,6 +418,7 @@ begin
     Exit;
 
   if TryGetSpellErrorWordVolume(ErrorPtr, volume) then begin
+    EnlargeVolume(volume, WORD_ZOOM_ENLARGE_FACTOR);
     drawings.GetCurrentDWG^.wa.ZoomToVolume(volume);
     programlog.LogOutFormatStr(
       'ZoomToSpellError: zoomed word "%s" at entity position %d',

--- a/experiments/test_userdict_logic.pas
+++ b/experiments/test_userdict_logic.pas
@@ -1,0 +1,189 @@
+// Standalone functional test for the user-dictionary file logic from
+// uzvfspelluserdict.pas (issue #1296). Verifies the hunspell .dic format
+// (count-first), round-trip read, dedup, and empty .aff creation.
+program test_userdict_logic;
+{$mode objfpc}{$H+}
+{$Codepage UTF8}
+
+uses
+  {$IFDEF UNIX}cwstring,{$ENDIF}  // widestring manager, as in the real GUI app
+  Classes, SysUtils;
+
+// --- copied verbatim from uzvfspelluserdict.pas ---
+
+function ReadFileRaw(const AFileName: string): RawByteString;
+var
+  fs: TFileStream;
+begin
+  Result := '';
+  fs := TFileStream.Create(AFileName, fmOpenRead or fmShareDenyWrite);
+  try
+    SetLength(Result, fs.Size);
+    if fs.Size > 0 then
+      fs.ReadBuffer(Result[1], fs.Size);
+  finally
+    fs.Free;
+  end;
+  // Файл словаря в UTF-8: помечаем байты как UTF-8 без перекодировки,
+  // чтобы сравнение слов было побайтовым и не зависело от системной кодировки.
+  SetCodePage(Result, CP_UTF8, False);
+end;
+
+procedure WriteFileRaw(const AFileName, AContent: string);
+var
+  fs: TFileStream;
+begin
+  fs := TFileStream.Create(AFileName, fmCreate);
+  try
+    if AContent <> '' then
+      fs.WriteBuffer(AContent[1], Length(AContent));
+  finally
+    fs.Free;
+  end;
+end;
+
+function IsAllDigits(const AStr: string): boolean;
+var
+  i: integer;
+begin
+  Result := AStr <> '';
+  for i := 1 to Length(AStr) do
+    if not (AStr[i] in ['0'..'9']) then
+      Exit(False);
+end;
+
+procedure LoadUserWords(AList: TStringList; const ADicPath: string);
+var
+  src: TStringList;
+  i, slashPos: integer;
+  line: string;
+begin
+  src := TStringList.Create;
+  try
+    src.Text := ReadFileRaw(ADicPath);
+    for i := 0 to src.Count - 1 do begin
+      line := src[i];
+      if (i = 0) and (Length(line) >= 3) and (line[1] = #$EF) and
+         (line[2] = #$BB) and (line[3] = #$BF) then
+        Delete(line, 1, 3);
+      line := Trim(line);
+      if line = '' then
+        Continue;
+      if (i = 0) and IsAllDigits(line) then
+        Continue;
+      slashPos := Pos('/', line);
+      if slashPos > 0 then
+        line := Trim(Copy(line, 1, slashPos - 1));
+      if (line <> '') and (AList.IndexOf(line) < 0) then
+        AList.Add(line);
+    end;
+  finally
+    src.Free;
+  end;
+end;
+
+procedure SaveUserWords(AList: TStringList; const ADicPath: string);
+var
+  content: string;
+  i: integer;
+begin
+  content := IntToStr(AList.Count) + LineEnding;
+  for i := 0 to AList.Count - 1 do
+    content := content + AList[i] + LineEnding;
+  WriteFileRaw(ADicPath, content);
+end;
+
+procedure EnsureAffFile(const ADicPath: string);
+var
+  affPath: string;
+begin
+  affPath := ChangeFileExt(ADicPath, '.aff');
+  if not FileExists(affPath) then
+    WriteFileRaw(affPath, '');
+end;
+
+// --- test driver ---
+
+var
+  dic, aff, firstLine: string;
+  words: TStringList;
+  failures: integer = 0;
+
+procedure Check(const AName: string; ACond: boolean);
+begin
+  if ACond then
+    writeln('ok   - ', AName)
+  else begin
+    writeln('FAIL - ', AName);
+    Inc(failures);
+  end;
+end;
+
+begin
+  dic := GetTempDir + 'userwords_test.dic';
+  aff := ChangeFileExt(dic, '.aff');
+  if FileExists(dic) then DeleteFile(dic);
+  if FileExists(aff) then DeleteFile(aff);
+
+  // First add: file does not exist yet
+  words := TStringList.Create;
+  words.CaseSensitive := True;
+  if FileExists(dic) then LoadUserWords(words, dic);
+  words.Add('Изврат');
+  SaveUserWords(words, dic);
+  EnsureAffFile(dic);
+  words.Free;
+
+  Check('dic file created', FileExists(dic));
+  Check('aff file created', FileExists(aff));
+  Check('aff file is empty', ReadFileRaw(aff) = '');
+
+  firstLine := ReadFileRaw(dic);
+  Check('first line is the count "1"',
+    Copy(firstLine, 1, 1) = '1');
+
+  // Second add: load existing, add a different word
+  words := TStringList.Create;
+  words.CaseSensitive := True;
+  LoadUserWords(words, dic);
+  Check('existing word loaded back (no count line)', words.Count = 1);
+  Check('loaded word matches', words[0] = 'Изврат');
+
+  words.Add('Перемычка');
+  SaveUserWords(words, dic);
+  words.Free;
+
+  // Reload, verify both present and count line correct
+  words := TStringList.Create;
+  words.CaseSensitive := True;
+  LoadUserWords(words, dic);
+  Check('two words after second add', words.Count = 2);
+  Check('first word present', words.IndexOf('Изврат') >= 0);
+  Check('second word present', words.IndexOf('Перемычка') >= 0);
+
+  firstLine := Trim(Copy(ReadFileRaw(dic), 1, Pos(LineEnding, ReadFileRaw(dic)) - 1));
+  Check('count line equals 2', firstLine = '2');
+
+  // Dedup: adding an already-present word does not duplicate
+  Check('dedup via IndexOf', words.IndexOf('Изврат') >= 0);
+  words.Free;
+
+  // Flags after '/' are stripped on load
+  WriteFileRaw(dic, '1' + LineEnding + 'извещатель/K' + LineEnding);
+  words := TStringList.Create;
+  words.CaseSensitive := True;
+  LoadUserWords(words, dic);
+  Check('affix flags stripped on load', words[0] = 'извещатель');
+  words.Free;
+
+  DeleteFile(dic);
+  DeleteFile(aff);
+
+  writeln;
+  if failures = 0 then
+    writeln('ALL USER-DICT LOGIC TESTS PASSED')
+  else begin
+    writeln(failures, ' TEST(S) FAILED');
+    Halt(1);
+  end;
+end.

--- a/test_issue1296_spellchecker_user_dictionary.py
+++ b/test_issue1296_spellchecker_user_dictionary.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Regression tests for issue #1296.
+
+Two features are covered:
+
+Task 1: Adding a selected error word to a user dictionary (created on demand,
+        saved/loaded the same way and in the same writable folder as panels).
+Task 2: Double-click zoom enlarges the word (as if 3x larger) so the zoom is
+        not too close, with the enlarge coefficient defined as a constant.
+"""
+
+from pathlib import Path
+import re
+
+
+ROOT = Path(__file__).resolve().parent
+SPELL_DIR = ROOT / "cad_source" / "zcad" / "velec" / "uzvfspellchecker"
+FORM_PAS = SPELL_DIR / "uzvfspellform.pas"
+FORM_LFM = SPELL_DIR / "uzvfspellform.lfm"
+ZOOM_PAS = SPELL_DIR / "uzvfspellzoom.pas"
+USERDICT_PAS = SPELL_DIR / "uzvfspelluserdict.pas"
+SPELLER_PAS = ROOT / "cad_source" / "zcad" / "misc" / "uzcspeller.pas"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def extract_routine(source: str, routine_name: str) -> str:
+    pattern = (
+        rf"(?:procedure|function)\s+{re.escape(routine_name)}\b.*?"
+        rf"(?=\nprocedure\s+|\nfunction\s+|\ninitialization|\nfinalization|\Z)"
+    )
+    match = re.search(pattern, source, flags=re.IGNORECASE | re.DOTALL)
+    assert match, f"{routine_name} routine is missing"
+    return match.group(0)
+
+
+# --- Task 2: zoom enlargement ------------------------------------------------
+
+def test_zoom_enlarge_factor_is_a_constant() -> None:
+    zoom_source = read_text(ZOOM_PAS)
+
+    # The size-increase coefficient must be a named constant (per the issue).
+    match = re.search(
+        r"WORD_ZOOM_ENLARGE_FACTOR\s*=\s*([0-9]+)", zoom_source)
+    assert match, "WORD_ZOOM_ENLARGE_FACTOR constant is missing"
+    # The issue asks for a 3x enlargement.
+    assert match.group(1) == "3", "enlarge factor must be 3"
+
+
+def test_zoom_enlarges_word_volume_before_zooming() -> None:
+    zoom_source = read_text(ZOOM_PAS)
+
+    assert "procedure EnlargeVolume" in zoom_source
+
+    # Extract from the implementation section (skip the interface declaration).
+    impl = zoom_source[zoom_source.index("\nimplementation"):]
+    handler = extract_routine(impl, "ZoomToSpellError")
+    # The word volume must be enlarged with the constant before zooming.
+    enlarge_pos = handler.find("EnlargeVolume(volume, WORD_ZOOM_ENLARGE_FACTOR)")
+    zoom_pos = handler.find("wa.ZoomToVolume(volume)")
+    assert enlarge_pos != -1, "ZoomToSpellError must enlarge the word volume"
+    assert zoom_pos != -1, "ZoomToSpellError must zoom to the volume"
+    assert enlarge_pos < zoom_pos, "enlargement must happen before zooming"
+
+
+def test_enlarge_volume_scales_around_center() -> None:
+    zoom_source = read_text(ZOOM_PAS)
+    routine = extract_routine(zoom_source, "EnlargeVolume")
+
+    # Scales the bounding box around its center by Factor.
+    assert "center.x := (Volume.LBN.x + Volume.RTF.x) / 2" in routine
+    assert "(Volume.LBN.x - center.x) * Factor" in routine
+    assert "(Volume.RTF.x - center.x) * Factor" in routine
+
+
+# --- Task 1: user dictionary -------------------------------------------------
+
+def test_user_dictionary_unit_exists() -> None:
+    assert USERDICT_PAS.exists(), "user dictionary logic must live in a unit"
+
+    source = read_text(USERDICT_PAS)
+    assert "unit uzvfspelluserdict;" in source
+    assert "function AddWordToUserDictionary" in source
+
+
+def test_user_dictionary_saved_in_writable_config_like_panels() -> None:
+    speller_source = read_text(SPELLER_PAS)
+
+    # Saved/loaded the same way and folder as panels (GetWritableFilePath +
+    # the dictionaries subfolder), mirroring SaveLayout.
+    assert "function GetUserDictionaryPath" in speller_source
+    speller_impl = speller_source[speller_source.index("\nimplementation"):]
+    path_routine = extract_routine(speller_impl, "GetUserDictionaryPath")
+    assert "GetWritableFilePath" in path_routine
+    assert "CFSdictionariesDir" in path_routine
+    assert "CUserDictionaryFile" in speller_source
+
+
+def test_user_dictionary_uses_hunspell_format_with_aff_pair() -> None:
+    source = read_text(USERDICT_PAS)
+
+    # hunspell .dic: first line is the word count.
+    save_routine = extract_routine(source, "SaveUserWords")
+    assert "IntToStr(AList.Count)" in save_routine
+
+    # A paired (possibly empty) .aff file is required by hunspell.
+    assert "procedure EnsureAffFile" in source
+    aff_routine = extract_routine(source, "EnsureAffFile")
+    assert "ChangeFileExt(ADicPath, '.aff')" in aff_routine
+
+
+def test_add_word_creates_dictionary_and_reloads_speller() -> None:
+    source = read_text(USERDICT_PAS)
+    impl = source[source.index("\nimplementation"):]
+    routine = extract_routine(impl, "AddWordToUserDictionary")
+
+    assert "GetUserDictionaryPath" in routine
+    assert "SaveUserWords" in routine
+    assert "EnsureAffFile" in routine
+    # The new word must be recognized immediately in-session.
+    assert "ReloadSpellChecker" in routine
+
+
+def test_speller_loads_user_dictionary_at_startup_and_reload() -> None:
+    speller_source = read_text(SPELLER_PAS)
+
+    assert "procedure ReloadSpellChecker" in speller_source
+    speller_impl = speller_source[speller_source.index("\nimplementation"):]
+    create_routine = extract_routine(speller_impl, "CreateSpellChecker")
+    # User dictionary is loaded on top of the configured dictionaries.
+    assert "GetUserDictionaryPath" in create_routine
+    assert "LoadDictionary" in create_routine
+
+    reload_routine = extract_routine(speller_impl, "ReloadSpellChecker")
+    assert "DestroySpellChecker" in reload_routine
+    assert "CreateSpellChecker" in reload_routine
+
+
+def test_form_has_add_to_dictionary_action_and_button() -> None:
+    form_source = read_text(FORM_PAS)
+    lfm_source = read_text(FORM_LFM)
+
+    assert "uzvfspelluserdict" in form_source
+    assert "AddToDictionaryAction: TAction" in form_source
+    assert "procedure AddToDictionaryActionExecute(Sender: TObject);" in form_source
+
+    handler = extract_routine(
+        form_source, "TSpellCheckerForm.AddToDictionaryActionExecute")
+    assert "GetFocusedError" in handler
+    assert "AddWordToUserDictionary" in handler
+    # After adding, the drawing is re-checked so the word stops being an error.
+    assert "CheckCurrentDrawing" in handler
+
+    assert "object AddToDictionaryAction: TAction" in lfm_source
+    assert "object AddToDictionaryButton: TToolButton" in lfm_source
+    assert "Action = AddToDictionaryAction" in lfm_source
+
+
+if __name__ == "__main__":
+    test_zoom_enlarge_factor_is_a_constant()
+    test_zoom_enlarges_word_volume_before_zooming()
+    test_enlarge_volume_scales_around_center()
+    test_user_dictionary_unit_exists()
+    test_user_dictionary_saved_in_writable_config_like_panels()
+    test_user_dictionary_uses_hunspell_format_with_aff_pair()
+    test_add_word_creates_dictionary_and_reloads_speller()
+    test_speller_loads_user_dictionary_at_startup_and_reload()
+    test_form_has_add_to_dictionary_action_and_button()
+    print("issue 1296 spellchecker user dictionary checks passed")


### PR DESCRIPTION
## Summary

Implements both parts of issue veb86/zcadvelecAI#1296 for the `uzvfspellchecker` spell-checking panel.

Fixes veb86/zcadvelecAI#1296

### Task 1 — Add a word to a user dictionary

When an error word is selected in the "word with error" panel, a new **«В словарь»** (Add to dictionary) button/action sends that word to a user dictionary. The dictionary is created on demand if it does not exist.

- **Stored like saved panels.** The dictionary is written via `GetWritableFilePath` into the same writable config directory used by `SaveLayout`, under the `dictionaries` subfolder (`CFSdictionariesDir`). This mirrors how ZCAD panels are saved/loaded and keeps the user dictionary alongside the other dictionaries.
- **Hunspell format, like existing dictionaries.** The file is a standard hunspell `.dic` (first line = word count, then one word per line) plus a paired empty `.aff` file — exactly the shape of the existing `abbrv.dic`/`abbrv.aff` dictionary.
- **Recognized immediately.** `uzcspeller` loads the user dictionary at startup and exposes `ReloadSpellChecker`, so a freshly added word stops being flagged in the current session. After adding, the form re-runs `CheckCurrentDrawing`.
- **Robust file handling.** Words are read/written as raw UTF‑8 bytes (no re-encoding), the count header and `word/FLAGS` affixes are stripped on load, duplicates are skipped, and a BOM (if present) is ignored.

New/changed code:
- `cad_source/zcad/velec/uzvfspellchecker/uzvfspelluserdict.pas` *(new)* — `AddWordToUserDictionary`, dictionary read/write/dedup logic, `.aff` creation.
- `cad_source/zcad/misc/uzcspeller.pas` — `GetUserDictionaryPath`, `CUserDictionaryFile='userwords.dic'`, startup load of the user dictionary, and `ReloadSpellChecker`.
- `cad_source/zcad/velec/uzvfspellchecker/uzvfspellform.pas` / `.lfm` — `AddToDictionaryAction` + `AddToDictionaryButton` and the execute handler.

### Task 2 — Soften the double-click zoom

On double-click of an error word the zoom was too close. The word's bounding volume is now enlarged around its center before zooming, as if the word were **3×** larger, so the view is not so tight. Per the issue, the enlargement coefficient is a named constant.

- `cad_source/zcad/velec/uzvfspellchecker/uzvfspellzoom.pas`:
  - `WORD_ZOOM_ENLARGE_FACTOR = 3;` (new constant)
  - `EnlargeVolume(var Volume; Factor)` scales the bounding box about its center.
  - `ZoomToSpellError` calls `EnlargeVolume(volume, WORD_ZOOM_ENLARGE_FACTOR)` right before `wa.ZoomToVolume(volume)`.

**Before:** zoom fit the word's exact bounding box → very close.
**After:** zoom fits a box 3× the word size around the same center → comfortably zoomed out.

## How to reproduce / verify

1. Open the spell-checker panel on a drawing with misspelled text.
2. Select an error word and click **«В словарь»** — the word is written to `…/dictionaries/userwords.dic` (created with a paired `userwords.aff` if missing) and disappears from the error list. It stays recognized on the next launch.
3. Double-click an error word — the view zooms to the word but ~3× wider than before.

## Tests

- `test_issue1296_spellchecker_user_dictionary.py` — source-inspection regression tests (same pattern as the other `test_issue129X_*.py`): verifies the zoom constant = 3, that `ZoomToSpellError` enlarges before zooming, the `EnlargeVolume` center scaling, the user-dict unit/format/`.aff` pairing, the writable-config path, startup + reload loading, and the form action/button wiring. **9 passed.**
- `experiments/test_userdict_logic.pas` — standalone FPC functional test of the dictionary file logic (create, round-trip, dedup, affix-strip, empty `.aff`). **All tests pass.**

> Note: a full GUI build is not feasible in this environment (most submodules are not checked out), so verification relies on the source-inspection tests plus the standalone functional test of the file logic.
