### PR TITLE
uzvfspellchecker: add word to user dictionary + double-click zoom (issue #1296)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ cad_source/zengine/tests/roundtrip1339
 
 # issue #1339 round-trip experiment output
 experiments/out1339/
+
+# Python bytecode cache (pytest):
+__pycache__/
+*.pyc

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-20T19:19:29.553Z for PR creation at branch issue-1296-e4fb5d3e1516 for issue https://github.com/veb86/zcadvelecAI/issues/1296

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-20T19:19:29.553Z for PR creation at branch issue-1296-e4fb5d3e1516 for issue https://github.com/veb86/zcadvelecAI/issues/1296

--- a/cad_source/zcad/misc/uzcspeller.pas
+++ b/cad_source/zcad/misc/uzcspeller.pas
@@ -76,14 +76,28 @@ procedure CreateSpellChecker;
 var
   lph:TLPSHandle;
   UserDict:string;
+  UserDictHandle:TSpeller.TLangHandle;
 begin
-  lph:=LPS.StartLongProcess('SpellChecker.Create and LoadDictionaries',nil);
+  // Путь к пользовательскому словарю показываем в сообщении прогресса,
+  // чтобы было видно, куда сохраняются добавленные слова (см. issue #1296).
+  UserDict:=GetUserDictionaryPath;
+  lph:=LPS.StartLongProcess(
+    'SpellChecker.Create and LoadDictionaries (пользовательский словарь: '+
+    UserDict+')',nil);
   SpellChecker.CreateRec(@SpellLogCallBack);
   SpellChecker.LoadDictionaries(ExpandPath(ZCSysParams.saved.DictionariesPath));
   // Подключить пользовательский словарь, если он уже создан
-  UserDict:=GetUserDictionaryPath;
-  if FileExists(UserDict) then
-    SpellChecker.LoadDictionary(UserDict);
+  if FileExists(UserDict) then begin
+    UserDictHandle:=SpellChecker.LoadDictionary(UserDict);
+    if UserDictHandle=TSpeller.WrongLang then
+      ProgramLog.LogOutStr(
+        'CreateSpellChecker: не удалось загрузить пользовательский словарь "'+
+        UserDict+'"',LM_Warning,LMDSpeller)
+    else
+      ProgramLog.LogOutStr(
+        'CreateSpellChecker: подключён пользовательский словарь "'+
+        UserDict+'"',LM_Info,LMDSpeller);
+  end;
   LPS.EndLongProcess(lph);
 end;
 

--- a/cad_source/zcad/velec/uzvfspellchecker/uzvfspelluserdict.pas
+++ b/cad_source/zcad/velec/uzvfspellchecker/uzvfspelluserdict.pas
@@ -19,7 +19,8 @@
 // Работа с пользовательским словарём орфографии (issue #1296):
 // добавление нового слова в словарь и его создание при необходимости.
 // Словарь хранится в формате hunspell (.dic: первая строка - количество
-// слов, далее сами слова) рядом с парным пустым файлом .aff, как у abbrv.
+// слов, далее сами слова) рядом с парным файлом .aff, который объявляет
+// кодировку UTF-8 (SET UTF-8), чтобы добавленные слова распознавались.
 
 unit uzvfspelluserdict;
 
@@ -39,6 +40,13 @@ uses
   Classes, SysUtils,
   uzclog,
   uzcSpeller;
+
+const
+  // Содержимое парного .aff: словарь хранится в UTF-8, поэтому явно указываем
+  // кодировку директивой SET UTF-8 (как в штатных ru_RU.aff/en_US.aff).
+  // Без неё hunspell считает словарь однобайтовым (ISO8859-1), и в некоторых
+  // сборках добавленное слово не распознаётся (см. issue #1296).
+  CUserDictAffContent = 'SET UTF-8' + LineEnding;
 
 // Прочитать файл как «сырые» байты без перекодировки (словарь в UTF-8).
 // Байты помечаются как UTF-8, чтобы сравнение слов было побайтовым и не
@@ -131,14 +139,24 @@ begin
   WriteFileRaw(ADicPath, content);
 end;
 
-// Создать парный пустой файл .aff, если его нет (требуется hunspell).
+// Прочитать весь файл в строку (или '' если файла нет).
+function ReadFileIfExists(const AFileName: string): RawByteString;
+begin
+  if FileExists(AFileName) then
+    Result := ReadFileRaw(AFileName)
+  else
+    Result := '';
+end;
+
+// Создать/обновить парный файл .aff с указанием кодировки UTF-8.
+// Требуется hunspell; перезаписываем и старые пустые .aff, созданные ранее.
 procedure EnsureAffFile(const ADicPath: string);
 var
   affPath: string;
 begin
   affPath := ChangeFileExt(ADicPath, '.aff');
-  if not FileExists(affPath) then
-    WriteFileRaw(affPath, '');
+  if ReadFileIfExists(affPath) <> CUserDictAffContent then
+    WriteFileRaw(affPath, CUserDictAffContent);
 end;
 
 function AddWordToUserDictionary(const AWord: string): boolean;

--- a/experiments/test_userdict_logic.pas
+++ b/experiments/test_userdict_logic.pas
@@ -1,6 +1,6 @@
 // Standalone functional test for the user-dictionary file logic from
 // uzvfspelluserdict.pas (issue #1296). Verifies the hunspell .dic format
-// (count-first), round-trip read, dedup, and empty .aff creation.
+// (count-first), round-trip read, dedup, and SET UTF-8 .aff creation.
 program test_userdict_logic;
 {$mode objfpc}{$H+}
 {$Codepage UTF8}
@@ -93,13 +93,24 @@ begin
   WriteFileRaw(ADicPath, content);
 end;
 
+const
+  CUserDictAffContent = 'SET UTF-8' + LineEnding;
+
+function ReadFileIfExists(const AFileName: string): RawByteString;
+begin
+  if FileExists(AFileName) then
+    Result := ReadFileRaw(AFileName)
+  else
+    Result := '';
+end;
+
 procedure EnsureAffFile(const ADicPath: string);
 var
   affPath: string;
 begin
   affPath := ChangeFileExt(ADicPath, '.aff');
-  if not FileExists(affPath) then
-    WriteFileRaw(affPath, '');
+  if ReadFileIfExists(affPath) <> CUserDictAffContent then
+    WriteFileRaw(affPath, CUserDictAffContent);
 end;
 
 // --- test driver ---
@@ -136,7 +147,7 @@ begin
 
   Check('dic file created', FileExists(dic));
   Check('aff file created', FileExists(aff));
-  Check('aff file is empty', ReadFileRaw(aff) = '');
+  Check('aff declares SET UTF-8', ReadFileRaw(aff) = 'SET UTF-8' + LineEnding);
 
   firstLine := ReadFileRaw(dic);
   Check('first line is the count "1"',

--- a/test_issue1296_spellchecker_user_dictionary.py
+++ b/test_issue1296_spellchecker_user_dictionary.py
@@ -105,10 +105,24 @@ def test_user_dictionary_uses_hunspell_format_with_aff_pair() -> None:
     save_routine = extract_routine(source, "SaveUserWords")
     assert "IntToStr(AList.Count)" in save_routine
 
-    # A paired (possibly empty) .aff file is required by hunspell.
+    # A paired .aff file is required by hunspell.
     assert "procedure EnsureAffFile" in source
     aff_routine = extract_routine(source, "EnsureAffFile")
     assert "ChangeFileExt(ADicPath, '.aff')" in aff_routine
+
+
+def test_user_dictionary_aff_declares_utf8_encoding() -> None:
+    # The dictionary stores UTF-8 words; the paired .aff must declare the
+    # encoding (SET UTF-8) so hunspell does not fall back to ISO8859-1 and
+    # fail to recognize the added word (issue #1296, follow-up comment 2).
+    source = read_text(USERDICT_PAS)
+
+    match = re.search(r"CUserDictAffContent\s*=\s*'SET UTF-8'", source)
+    assert match, "user .aff must declare SET UTF-8"
+
+    aff_routine = extract_routine(source, "EnsureAffFile")
+    assert "CUserDictAffContent" in aff_routine, (
+        "EnsureAffFile must write the SET UTF-8 affix content")
 
 
 def test_add_word_creates_dictionary_and_reloads_speller() -> None:


### PR DESCRIPTION
## Summary

Implements issue veb86/zcadvelecAI#1296 and addresses the two follow-up review comments from @veb86.

Fixes veb86/zcadvelecAI#1296

### Original tasks (merged earlier via #1348)
1. **User dictionary** — a selected spell-error word can be added to a user dictionary, created on demand and saved/loaded the same way and in the same writable config folder as saved panels (`SaveLayout`).
2. **Double-click zoom** — enlarges the word ~3× so the zoom is not too close; the enlarge coefficient is a named constant `WORD_ZOOM_ENLARGE_FACTOR = 3`.

### Follow-up review fixes (this update)
1. **Show the save path.** The `SpellChecker.Create and LoadDictionaries` progress message now embeds the user dictionary path, so it is visible where added words are stored.
2. **Make the user dictionary actually take effect.** Previously the paired `.aff` was written empty, so hunspell defaulted to ISO8859-1 and (in the bundled Windows build) failed to match the UTF-8 word — pressing *refresh all errors* still flagged the just-added word. The `.aff` is now written with an explicit `SET UTF-8` directive (matching the shipped `ru_RU.aff` / `en_US.aff`). `CreateSpellChecker` additionally logs whether the user dictionary loaded successfully, for diagnosability.

### How to reproduce / verify
- Add a word via the spell-checker panel → it is written to `<writable-config>/dictionaries/userwords.dic` (path shown in the progress message) with a paired `userwords.aff` containing `SET UTF-8`.
- Press *refresh all errors* → the added word is no longer reported as an error (the speller is reloaded in-session).

### Tests
- `test_issue1296_spellchecker_user_dictionary.py` — source-level regression checks (zoom constant, writable-config save path, hunspell `.dic` format, `SET UTF-8` affix, in-session reload, form action/button). 10 tests, all passing.
- `experiments/test_userdict_logic.pas` — standalone FPC functional test of the dictionary file logic (count-first format, round-trip, dedup, `SET UTF-8` `.aff` creation). All checks pass.

> Note for @veb86: the empty-`.aff` failure could not be reproduced on Linux/hunspell 1.7.2 (exact-word matching works regardless of affix encoding there), so this fix targets the encoding ambiguity in the bundled Windows DLL by using the proven shipped `SET UTF-8` format. Please confirm on Windows that the added word is now accepted after *refresh all errors*.

---
*This PR was created automatically by the AI issue solver*
