### PR TITLE
uzvspreadsheet. Добавить команду создать таблицу GDBObjAcadTable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T13:30:34.175Z for PR creation at branch issue-1357-bb55aee785e4 for issue https://github.com/veb86/zcadvelecAI/issues/1357

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T13:30:34.175Z for PR creation at branch issue-1357-bb55aee785e4 for issue https://github.com/veb86/zcadvelecAI/issues/1357

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -116,6 +116,11 @@ type
     FCellTexts: TTableTextArray;
     // Признак того, что геометрия уже была построена
     FGeometryBuilt: Boolean;
+    // Если True — при рендеринге все строки используют базовый стиль Data
+    // (issue #1357). В этой задаче программно созданная из редактора
+    // электронных таблиц таблица состоит только из ячеек данных; отдельное
+    // отображение строк Title/Header добавят будущие задачи.
+    FForceDataStyleAllRows: Boolean;
     // Хэндл DXF-стиля таблицы (group code 342)
     FTableStyleHandle: String;
     // Флаги свойств таблицы (group code 90)
@@ -344,6 +349,16 @@ type
     function SetTableStyleName(
       const AValue: String; var ADrawing: TDrawingDef): Boolean; virtual;
     procedure SetDXFRawEntityText(const ARawText: string); virtual;
+    // Программно строит таблицу из текстов ячеек редактора электронных
+    // таблиц (issue #1357). Все ячейки имеют тип cdtText и оформляются
+    // стилем Data, объединения отсутствуют. ACellTexts индексируется как
+    // строка*AColCount + столбец; недостающие тексты считаются пустыми.
+    // Высоты строк и ширины столбцов берутся по умолчанию. Возвращает
+    // True при успешном построении непустой таблицы.
+    function BuildFromCellTexts(
+      ARowCount, AColCount: Integer;
+      const ACellTexts: TTableTextArray;
+      const AInsertPoint: TzePoint3d): Boolean; virtual;
 
     // Публичные свойства для инспектора объектов
     property InsertPoint: TzePoint3d read FInsertPoint;
@@ -352,6 +367,9 @@ type
     property Width: Double read GetTotalWidth;
     property Height: Double read GetTotalHeight;
     property TableStyleName: String read GetTableStyleName;
+    // Если True — все строки таблицы отображаются стилем Data (issue #1357).
+    property ForceDataStyleForAllRows: Boolean
+      read FForceDataStyleAllRows write FForceDataStyleAllRows;
     // Признак разрыва вычисляется: учитывает как DXF-флаг, так и
     // поглощённые части-продолжения (issue #1305, часть 2a). Запись
     // в False объединяет разорванную таблицу сверху вниз (часть 2b).
@@ -501,6 +519,101 @@ begin
   Result := True;
 end;
 
+function GDBObjAcadTable.BuildFromCellTexts(
+  ARowCount, AColCount: Integer;
+  const ACellTexts: TTableTextArray;
+  const AInsertPoint: TzePoint3d): Boolean;
+var
+  RowIdx, ColIdx, CellIndex: Integer;
+begin
+  Result := False;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: BuildFromCellTexts START rows=%d cols=%d texts=%d',
+    [ARowCount, AColCount, Length(ACellTexts)], LM_Info);
+
+  if (ARowCount <= 0) or (AColCount <= 0) then
+  begin
+    programlog.LogOutStr(
+      'AcadTable: model: BuildFromCellTexts — пустые размеры таблицы',
+      LM_Info);
+    Exit;
+  end;
+
+  if ARowCount > CAcadTableMaxDimension then
+    ARowCount := CAcadTableMaxDimension;
+  if AColCount > CAcadTableMaxDimension then
+    AColCount := CAcadTableMaxDimension;
+
+  FInsertPoint := AInsertPoint;
+  Local.P_insert := FInsertPoint;
+  FRowCount := ARowCount;
+  FColCount := AColCount;
+
+  // Высоты строк и ширины столбцов — значения по умолчанию
+  for RowIdx := 0 to FRowCount - 1 do
+    FRowHeights.PushBackData(CAcadTableDefaultRowHeight);
+  for ColIdx := 0 to FColCount - 1 do
+    FColWidths.PushBackData(CAcadTableDefaultColWidth);
+
+  // Тексты ячеек: индекс = строка*FColCount + столбец
+  System.SetLength(FCellTexts, FRowCount * FColCount);
+  for CellIndex := 0 to High(FCellTexts) do
+    if CellIndex <= High(ACellTexts) then
+      FCellTexts[CellIndex] := ACellTexts[CellIndex]
+    else
+      FCellTexts[CellIndex] := '';
+
+  // Инициализируем табличный стиль значениями по умолчанию (стиль Standard
+  // присваивается командой через SetTableStyleName)
+  InitTableStyle(FTableStyle);
+
+  // Все строки отображаются как данные (Title/Header в этой задаче нет)
+  FForceDataStyleAllRows := True;
+
+  // Инициализируем строки, столбцы и ячейки (все ячейки — текстовые)
+  System.SetLength(FRows, FRowCount);
+  for RowIdx := 0 to FRowCount - 1 do
+  begin
+    FRows[RowIdx].Height := GetRowHeightLocal(RowIdx);
+    InitCellStyle(FRows[RowIdx].Style);
+  end;
+
+  System.SetLength(FCols, FColCount);
+  for ColIdx := 0 to FColCount - 1 do
+  begin
+    FCols[ColIdx].Width := GetColWidthLocal(ColIdx);
+    InitCellStyle(FCols[ColIdx].Style);
+  end;
+
+  System.SetLength(FCells, FRowCount, FColCount);
+  for RowIdx := 0 to FRowCount - 1 do
+    for ColIdx := 0 to FColCount - 1 do
+    begin
+      FCells[RowIdx][ColIdx].DataType := cdtText;
+      FCells[RowIdx][ColIdx].Text := GetCellTextLocal(RowIdx, ColIdx);
+      FCells[RowIdx][ColIdx].Value := 0;
+      FCells[RowIdx][ColIdx].Formula := '';
+      FCells[RowIdx][ColIdx].BlockName := '';
+      FCells[RowIdx][ColIdx].CellAlignment := 0;
+      FCells[RowIdx][ColIdx].ColSpan := 1;
+      FCells[RowIdx][ColIdx].RowSpan := 1;
+      InitCellStyle(FCells[RowIdx][ColIdx].Style);
+    end;
+
+  // Программно созданная таблица не содержит объединений ячеек
+  System.SetLength(FMerges, 0);
+
+  FGeometryBuilt := False;
+  InvalidateRawDXFEntity;
+
+  programlog.LogOutFormatStr(
+    'AcadTable: model: BuildFromCellTexts END rows=%d cols=%d cells=%d',
+    [FRowCount, FColCount, Length(FCellTexts)], LM_Info);
+
+  Result := True;
+end;
+
 function GDBObjAcadTable.GetCellTextLocal(
   RowIdx, ColIdx: Integer): String;
 var
@@ -527,6 +640,7 @@ begin
   FColWidths.initnul;
   System.SetLength(FCellTexts, 0);
   FGeometryBuilt := False;
+  FForceDataStyleAllRows := False;
   FTableStyleHandle := '';
   FTableFlags := 0;
   FBreakEnabled := False;
@@ -833,6 +947,7 @@ var
   SegmentOffsetX, SegmentOffsetY: Double;
   MergeRootPt: TPoint;
   InlineBreakEnabled: Boolean;
+  StyleRowIndex: Integer;
 begin
   programlog.LogOutFormatStr(
     'AcadTable: model: RenderCurrentTable START ' +
@@ -1041,8 +1156,16 @@ begin
 
         if CellStr <> '' then
         begin
+          // По умолчанию базовый стиль строки выбирается по её позиции
+          // (0=Title, 1=Header, >=2=Data). Для программно созданной из
+          // редактора таблицы (issue #1357) все строки оформляются как
+          // данные — принудительно используем индекс строки данных.
+          if FForceDataStyleAllRows then
+            StyleRowIndex := 2
+          else
+            StyleRowIndex := ARowBaseIndex + RowIdx;
           CellStyleLocal := uzeacadtable_cell.ResolveCellStyleForBaseRow(
-            ARowBaseIndex + RowIdx, RowIdx, ColIdx, FTableStyle,
+            StyleRowIndex, RowIdx, ColIdx, FTableStyle,
             FRows, FCols, FCells,
             FRowCount, FColCount, FTableFlags);
 

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
@@ -1,0 +1,404 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+{
+@author(Vladimir Bobrov)
+}
+{$mode objfpc}{$H+}
+
+{** Модуль команды создания таблицы ACAD_TABLE (GDBObjAcadTable) из редактора
+    электронных таблиц на чертёж (issue #1357).
+
+    Команда анализирует заполненную часть активного листа книги, строит по её
+    содержимому AutoCAD-совместимую таблицу ACAD_TABLE со стилем "Standard" и
+    помещает её на чертёж. В этой задаче все ячейки оформляются как данные
+    (Data); отдельное отображение строк заголовка/названия (Title/Header)
+    добавят будущие задачи. }
+unit uzvspreadsheet_cmdcreateacadtable;
+
+{$INCLUDE zengineconfig.inc}
+
+interface
+
+uses
+  Classes,
+  SysUtils,
+  fpspreadsheet,
+  fpsTypes,
+  fpspreadsheetctrls,
+  fpspreadsheetgrid,
+  uzccommandsabstract,
+  uzccommandsimpl,
+  uzccommandsmanager,
+  uzcdrawings,
+  uzcinterface,
+  uzcutils,
+  uzcstrconsts,
+  uzeacadtable_types,
+  uzeacadtable_model,
+  uzestylestablesdxf,
+  uzeentsubordinated,
+  uzeconsts,
+  uzeTypes,
+  uzegeometry,
+  uzgldrawcontext,
+  uzvspreadsheet_gui;
+
+const
+  // Имя стиля таблицы по умолчанию для создаваемой ACAD_TABLE (issue #1357)
+  ACADTABLE_DEFAULT_STYLE = 'Standard';
+  // Максимальное количество строк/столбцов для проверки заполненности
+  MAX_CHECK_ROWS = 500;
+  MAX_CHECK_COLS = 50;
+
+// Команда создания таблицы ACAD_TABLE из редактора на чертёж
+// @param Context - контекст выполнения команды
+// @param operands - операнды команды
+// @return результат выполнения команды
+function CreateAcadTableFromEditor_com(
+  const Context: TZCADCommandContext;
+  operands: TCommandOperands
+): TCommandResult;
+
+implementation
+
+uses
+  uzclog,
+  uzvspreadsheet_cmdregistry;
+
+// Находит последнюю заполненную строку в листе
+// @param worksheet - рабочий лист
+// @return индекс последней заполненной строки (0-based) или 0 если пусто
+function FindLastFilledRow(worksheet: TsWorksheet): Cardinal;
+var
+  row, col: Cardinal;
+  cell: PCell;
+  maxRow: Cardinal;
+  content: string;
+begin
+  Result := 0;
+  maxRow := 0;
+
+  if worksheet = nil then
+    Exit;
+
+  for row := 0 to MAX_CHECK_ROWS do
+    for col := 0 to MAX_CHECK_COLS do
+    begin
+      cell := worksheet.FindCell(row, col);
+      if cell <> nil then
+      begin
+        content := worksheet.ReadAsText(cell);
+        if Trim(content) <> '' then
+          if row > maxRow then
+            maxRow := row;
+      end;
+    end;
+
+  Result := maxRow;
+end;
+
+// Находит последний заполненный столбец в листе
+// @param worksheet - рабочий лист
+// @return индекс последнего заполненного столбца (0-based) или 0 если пусто
+function FindLastFilledCol(worksheet: TsWorksheet): Cardinal;
+var
+  row, col: Cardinal;
+  cell: PCell;
+  maxCol: Cardinal;
+  content: string;
+begin
+  Result := 0;
+  maxCol := 0;
+
+  if worksheet = nil then
+    Exit;
+
+  for col := 0 to MAX_CHECK_COLS do
+    for row := 0 to MAX_CHECK_ROWS do
+    begin
+      cell := worksheet.FindCell(row, col);
+      if cell <> nil then
+      begin
+        content := worksheet.ReadAsText(cell);
+        if Trim(content) <> '' then
+          if col > maxCol then
+            maxCol := col;
+      end;
+    end;
+
+  Result := maxCol;
+end;
+
+// Гарантирует наличие стиля таблицы DXF с заданным именем в текущем чертеже.
+// Если стиль отсутствует, создаёт его (со значениями по умолчанию).
+procedure EnsureDXFTableStyle(const AStyleName: string);
+var
+  styleTable: PGDBDXFTableStyleArray;
+begin
+  styleTable := @drawings.GetCurrentDWG^.DXFTableStyleTable;
+  styleTable^.AddStyle(AStyleName);
+end;
+
+// Создаёт таблицу ACAD_TABLE (GDBObjAcadTable) из данных редактора в
+// конструктивной области чертежа.
+// @param worksheet - рабочий лист с данными
+// @param lastRow - последняя заполненная строка (0-based)
+// @param lastCol - последний заполненный столбец (0-based)
+// @return указатель на созданный объект таблицы или nil при ошибке
+function CreateAcadTableFromWorksheet(
+  worksheet: TsWorksheet;
+  lastRow: Cardinal;
+  lastCol: Cardinal
+): PGDBObjAcadTable;
+var
+  pt: PGDBObjAcadTable;
+  row, col: Cardinal;
+  cell: PCell;
+  texts: TTableTextArray;
+  rowCount, colCount: Integer;
+  insPt: TzePoint3d;
+  dc: TDrawContext;
+begin
+  Result := nil;
+
+  if worksheet = nil then
+  begin
+    programlog.LogOutFormatStr(
+      'CreateAcadTableFromWorksheet: worksheet is nil', [], LM_Info);
+    Exit;
+  end;
+
+  // Проверяем, есть ли данные для построения
+  if (lastRow = 0) and (lastCol = 0) then
+  begin
+    cell := worksheet.FindCell(0, 0);
+    if (cell = nil) or (Trim(worksheet.ReadAsText(cell)) = '') then
+    begin
+      programlog.LogOutFormatStr(
+        'CreateAcadTableFromWorksheet: no data to build', [], LM_Info);
+      Exit;
+    end;
+  end;
+
+  rowCount := Integer(lastRow) + 1;
+  colCount := Integer(lastCol) + 1;
+
+  // Собираем тексты ячеек: индекс = строка*colCount + столбец
+  SetLength(texts, rowCount * colCount);
+  for row := 0 to lastRow do
+    for col := 0 to lastCol do
+    begin
+      cell := worksheet.FindCell(row, col);
+      if cell <> nil then
+        texts[Integer(row) * colCount + Integer(col)] :=
+          worksheet.ReadAsText(cell)
+      else
+        texts[Integer(row) * colCount + Integer(col)] := '';
+    end;
+
+  // Создаём сущность и помещаем её в конструктивный root чертежа
+  pt := AllocAndInitAcadTable(
+    PGDBObjGenericWithSubordinated(@drawings.CurrentDWG^.ConstructObjRoot));
+  drawings.CurrentDWG^.ConstructObjRoot.ObjArray.AddPEntity(pt^);
+
+  // Строим таблицу из текстов ячеек (точка вставки временная, нулевая —
+  // окончательное положение пользователь укажет при перемещении из root)
+  insPt := NulVertex;
+  if not pt^.BuildFromCellTexts(rowCount, colCount, texts, insPt) then
+  begin
+    programlog.LogOutFormatStr(
+      'CreateAcadTableFromWorksheet: BuildFromCellTexts failed', [], LM_Info);
+    Exit;
+  end;
+
+  // Гарантируем наличие и применяем стиль "Standard" (issue #1357).
+  // Если применение не удалось, остаётся стиль по умолчанию из
+  // InitTableStyle, который также даёт корректную равномерную геометрию.
+  EnsureDXFTableStyle(ACADTABLE_DEFAULT_STYLE);
+  if not pt^.SetTableStyleName(ACADTABLE_DEFAULT_STYLE,
+       drawings.GetCurrentDWG^) then
+    programlog.LogOutFormatStr(
+      'CreateAcadTableFromWorksheet: style "%s" not applied, using default',
+      [ACADTABLE_DEFAULT_STYLE], LM_Info);
+
+  // Строим геометрию таблицы в конструктивном root
+  dc := drawings.GetCurrentDWG^.CreateDrawingRC;
+  pt^.FormatEntity(drawings.GetCurrentDWG^, dc);
+
+  programlog.LogOutFormatStr(
+    'CreateAcadTableFromWorksheet: created ACAD_TABLE %d rows, %d cols',
+    [rowCount, colCount], LM_Info);
+
+  Result := pt;
+end;
+
+// Перемещает таблицу из конструктивного root в чертёж с запросом точки вставки
+// @return True если пользователь указал точку и таблица успешно вставлена
+function MoveAcadTableToDrawingInteractive: Boolean;
+begin
+  Result := False;
+
+  if commandmanager.MoveConstructRootTo(rscmSpecifyFirstPoint) = IRNormal then
+  begin
+    zcMoveEntsFromConstructRootToCurrentDrawingWithUndo('CreateAcadTable');
+    programlog.LogOutFormatStr(
+      'MoveAcadTableToDrawingInteractive: table inserted successfully',
+      [], LM_Info);
+    Result := True;
+  end
+  else
+    programlog.LogOutFormatStr(
+      'MoveAcadTableToDrawingInteractive: user cancelled insertion',
+      [], LM_Info);
+end;
+
+// Создаёт таблицу из редактора и помещает её в конструктивную область чертежа.
+// Возвращает количество строк и столбцов через параметры.
+// @return True если таблица успешно создана в конструктивной области
+function BuildAcadTableInConstructRoot(out lastRow, lastCol: Cardinal): Boolean;
+var
+  workbookSource: TsWorkbookSource;
+  worksheet: TsWorksheet;
+begin
+  Result := False;
+  lastRow := 0;
+  lastCol := 0;
+
+  // Проверяем, открыта ли форма редактора
+  if uzvSpreadsheetForm = nil then
+  begin
+    zcUI.TextMessage('Ошибка: редактор таблиц не открыт.', TMWOHistoryOut);
+    Exit;
+  end;
+
+  // Получаем источник данных книги
+  workbookSource := uzvSpreadsheetForm.FWorkbookSource;
+  if workbookSource = nil then
+  begin
+    zcUI.TextMessage(
+      'Ошибка: источник данных книги не инициализирован', TMWOHistoryOut);
+    Exit;
+  end;
+
+  // Получаем активный рабочий лист
+  worksheet := workbookSource.Workbook.ActiveWorksheet;
+  if worksheet = nil then
+  begin
+    zcUI.TextMessage('Ошибка: активный лист не найден', TMWOHistoryOut);
+    Exit;
+  end;
+
+  // Определяем заполненный диапазон
+  lastRow := FindLastFilledRow(worksheet);
+  lastCol := FindLastFilledCol(worksheet);
+
+  programlog.LogOutFormatStr(
+    'BuildAcadTableInConstructRoot: filled range rows 0..%d, cols 0..%d',
+    [lastRow, lastCol], LM_Info);
+
+  // Проверяем, есть ли данные
+  if (lastRow = 0) and (lastCol = 0) then
+  begin
+    if worksheet.FindCell(0, 0) = nil then
+    begin
+      zcUI.TextMessage(
+        'Таблица пуста. Нет данных для создания.', TMWOHistoryOut);
+      Exit;
+    end;
+  end;
+
+  // Создаём таблицу ACAD_TABLE из данных редактора в конструктивном root
+  if CreateAcadTableFromWorksheet(worksheet, lastRow, lastCol) = nil then
+  begin
+    zcUI.TextMessage(
+      'Ошибка: не удалось создать таблицу из данных редактора',
+      TMWOHistoryOut);
+    Exit;
+  end;
+
+  Result := True;
+end;
+
+// Основная функция команды создания таблицы ACAD_TABLE
+function CreateAcadTableFromEditor_com(
+  const Context: TZCADCommandContext;
+  operands: TCommandOperands
+): TCommandResult;
+var
+  lastRow, lastCol: Cardinal;
+begin
+  Result := cmd_ok;
+
+  programlog.LogOutFormatStr(
+    'CreateAcadTableFromEditor_com: command started', [], LM_Info);
+
+  // Создаём таблицу в конструктивной области
+  if not BuildAcadTableInConstructRoot(lastRow, lastCol) then
+  begin
+    Result := cmd_cancel;
+    Exit;
+  end;
+
+  // Предлагаем пользователю указать точку вставки и перемещаем таблицу
+  if MoveAcadTableToDrawingInteractive then
+  begin
+    zcUI.TextMessage(
+      Format('Таблица ACAD_TABLE создана (%d строк, %d столбцов)',
+        [lastRow + 1, lastCol + 1]),
+      TMWOHistoryOut);
+    zcRedrawCurrentDrawing;
+  end
+  else
+    Result := cmd_cancel;
+
+  programlog.LogOutFormatStr(
+    'CreateAcadTableFromEditor_com: command finished', [], LM_Info);
+end;
+
+{ Обработчик команды "Создать таблицу ACAD_TABLE" для реестра команд.
+  Выполняет зарегистрированную в ZCAD команду. }
+procedure CommandCreateAcadTable(const Context: TSpreadsheetCommandContext);
+begin
+  commandmanager.executecommand(
+    'CreateAcadTableFromEditor',
+    drawings.GetCurrentDWG,
+    drawings.GetCurrentOGLWParam
+  );
+end;
+
+initialization
+  // Регистрируем команду в системе ZCAD
+  CreateZCADCommand(
+    @CreateAcadTableFromEditor_com,
+    'CreateAcadTableFromEditor',
+    CADWG,
+    0
+  );
+
+  programlog.LogOutFormatStr(
+    'Команда CreateAcadTableFromEditor зарегистрирована', [], LM_Info);
+
+  // Регистрируем кнопку команды в редакторе электронных таблиц
+  RegisterSpreadsheetCommand(
+    'CreateAcadTable',
+    'Создать таблицу ACAD_TABLE',
+    'Создать таблицу ACAD_TABLE из редактора на чертёж',
+    'velec/table_insert',
+    @CommandCreateAcadTable,
+    161,
+    6
+  );
+
+end.

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_commands.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_commands.pas
@@ -46,7 +46,8 @@ uses
   uzvspreadsheet_cmdrowcolumns,
   uzvspreadsheet_cmdmergecells,
   uzvspreadsheet_cmdfillspaceroom,
-  uzvspreadsheet_cmdinserttable;
+  uzvspreadsheet_cmdinserttable,
+  uzvspreadsheet_cmdcreateacadtable;
 
 implementation
 

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -143,6 +143,12 @@ type
     // должны получать свежие хэндлы из общего счётчика документа, а
     // round-trip XRECORD (360/361/330) — ссылаться на эти же новые хэндлы.
     procedure RenumbersRawAcadTableEntityHandlesToAvoidCollision;
+    // issue #1357: программное построение ACAD_TABLE из текстов ячеек
+    // (как при вставке из редактора электронных таблиц) должно задавать
+    // размеры таблицы и отрисовывать текст каждой непустой ячейки.
+    procedure BuildsAcadTableFromCellTexts;
+    // issue #1357: пустой диапазон не создаёт таблицу.
+    procedure BuildFromCellTextsRejectsEmptyDimensions;
   end;
 
 implementation
@@ -2120,6 +2126,79 @@ begin
     'Round-trip не должен ссылаться на исходный хэндл EB');
   CheckEquals(0, CountDxfPairs(DXFText, '330', '54C'),
     'Round-trip не должен ссылаться на исходный хэндл продолжения 54C');
+end;
+
+procedure TAcadTableStyleTest.BuildsAcadTableFromCellTexts;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  InsertPt: TzePoint3d;
+  Ok: Boolean;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    // Заполненный диапазон 2 строки × 3 столбца. Часть ячеек пустые,
+    // чтобы проверить, что отрисовывается только непустой текст.
+    System.SetLength(Texts, 6);
+    Texts[0] := 'A1'; Texts[1] := 'B1'; Texts[2] := 'C1';
+    Texts[3] := 'A2'; Texts[4] := '';   Texts[5] := 'C2';
+
+    InsertPt := NulVertex;
+    Ok := Table^.BuildFromCellTexts(2, 3, Texts, InsertPt);
+    CheckTrue(Ok, 'BuildFromCellTexts должен успешно построить таблицу');
+
+    CheckEquals(2, Table^.RowCount,
+      'Число строк должно соответствовать заполненному диапазону');
+    CheckEquals(3, Table^.ColCount,
+      'Число столбцов должно соответствовать заполненному диапазону');
+    CheckTrue(Table^.ForceDataStyleForAllRows,
+      'Все строки должны оформляться стилем Data (issue #1357)');
+
+    // Строим геометрию и проверяем, что текст каждой непустой ячейки
+    // отрисован ровно один раз, а пустая ячейка текста не создаёт.
+    Table^.BuildGeometry(Drawing);
+    CheckEquals(1, CountMTextByTemplate(Table^.ConstObjArray, 'A1'),
+      'Ячейка A1 должна быть отрисована');
+    CheckEquals(1, CountMTextByTemplate(Table^.ConstObjArray, 'C2'),
+      'Ячейка C2 должна быть отрисована');
+    CheckEquals(0, CountMTextByTemplate(Table^.ConstObjArray, ''),
+      'Пустая ячейка не должна создавать текст');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.BuildFromCellTextsRejectsEmptyDimensions;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  InsertPt: TzePoint3d;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 0);
+    InsertPt := NulVertex;
+    CheckFalse(Table^.BuildFromCellTexts(0, 0, Texts, InsertPt),
+      'Пустой диапазон не должен создавать таблицу');
+    CheckEquals(0, Table^.RowCount,
+      'У не построенной таблицы число строк должно остаться 0');
+    CheckEquals(0, Table^.ColCount,
+      'У не построенной таблицы число столбцов должно остаться 0');
+  finally
+    Drawing.done;
+  end;
 end;
 
 begin


### PR DESCRIPTION
## Summary

Implements issue #1357: adds a command to the **uzvspreadsheet** (spreadsheet editor) that creates an AutoCAD-compatible **ACAD_TABLE** entity (`GDBObjAcadTable`) on the drawing, sized to the **filled** part of the active worksheet.

The command:
1. Detects the filled cell range of the active worksheet (last filled row/column).
2. Builds a `GDBObjAcadTable` with the **"Standard"** DXF table style.
3. Renders **every cell** with the **Data** cell style (per this issue's scope).
4. Places the table in the construct root and lets the user pick the insertion point interactively (same UX as the existing "Insert table" command).

> Per the issue, separate Header/Title row display is intentionally **out of scope** and left for a future task — for now all cells use the Data style.

## Changes

- **`uzeacadtable_model.pas`** — new public construction API `BuildFromCellTexts(rows, cols, cellTexts, insertPoint)` (mirrors the DXF load path) plus a `ForceDataStyleForAllRows` flag. When set, `RenderCurrentTable` forces every cell to resolve with the Data-row style (row index 2), surviving the table-style re-apply during `BuildGeometry`.
- **`uzvspreadsheet_cmdcreateacadtable.pas`** — new command unit (`CreateAcadTableFromEditor`). Modeled on the proven `uzvspreadsheet_cmdinserttable` unit. Ensures the "Standard" DXF table style exists, builds the table from worksheet texts, and moves it into the drawing interactively. Self-registers a ZCAD command and a spreadsheet toolbar button via its `initialization` section.
- **`uzvspreadsheet_commands.pas`** — adds the new unit to the assembly `uses` clause so its registration runs.
- **`uzctacadtable.pas`** — fpcunit tests.

## How to reproduce / verify manually

1. Open the spreadsheet editor in ZCAD, fill some cells (e.g. a 2×3 block).
2. Run the new command (toolbar button "Создать таблицу ACAD_TABLE" or command `CreateAcadTableFromEditor`).
3. Pick an insertion point — an ACAD_TABLE matching the filled range appears, all cells in Data style, "Standard" table style.

## Automated tests (`uzctacadtable.pas`)

- `BuildsAcadTableFromCellTexts` — builds a 2×3 table from cell texts (`A1,B1,C1,A2,'',C2`), asserts `RowCount`/`ColCount`, that `ForceDataStyleForAllRows` is set, and after `BuildGeometry` that each non-empty cell produced exactly one MText with the expected text (and empty cells produced none).
- `BuildFromCellTextsRejectsEmptyDimensions` — `BuildFromCellTexts(0,0,…)` returns `False` and leaves `RowCount`/`ColCount` at 0.

Closes #1357
