### PR TITLE
uzvspreadsheet: комбобокс выравнивания текста в ячейке

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-20T21:36:54.329Z for PR creation at branch issue-1352-b4a57179bc49 for issue https://github.com/veb86/zcadvelecAI/issues/1352

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-20T21:36:54.329Z for PR creation at branch issue-1352-b4a57179bc49 for issue https://github.com/veb86/zcadvelecAI/issues/1352

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdalignment.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdalignment.pas
@@ -1,0 +1,278 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+{
+@author(Vladimir Bobrov)
+}
+{$mode objfpc}{$H+}
+
+{** Модуль выравнивания текста внутри ячеек электронной таблицы.
+
+    Содержит логику преобразования между индексом комбобокса выравнивания
+    (9 вариантов: левое/центр/правое × верх/центр/низ) и парой выравниваний
+    fpspreadsheet (TsHorAlignment, TsVertAlignment), а также применение
+    выравнивания к выделенному диапазону и чтение выравнивания активной ячейки.
+
+    Используется модулем формы (uzvspreadsheet_gui) для комбобокса на панели
+    инструментов. Логика преобразования индексов вынесена в отдельные функции,
+    чтобы её можно было покрыть автоматическими тестами. }
+unit uzvspreadsheet_cmdalignment;
+
+{$INCLUDE zengineconfig.inc}
+
+interface
+
+uses
+  Classes,
+  SysUtils,
+  Grids,
+  fpspreadsheet,
+  fpsTypes,
+  fpspreadsheetctrls,
+  fpspreadsheetgrid;
+
+const
+  // Количество вариантов выравнивания в комбобоксе
+  ALIGNMENT_OPTION_COUNT = 9;
+
+  // Подписи вариантов выравнивания в порядке индексов комбобокса.
+  // Порядок: слева направо (левое/центр/правое), сверху вниз (верх/центр/низ).
+  ALIGNMENT_CAPTIONS: array[0..ALIGNMENT_OPTION_COUNT - 1] of string = (
+    'По левому краю вверху',
+    'По центру вверху',
+    'По правому краю вверху',
+    'По левому краю по центру',
+    'По центру по центру',
+    'По правому краю по центру',
+    'По левому краю внизу',
+    'По центру внизу',
+    'По правому краю внизу'
+  );
+
+{ Преобразует индекс комбобокса (0..8) в пару выравниваний fpspreadsheet.
+  Возвращает False, если индекс выходит за допустимые границы. }
+function AlignmentIndexToAlignments(aIndex: Integer;
+  out aHor: TsHorAlignment; out aVert: TsVertAlignment): Boolean;
+
+{ Преобразует пару выравниваний fpspreadsheet в индекс комбобокса (0..8).
+  Значения "по умолчанию" (haDefault/vaDefault) трактуются как левое/верхнее. }
+function AlignmentsToIndex(aHor: TsHorAlignment;
+  aVert: TsVertAlignment): Integer;
+
+{ Заполняет список подписями вариантов выравнивания (для Items комбобокса) }
+procedure FillAlignmentItems(aItems: TStrings);
+
+{ Применяет выбранное выравнивание (по индексу комбобокса) ко всем ячейкам
+  выделенного диапазона таблицы }
+procedure ApplyAlignmentToSelection(aWorkbookSource: TsWorkbookSource;
+  aWorksheetGrid: TsWorksheetGrid; aIndex: Integer);
+
+{ Возвращает индекс комбобокса, соответствующий выравниванию активной ячейки.
+  Если данные недоступны, возвращает 0 (левое/верхнее). }
+function GetActiveCellAlignmentIndex(aWorkbookSource: TsWorkbookSource;
+  aWorksheetGrid: TsWorksheetGrid): Integer;
+
+implementation
+
+uses
+  uzclog,
+  uzcinterface;
+
+{ Группа горизонтального выравнивания: 0 - левое, 1 - центр, 2 - правое }
+function HorToGroup(aHor: TsHorAlignment): Integer;
+begin
+  case aHor of
+    haCenter: Result := 1;
+    haRight:  Result := 2;
+    else      Result := 0;  // haLeft, haDefault
+  end;
+end;
+
+{ Группа вертикального выравнивания: 0 - верх, 1 - центр, 2 - низ }
+function VertToGroup(aVert: TsVertAlignment): Integer;
+begin
+  case aVert of
+    vaCenter: Result := 1;
+    vaBottom: Result := 2;
+    else      Result := 0;  // vaTop, vaDefault
+  end;
+end;
+
+function AlignmentIndexToAlignments(aIndex: Integer;
+  out aHor: TsHorAlignment; out aVert: TsVertAlignment): Boolean;
+const
+  HorByGroup: array[0..2] of TsHorAlignment = (haLeft, haCenter, haRight);
+  VertByGroup: array[0..2] of TsVertAlignment = (vaTop, vaCenter, vaBottom);
+begin
+  aHor := haLeft;
+  aVert := vaTop;
+  Result := (aIndex >= 0) and (aIndex < ALIGNMENT_OPTION_COUNT);
+  if not Result then
+    Exit;
+
+  aHor := HorByGroup[aIndex mod 3];
+  aVert := VertByGroup[aIndex div 3];
+end;
+
+function AlignmentsToIndex(aHor: TsHorAlignment;
+  aVert: TsVertAlignment): Integer;
+begin
+  Result := VertToGroup(aVert) * 3 + HorToGroup(aHor);
+end;
+
+procedure FillAlignmentItems(aItems: TStrings);
+var
+  i: Integer;
+begin
+  if aItems = nil then
+    Exit;
+
+  aItems.BeginUpdate;
+  try
+    aItems.Clear;
+    for i := 0 to ALIGNMENT_OPTION_COUNT - 1 do
+      aItems.Add(ALIGNMENT_CAPTIONS[i]);
+  finally
+    aItems.EndUpdate;
+  end;
+end;
+
+{ Возвращает выделенный диапазон в координатах листа (без фиксированных
+  заголовков) с упорядоченными границами. False, если диапазон некорректен. }
+function GetNormalizedSelection(aWorksheetGrid: TsWorksheetGrid;
+  out aStartRow, aEndRow, aStartCol, aEndCol: Integer): Boolean;
+var
+  selection: TGridRect;
+  temp: Integer;
+begin
+  Result := False;
+  aStartRow := 0;
+  aEndRow := 0;
+  aStartCol := 0;
+  aEndCol := 0;
+
+  if aWorksheetGrid = nil then
+    Exit;
+
+  selection := aWorksheetGrid.Selection;
+
+  aStartRow := selection.Top - aWorksheetGrid.FixedRows;
+  aEndRow := selection.Bottom - aWorksheetGrid.FixedRows;
+  aStartCol := selection.Left - aWorksheetGrid.FixedCols;
+  aEndCol := selection.Right - aWorksheetGrid.FixedCols;
+
+  if aStartRow > aEndRow then
+  begin
+    temp := aStartRow;
+    aStartRow := aEndRow;
+    aEndRow := temp;
+  end;
+
+  if aStartCol > aEndCol then
+  begin
+    temp := aStartCol;
+    aStartCol := aEndCol;
+    aEndCol := temp;
+  end;
+
+  Result := (aStartRow >= 0) and (aStartCol >= 0) and
+            (aEndRow >= aStartRow) and (aEndCol >= aStartCol);
+end;
+
+procedure ApplyAlignmentToSelection(aWorkbookSource: TsWorkbookSource;
+  aWorksheetGrid: TsWorksheetGrid; aIndex: Integer);
+var
+  worksheet: TsWorksheet;
+  hor: TsHorAlignment;
+  vert: TsVertAlignment;
+  startRow, endRow, startCol, endCol: Integer;
+  row, col: Integer;
+begin
+  if (aWorkbookSource = nil) or (aWorksheetGrid = nil) then
+    Exit;
+
+  if aWorkbookSource.Workbook = nil then
+    Exit;
+
+  worksheet := aWorkbookSource.Workbook.ActiveWorksheet;
+  if worksheet = nil then
+    Exit;
+
+  if not AlignmentIndexToAlignments(aIndex, hor, vert) then
+    Exit;
+
+  if not GetNormalizedSelection(aWorksheetGrid, startRow, endRow,
+    startCol, endCol) then
+    Exit;
+
+  try
+    for row := startRow to endRow do
+      for col := startCol to endCol do
+      begin
+        worksheet.WriteHorAlignment(Cardinal(row), Cardinal(col), hor);
+        worksheet.WriteVertAlignment(Cardinal(row), Cardinal(col), vert);
+      end;
+
+    programlog.LogOutFormatStr(
+      'Выравнивание ячеек [%d,%d]-[%d,%d] изменено на "%s"',
+      [startRow, startCol, endRow, endCol, ALIGNMENT_CAPTIONS[aIndex]],
+      LM_Info
+    );
+  except
+    on E: Exception do
+    begin
+      programlog.LogOutFormatStr(
+        'Ошибка изменения выравнивания: %s',
+        [E.Message],
+        LM_Error
+      );
+      zcUI.TextMessage('Ошибка изменения выравнивания: ' + E.Message,
+        TMWOHistoryOut);
+    end;
+  end;
+end;
+
+function GetActiveCellAlignmentIndex(aWorkbookSource: TsWorkbookSource;
+  aWorksheetGrid: TsWorksheetGrid): Integer;
+var
+  worksheet: TsWorksheet;
+  cell: PCell;
+  row, col: Integer;
+begin
+  Result := 0;
+
+  if (aWorkbookSource = nil) or (aWorksheetGrid = nil) then
+    Exit;
+
+  if aWorkbookSource.Workbook = nil then
+    Exit;
+
+  worksheet := aWorkbookSource.Workbook.ActiveWorksheet;
+  if worksheet = nil then
+    Exit;
+
+  row := aWorksheetGrid.Row - aWorksheetGrid.FixedRows;
+  col := aWorksheetGrid.Col - aWorksheetGrid.FixedCols;
+  if (row < 0) or (col < 0) then
+    Exit;
+
+  cell := worksheet.FindCell(Cardinal(row), Cardinal(col));
+  if cell = nil then
+    Exit;
+
+  Result := AlignmentsToIndex(worksheet.ReadHorAlignment(cell),
+    worksheet.ReadVertAlignment(cell));
+end;
+
+end.

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
@@ -77,6 +77,12 @@ type
     // Панель инструментов
     FToolBar: TToolBar;
 
+    // Комбобокс выбора выравнивания текста внутри ячейки
+    FAlignmentCombo: TComboBox;
+    // Флаг: комбобокс выравнивания обновляется программно (не реагировать
+    // на OnChange, чтобы не перезаписывать выравнивание выделенной ячейки)
+    FUpdatingAlignmentCombo: Boolean;
+
     // Действия и построитель панели инструментов по реестру команд
     FActionList: TActionList;
     FCommandBar: TSpreadsheetCommandBar;
@@ -91,9 +97,15 @@ type
     // Процедуры создания компонентов
     procedure CreatePanels;
     procedure CreateToolBar;
+    procedure CreateAlignmentCombo;
     procedure CreateSpreadsheetComponents;
     procedure CreateCellInfoPanel;
     procedure BuildCommandBar;
+
+    // Обработчик изменения выравнивания через комбобокс
+    procedure OnAlignmentComboChange(Sender: TObject);
+    // Обновляет комбобокс выравнивания по выделенной ячейке
+    procedure UpdateAlignmentCombo;
 
     // Обработчики событий
     procedure OnWorksheetGridSelection(Sender: TObject;
@@ -139,6 +151,7 @@ implementation
 uses
   uzclog,
   uzcinterface,
+  uzvspreadsheet_cmdalignment,
   uzvspreadsheet_cmdundoredo;
 
 { TuzvSpreadsheetForm }
@@ -152,6 +165,7 @@ begin
   FEditingRow := 0;
   FEditingCol := 0;
   FUndoSavedForCurrentEdit := False;
+  FUpdatingAlignmentCombo := False;
 
   // Настройка основных параметров формы
   Caption := 'Электронные таблицы / Spreadsheet';
@@ -167,6 +181,9 @@ begin
   // Панель инструментов строится по реестру команд после создания
   // компонентов таблицы, чтобы передать их в контекст команд
   BuildCommandBar;
+  // Комбобокс выравнивания добавляется после кнопок команд, чтобы
+  // располагаться в конце панели инструментов
+  CreateAlignmentCombo;
 
   zcUI.TextMessage('Форма электронных таблиц создана', TMWOHistoryOut);
 end;
@@ -238,6 +255,32 @@ begin
   FToolBar.Images := ImagesManager.IconList;  // Устанавливаем список иконок
   FToolBar.ButtonWidth := 28;
   FToolBar.ButtonHeight := 28;
+end;
+
+{ Создание комбобокса выбора выравнивания текста внутри ячейки.
+  Размещается на панели инструментов после кнопок команд. Показывает текущее
+  выравнивание выделенной ячейки и применяет выбранное выравнивание к
+  выделенному диапазону. }
+procedure TuzvSpreadsheetForm.CreateAlignmentCombo;
+var
+  Separator: TToolButton;
+begin
+  // Разделитель между кнопками команд и комбобоксом выравнивания
+  Separator := TToolButton.Create(FToolBar);
+  Separator.Parent := FToolBar;
+  Separator.Style := tbsSeparator;
+  Separator.Width := 10;
+
+  // Комбобокс выравнивания (только выбор из списка)
+  FAlignmentCombo := TComboBox.Create(Self);
+  FAlignmentCombo.Parent := FToolBar;
+  FAlignmentCombo.Style := csDropDownList;
+  FAlignmentCombo.Width := 180;
+  FAlignmentCombo.Hint := 'Выравнивание текста внутри ячейки';
+  FAlignmentCombo.ShowHint := True;
+  FillAlignmentItems(FAlignmentCombo.Items);
+  FAlignmentCombo.ItemIndex := 0;
+  FAlignmentCombo.OnChange := @OnAlignmentComboChange;
 end;
 
 { Создание панели информации о ячейке }
@@ -448,6 +491,49 @@ begin
     cellContent := '';
 
   FEditCellContent.Text := cellContent;
+
+  // Синхронизируем комбобокс выравнивания с выделенной ячейкой
+  UpdateAlignmentCombo;
+end;
+
+{ Обновление комбобокса выравнивания по выделенной ячейке }
+procedure TuzvSpreadsheetForm.UpdateAlignmentCombo;
+var
+  index: Integer;
+begin
+  if FAlignmentCombo = nil then
+    Exit;
+
+  index := GetActiveCellAlignmentIndex(FWorkbookSource, FWorksheetGrid);
+
+  // Устанавливаем индекс программно, не вызывая обработчик OnChange
+  FUpdatingAlignmentCombo := True;
+  try
+    FAlignmentCombo.ItemIndex := index;
+  finally
+    FUpdatingAlignmentCombo := False;
+  end;
+end;
+
+{ Обработчик изменения выравнивания через комбобокс }
+procedure TuzvSpreadsheetForm.OnAlignmentComboChange(Sender: TObject);
+begin
+  // Игнорируем программное обновление индекса (синхронизация с ячейкой)
+  if FUpdatingAlignmentCombo then
+    Exit;
+
+  if FAlignmentCombo = nil then
+    Exit;
+
+  ApplyAlignmentToSelection(FWorkbookSource, FWorksheetGrid,
+    FAlignmentCombo.ItemIndex);
+
+  // Принудительно перерисовываем таблицу, чтобы изменения стали видны
+  if FWorksheetGrid <> nil then
+  begin
+    FWorksheetGrid.Invalidate;
+    FWorksheetGrid.SetFocus;
+  end;
 end;
 
 { Применение содержимого из поля редактирования к ячейке }

--- a/experiments/test_alignment_mapping.pas
+++ b/experiments/test_alignment_mapping.pas
@@ -1,0 +1,150 @@
+{ Standalone test for the spreadsheet cell alignment combobox mapping logic
+  (issue #1352).
+
+  fpspreadsheet is not installed in this environment, so this program
+  replicates the enum order from fpsTypes:
+      TsHorAlignment  = (haDefault, haLeft, haCenter, haRight);
+      TsVertAlignment = (vaDefault, vaTop, vaCenter, vaBottom);
+  and the exact mapping logic implemented in
+  cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdalignment.pas.
+
+  It verifies:
+    * each of the 9 combobox indices maps to the expected (hor, vert) pair,
+    * AlignmentsToIndex is the inverse of AlignmentIndexToAlignments,
+    * "default" alignments are treated as left/top,
+    * out-of-range indices are rejected.
+
+  Build & run:
+    fpc -Mobjfpc experiments/test_alignment_mapping.pas && ./experiments/test_alignment_mapping
+}
+program test_alignment_mapping;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils;
+
+type
+  // Mirror of fpsTypes enums (same declaration order!)
+  TsHorAlignment = (haDefault, haLeft, haCenter, haRight);
+  TsVertAlignment = (vaDefault, vaTop, vaCenter, vaBottom);
+
+const
+  ALIGNMENT_OPTION_COUNT = 9;
+
+{ ---- logic copied verbatim from uzvspreadsheet_cmdalignment.pas ---- }
+
+function HorToGroup(aHor: TsHorAlignment): Integer;
+begin
+  case aHor of
+    haCenter: Result := 1;
+    haRight:  Result := 2;
+    else      Result := 0;  // haLeft, haDefault
+  end;
+end;
+
+function VertToGroup(aVert: TsVertAlignment): Integer;
+begin
+  case aVert of
+    vaCenter: Result := 1;
+    vaBottom: Result := 2;
+    else      Result := 0;  // vaTop, vaDefault
+  end;
+end;
+
+function AlignmentIndexToAlignments(aIndex: Integer;
+  out aHor: TsHorAlignment; out aVert: TsVertAlignment): Boolean;
+const
+  HorByGroup: array[0..2] of TsHorAlignment = (haLeft, haCenter, haRight);
+  VertByGroup: array[0..2] of TsVertAlignment = (vaTop, vaCenter, vaBottom);
+begin
+  aHor := haLeft;
+  aVert := vaTop;
+  Result := (aIndex >= 0) and (aIndex < ALIGNMENT_OPTION_COUNT);
+  if not Result then
+    Exit;
+  aHor := HorByGroup[aIndex mod 3];
+  aVert := VertByGroup[aIndex div 3];
+end;
+
+function AlignmentsToIndex(aHor: TsHorAlignment;
+  aVert: TsVertAlignment): Integer;
+begin
+  Result := VertToGroup(aVert) * 3 + HorToGroup(aHor);
+end;
+
+{ ---- test harness ---- }
+
+var
+  Failures: Integer = 0;
+
+procedure Check(aCondition: Boolean; const aMsg: string);
+begin
+  if aCondition then
+    WriteLn('  ok  : ', aMsg)
+  else
+  begin
+    WriteLn('  FAIL: ', aMsg);
+    Inc(Failures);
+  end;
+end;
+
+procedure ExpectMapping(aIndex: Integer; aHor: TsHorAlignment;
+  aVert: TsVertAlignment; const aName: string);
+var
+  hor: TsHorAlignment;
+  vert: TsVertAlignment;
+begin
+  Check(AlignmentIndexToAlignments(aIndex, hor, vert), aName + ': valid index');
+  Check((hor = aHor) and (vert = aVert), aName + ': index -> alignments');
+  Check(AlignmentsToIndex(aHor, aVert) = aIndex, aName + ': alignments -> index');
+end;
+
+var
+  i: Integer;
+  hor: TsHorAlignment;
+  vert: TsVertAlignment;
+begin
+  WriteLn('Testing alignment mapping (issue #1352)');
+
+  // Order required by the issue: left/center/right x top/center/bottom
+  ExpectMapping(0, haLeft,   vaTop,    'left-top');
+  ExpectMapping(1, haCenter, vaTop,    'center-top');
+  ExpectMapping(2, haRight,  vaTop,    'right-top');
+  ExpectMapping(3, haLeft,   vaCenter, 'left-center');
+  ExpectMapping(4, haCenter, vaCenter, 'center-center');
+  ExpectMapping(5, haRight,  vaCenter, 'right-center');
+  ExpectMapping(6, haLeft,   vaBottom, 'left-bottom');
+  ExpectMapping(7, haCenter, vaBottom, 'center-bottom');
+  ExpectMapping(8, haRight,  vaBottom, 'right-bottom');
+
+  // Round-trip for every valid index
+  for i := 0 to ALIGNMENT_OPTION_COUNT - 1 do
+  begin
+    AlignmentIndexToAlignments(i, hor, vert);
+    Check(AlignmentsToIndex(hor, vert) = i,
+      Format('round-trip index %d', [i]));
+  end;
+
+  // Defaults are treated as left/top -> index 0
+  Check(AlignmentsToIndex(haDefault, vaDefault) = 0,
+    'haDefault/vaDefault -> index 0');
+  Check(AlignmentsToIndex(haDefault, vaCenter) = 3,
+    'haDefault/vaCenter -> index 3 (left-center)');
+  Check(AlignmentsToIndex(haRight, vaDefault) = 2,
+    'haRight/vaDefault -> index 2 (right-top)');
+
+  // Out-of-range indices are rejected
+  Check(not AlignmentIndexToAlignments(-1, hor, vert), 'reject index -1');
+  Check(not AlignmentIndexToAlignments(ALIGNMENT_OPTION_COUNT, hor, vert),
+    'reject index 9');
+
+  WriteLn;
+  if Failures = 0 then
+    WriteLn('ALL TESTS PASSED')
+  else
+  begin
+    WriteLn(Failures, ' TEST(S) FAILED');
+    Halt(1);
+  end;
+end.


### PR DESCRIPTION
## Что сделано

Добавлен комбобокс выбора выравнивания текста в ячейке на существующую панель инструментов редактора электронных таблиц (`cad_source/zcad/velec/uzvspreadsheet/`).

Закрывает #1352.

### Поведение
- Комбобокс содержит ровно 9 вариантов выравнивания в порядке из задачи:
  1. По левому краю вверху
  2. По центру вверху
  3. По правому краю вверху
  4. По левому краю по центру
  5. По центру по центру
  6. По правому краю по центру
  7. По левому краю внизу
  8. По центру внизу
  9. По правому краю внизу
- Комбобокс **отображает** фактическое выравнивание активной ячейки (синхронизируется при смене выделения).
- Изменение комбобокса **применяет** выбранное выравнивание ко всем ячейкам выделенного диапазона.

## Реализация

- **`uzvspreadsheet_cmdalignment.pas`** (новый модуль) — вся логика выравнивания:
  - `AlignmentIndexToAlignments` / `AlignmentsToIndex` — отображение индекса комбобокса (0..8) ↔ пара `TsHorAlignment`/`TsVertAlignment` fpspreadsheet (`index = вертГруппа*3 + горГруппа`).
  - `FillAlignmentItems` — заполнение списка подписями.
  - `ApplyAlignmentToSelection` — запись `WriteHorAlignment`/`WriteVertAlignment` по всем ячейкам нормализованного выделения.
  - `GetActiveCellAlignmentIndex` — чтение выравнивания активной ячейки (`ReadHorAlignment`/`ReadVertAlignment`).
  - Логика преобразования индексов вынесена в отдельный модуль, чтобы покрыть её автотестом.
- **`uzvspreadsheet_gui.pas`** — комбобокс создаётся на панели инструментов после `BuildCommandBar` (встаёт в конец панели), синхронизируется из `UpdateCellInfo`, применяет выравнивание в `OnAlignmentComboChange`. Программная установка `ItemIndex` защищена флагом `FUpdatingAlignmentCombo`, чтобы не вызвать ложный `OnChange`.

## Как проверить

1. Открыть редактор электронных таблиц в ZCAD.
2. На панели инструментов появится комбобокс выравнивания (в конце панели).
3. Выделить ячейку — комбобокс показывает её текущее выравнивание.
4. Выбрать вариант в комбобоксе — выравнивание текста в выделенных ячейках меняется.

## Тесты

`experiments/test_alignment_mapping.pas` — автономный тест логики отображения индекс ↔ выравнивание (повторяет порядок enum'ов fpsTypes, т.к. пакет fpspreadsheet не установлен в окружении сборки). Проверяет все 9 соответствий, обратимость, обработку значений «по умолчанию» и отклонение индексов вне диапазона.

```
fpc -Mobjfpc experiments/test_alignment_mapping.pas && ./experiments/test_alignment_mapping
...
ALL TESTS PASSED
```

> Примечание: полная сборка проекта в окружении невозможна (пакет fpspreadsheet не установлен; CI собирает только документацию). Используемые API (`WriteHorAlignment`, `ReadHorAlignment`, и т.д.) сверены с исходниками fpspreadsheet.



Fixes veb86/zcadvelecAI#1352