### PR TITLE
uzvspreadsheet. Развитие команды создать таблицу GDBObjAcadTable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T14:52:58.183Z for PR creation at branch issue-1359-912c8204b45b for issue https://github.com/veb86/zcadvelecAI/issues/1359

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T14:52:58.183Z for PR creation at branch issue-1359-912c8204b45b for issue https://github.com/veb86/zcadvelecAI/issues/1359

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -359,6 +359,17 @@ type
       ARowCount, AColCount: Integer;
       const ACellTexts: TTableTextArray;
       const AInsertPoint: TzePoint3d): Boolean; virtual;
+    // Расширенный вариант построения таблицы из текстов ячеек с явным
+    // указанием ширин столбцов и высот строк в единицах чертежа (issue
+    // #1359). AColWidths индексируется по столбцам, ARowHeights — по
+    // строкам. Если размер отсутствует или не положителен, берётся
+    // значение по умолчанию. BuildFromCellTexts делегирует сюда с
+    // пустыми массивами размеров. Возвращает True при успехе.
+    function BuildFromCellTextsWithSizes(
+      ARowCount, AColCount: Integer;
+      const ACellTexts: TTableTextArray;
+      const AColWidths, ARowHeights: TTableSizeArray;
+      const AInsertPoint: TzePoint3d): Boolean; virtual;
 
     // Публичные свойства для инспектора объектов
     property InsertPoint: TzePoint3d read FInsertPoint;
@@ -524,6 +535,32 @@ function GDBObjAcadTable.BuildFromCellTexts(
   const ACellTexts: TTableTextArray;
   const AInsertPoint: TzePoint3d): Boolean;
 var
+  EmptySizes: TTableSizeArray;
+begin
+  // Делегируем расширенному варианту без явных размеров — все ширины
+  // столбцов и высоты строк будут взяты по умолчанию.
+  System.SetLength(EmptySizes, 0);
+  Result := BuildFromCellTextsWithSizes(ARowCount, AColCount, ACellTexts,
+    EmptySizes, EmptySizes, AInsertPoint);
+end;
+
+{ Возвращает размер из массива по индексу, либо значение по умолчанию,
+  если индекс вне диапазона или размер не положителен. }
+function SizeOrDefault(const ASizes: TTableSizeArray;
+  AIndex: Integer; ADefault: Double): Double;
+begin
+  if (AIndex >= 0) and (AIndex <= High(ASizes)) and (ASizes[AIndex] > 0) then
+    Result := ASizes[AIndex]
+  else
+    Result := ADefault;
+end;
+
+function GDBObjAcadTable.BuildFromCellTextsWithSizes(
+  ARowCount, AColCount: Integer;
+  const ACellTexts: TTableTextArray;
+  const AColWidths, ARowHeights: TTableSizeArray;
+  const AInsertPoint: TzePoint3d): Boolean;
+var
   RowIdx, ColIdx, CellIndex: Integer;
 begin
   Result := False;
@@ -550,11 +587,14 @@ begin
   FRowCount := ARowCount;
   FColCount := AColCount;
 
-  // Высоты строк и ширины столбцов — значения по умолчанию
+  // Высоты строк и ширины столбцов: берём из переданных массивов,
+  // при отсутствии значения — по умолчанию (issue #1359).
   for RowIdx := 0 to FRowCount - 1 do
-    FRowHeights.PushBackData(CAcadTableDefaultRowHeight);
+    FRowHeights.PushBackData(
+      SizeOrDefault(ARowHeights, RowIdx, CAcadTableDefaultRowHeight));
   for ColIdx := 0 to FColCount - 1 do
-    FColWidths.PushBackData(CAcadTableDefaultColWidth);
+    FColWidths.PushBackData(
+      SizeOrDefault(AColWidths, ColIdx, CAcadTableDefaultColWidth));
 
   // Тексты ячеек: индекс = строка*FColCount + столбец
   System.SetLength(FCellTexts, FRowCount * FColCount);

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
@@ -166,6 +166,10 @@ type
   TTableColumnArray = array of TTableColumn;
   TMergeRangeArray = array of TMergeRange;
   TTableTextArray = array of String;
+  // Массив размеров (ширин столбцов или высот строк) в единицах чертежа.
+  // Используется для переноса размеров ячеек из электронной таблицы
+  // (TsWorksheet) в таблицу ACAD_TABLE при её создании (issue #1359).
+  TTableSizeArray = array of Double;
 
 implementation
 

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
@@ -53,6 +53,7 @@ uses
   uzeTypes,
   uzegeometry,
   uzgldrawcontext,
+  uzvspreadsheet_dimensions,
   uzvspreadsheet_gui;
 
 const
@@ -167,6 +168,7 @@ var
   row, col: Cardinal;
   cell: PCell;
   texts: TTableTextArray;
+  colWidths, rowHeights: TTableSizeArray;
   rowCount, colCount: Integer;
   insPt: TzePoint3d;
   dc: TDrawContext;
@@ -208,15 +210,22 @@ begin
         texts[Integer(row) * colCount + Integer(col)] := '';
     end;
 
+  // Собираем ширины столбцов и высоты строк листа в единицах чертежа,
+  // чтобы перенести их в таблицу ACAD_TABLE (issue #1359)
+  colWidths := CollectColWidths(worksheet, colCount);
+  rowHeights := CollectRowHeights(worksheet, rowCount);
+
   // Создаём сущность и помещаем её в конструктивный root чертежа
   pt := AllocAndInitAcadTable(
     PGDBObjGenericWithSubordinated(@drawings.CurrentDWG^.ConstructObjRoot));
   drawings.CurrentDWG^.ConstructObjRoot.ObjArray.AddPEntity(pt^);
 
-  // Строим таблицу из текстов ячеек (точка вставки временная, нулевая —
-  // окончательное положение пользователь укажет при перемещении из root)
+  // Строим таблицу из текстов ячеек с переносом размеров столбцов/строк
+  // (точка вставки временная, нулевая — окончательное положение
+  // пользователь укажет при перемещении из root)
   insPt := NulVertex;
-  if not pt^.BuildFromCellTexts(rowCount, colCount, texts, insPt) then
+  if not pt^.BuildFromCellTextsWithSizes(rowCount, colCount, texts,
+       colWidths, rowHeights, insPt) then
   begin
     programlog.LogOutFormatStr(
       'CreateAcadTableFromWorksheet: BuildFromCellTexts failed', [], LM_Info);

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
@@ -1,0 +1,168 @@
+{
+*****************************************************************************
+*                                                                           *
+*  This file is part of the ZCAD                                            *
+*                                                                           *
+*  See the file COPYING.txt, included in this distribution,                 *
+*  for details about the copyright.                                         *
+*                                                                           *
+*  This program is distributed in the hope that it will be useful,          *
+*  but WITHOUT ANY WARRANTY; without even the implied warranty of           *
+*  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.                     *
+*                                                                           *
+*****************************************************************************
+}
+{
+@author(Vladimir Bobrov)
+}
+{$mode objfpc}{$H+}
+
+{** Модуль связывания размеров ячеек электронной таблицы (TsWorksheet)
+    с размерами ячеек таблицы ACAD_TABLE (GDBObjAcadTable), issue #1359.
+
+    Содержит:
+    - константу масштаба перевода размеров листа в единицы чертежа;
+    - функции преобразования "лист <-> ACAD" для одного размера;
+    - чтение/запись ширины столбца и высоты строки активной ячейки листа
+      в миллиметрах;
+    - сбор массивов ширин столбцов и высот строк в единицах чертежа для
+      передачи в GDBObjAcadTable.BuildFromCellTextsWithSizes.
+
+    Логика вынесена отдельно от формы (uzvspreadsheet_gui) и команды
+    (uzvspreadsheet_cmdcreateacadtable), чтобы её можно было покрыть
+    автоматическими тестами. Размеры листа читаются в миллиметрах
+    (suMillimeters); единицы по умолчанию у книги fpspreadsheet —
+    миллиметры, поэтому перенос в чертёж выполняется один к одному. }
+unit uzvspreadsheet_dimensions;
+
+{$INCLUDE zengineconfig.inc}
+
+interface
+
+uses
+  SysUtils,
+  fpspreadsheet,
+  fpsTypes,
+  uzeacadtable_types;
+
+const
+  // Масштаб перевода размера ячейки листа (мм) в единицы чертежа ACAD.
+  // По умолчанию 1:1 — чертёж ведётся в миллиметрах. Значение вынесено
+  // в именованную константу, чтобы при необходимости поменять связь.
+  CWorksheetToAcadScale = 1.0;
+
+{ Переводит размер ячейки листа (в миллиметрах) в размер ячейки таблицы
+  ACAD (в единицах чертежа). }
+function WorksheetToAcadSize(AWorksheetMM: Double): Double;
+
+{ Переводит размер ячейки таблицы ACAD (единицы чертежа) обратно в размер
+  ячейки листа (в миллиметрах). }
+function AcadToWorksheetSize(AAcadSize: Double): Double;
+
+{ Возвращает ширину столбца листа в миллиметрах. Если данные недоступны,
+  возвращает 0. }
+function GetWorksheetColWidthMM(AWorksheet: TsWorksheet; ACol: Integer): Double;
+
+{ Возвращает высоту строки листа в миллиметрах. Если данные недоступны,
+  возвращает 0. }
+function GetWorksheetRowHeightMM(AWorksheet: TsWorksheet; ARow: Integer): Double;
+
+{ Задаёт ширину столбца листа в миллиметрах. Возвращает False, если данные
+  недоступны или значение не положительно. }
+function SetWorksheetColWidthMM(AWorksheet: TsWorksheet;
+  ACol: Integer; AWidthMM: Double): Boolean;
+
+{ Задаёт высоту строки листа в миллиметрах. Возвращает False, если данные
+  недоступны или значение не положительно. }
+function SetWorksheetRowHeightMM(AWorksheet: TsWorksheet;
+  ARow: Integer; AHeightMM: Double): Boolean;
+
+{ Собирает ширины столбцов листа в единицах чертежа (для передачи в
+  GDBObjAcadTable.BuildFromCellTextsWithSizes). }
+function CollectColWidths(AWorksheet: TsWorksheet;
+  AColCount: Integer): TTableSizeArray;
+
+{ Собирает высоты строк листа в единицах чертежа. }
+function CollectRowHeights(AWorksheet: TsWorksheet;
+  ARowCount: Integer): TTableSizeArray;
+
+implementation
+
+function WorksheetToAcadSize(AWorksheetMM: Double): Double;
+begin
+  Result := AWorksheetMM * CWorksheetToAcadScale;
+end;
+
+function AcadToWorksheetSize(AAcadSize: Double): Double;
+begin
+  if CWorksheetToAcadScale = 0 then
+    Result := AAcadSize
+  else
+    Result := AAcadSize / CWorksheetToAcadScale;
+end;
+
+function GetWorksheetColWidthMM(AWorksheet: TsWorksheet; ACol: Integer): Double;
+begin
+  Result := 0;
+  if (AWorksheet = nil) or (ACol < 0) then
+    Exit;
+  Result := AWorksheet.GetColWidth(Cardinal(ACol), suMillimeters);
+end;
+
+function GetWorksheetRowHeightMM(AWorksheet: TsWorksheet; ARow: Integer): Double;
+begin
+  Result := 0;
+  if (AWorksheet = nil) or (ARow < 0) then
+    Exit;
+  Result := AWorksheet.GetRowHeight(Cardinal(ARow), suMillimeters);
+end;
+
+function SetWorksheetColWidthMM(AWorksheet: TsWorksheet;
+  ACol: Integer; AWidthMM: Double): Boolean;
+begin
+  Result := False;
+  if (AWorksheet = nil) or (ACol < 0) or (AWidthMM <= 0) then
+    Exit;
+  AWorksheet.WriteColWidth(Cardinal(ACol), AWidthMM, suMillimeters);
+  Result := True;
+end;
+
+function SetWorksheetRowHeightMM(AWorksheet: TsWorksheet;
+  ARow: Integer; AHeightMM: Double): Boolean;
+begin
+  Result := False;
+  if (AWorksheet = nil) or (ARow < 0) or (AHeightMM <= 0) then
+    Exit;
+  AWorksheet.WriteRowHeight(Cardinal(ARow), AHeightMM, suMillimeters);
+  Result := True;
+end;
+
+function CollectColWidths(AWorksheet: TsWorksheet;
+  AColCount: Integer): TTableSizeArray;
+var
+  ColIdx: Integer;
+begin
+  System.SetLength(Result, 0);
+  if (AWorksheet = nil) or (AColCount <= 0) then
+    Exit;
+  System.SetLength(Result, AColCount);
+  for ColIdx := 0 to AColCount - 1 do
+    Result[ColIdx] :=
+      WorksheetToAcadSize(GetWorksheetColWidthMM(AWorksheet, ColIdx));
+end;
+
+function CollectRowHeights(AWorksheet: TsWorksheet;
+  ARowCount: Integer): TTableSizeArray;
+var
+  RowIdx: Integer;
+begin
+  System.SetLength(Result, 0);
+  if (AWorksheet = nil) or (ARowCount <= 0) then
+    Exit;
+  System.SetLength(Result, ARowCount);
+  for RowIdx := 0 to ARowCount - 1 do
+    Result[RowIdx] :=
+      WorksheetToAcadSize(GetWorksheetRowHeightMM(AWorksheet, RowIdx));
+end;
+
+end.

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
@@ -55,6 +55,12 @@ const
   SPREADSHEET_PANEL_CONTROL = 'SpreadSheet_PanelControl';
   SPREADSHEET_PANEL_SHEET = 'SpreadSheet_PanelSheet';
 
+  // Размеры полей размеров ячейки на панели инструментов (issue #1359)
+  DIMENSION_LABEL_WIDTH = 90;   // Ширина подписи поля
+  DIMENSION_EDIT_WIDTH = 55;    // Ширина одного поля ввода значения
+  // Формат вывода размеров (мм / единицы чертежа) с двумя знаками
+  DIMENSION_VALUE_FORMAT = '%.2f';
+
 type
   { TuzvSpreadsheetForm }
   { Главная форма модуля визуализации электронных таблиц }
@@ -83,6 +89,17 @@ type
     // на OnChange, чтобы не перезаписывать выравнивание выделенной ячейки)
     FUpdatingAlignmentCombo: Boolean;
 
+    // Поля размеров ячейки (issue #1359). Каждое поле состоит из двух
+    // значений: размер в листе (TsWorksheet, мм, редактируемый) и размер
+    // в таблице ACAD_TABLE (GDBObjAcadTable, единицы чертежа, только чтение).
+    FEditColWidthWS: TEdit;     // Ширина столбца в листе (мм)
+    FEditColWidthAcad: TEdit;   // Ширина столбца в таблице ACAD
+    FEditRowHeightWS: TEdit;    // Высота строки в листе (мм)
+    FEditRowHeightAcad: TEdit;  // Высота строки в таблице ACAD
+    // Флаг: поля размеров обновляются программно (не записывать изменения
+    // обратно в лист при синхронизации с выделенной ячейкой)
+    FUpdatingDimensionFields: Boolean;
+
     // Действия и построитель панели инструментов по реестру команд
     FActionList: TActionList;
     FCommandBar: TSpreadsheetCommandBar;
@@ -98,6 +115,11 @@ type
     procedure CreatePanels;
     procedure CreateToolBar;
     procedure CreateAlignmentCombo;
+    procedure CreateDimensionFields;
+    // Вспомогательные конструкторы элементов панели размеров (issue #1359)
+    function CreateToolbarLabel(const ACaption: String): TLabel;
+    function CreateDimensionEdit(AReadOnly: Boolean;
+      const AHint: String): TEdit;
     procedure CreateSpreadsheetComponents;
     procedure CreateCellInfoPanel;
     procedure BuildCommandBar;
@@ -106,6 +128,21 @@ type
     procedure OnAlignmentComboChange(Sender: TObject);
     // Обновляет комбобокс выравнивания по выделенной ячейке
     procedure UpdateAlignmentCombo;
+
+    // Обновляет поля размеров (ширина столбца/высота строки) по выделенной
+    // ячейке: значения листа и соответствующие значения таблицы ACAD
+    procedure UpdateDimensionFields;
+    // Применяет введённую ширину столбца к листу
+    procedure OnColWidthEditExit(Sender: TObject);
+    procedure OnColWidthKeyPress(Sender: TObject; var Key: Char);
+    // Применяет введённую высоту строки к листу
+    procedure OnRowHeightEditExit(Sender: TObject);
+    procedure OnRowHeightKeyPress(Sender: TObject; var Key: Char);
+    // Записывает ширину столбца / высоту строки из полей в лист
+    procedure ApplyColWidthFromField;
+    procedure ApplyRowHeightFromField;
+    // Возвращает активный лист книги либо nil
+    function GetActiveWorksheet: TsWorksheet;
 
     // Обработчики событий
     procedure OnWorksheetGridSelection(Sender: TObject;
@@ -152,6 +189,7 @@ uses
   uzclog,
   uzcinterface,
   uzvspreadsheet_cmdalignment,
+  uzvspreadsheet_dimensions,
   uzvspreadsheet_cmdundoredo;
 
 { TuzvSpreadsheetForm }
@@ -166,6 +204,7 @@ begin
   FEditingCol := 0;
   FUndoSavedForCurrentEdit := False;
   FUpdatingAlignmentCombo := False;
+  FUpdatingDimensionFields := False;
 
   // Настройка основных параметров формы
   Caption := 'Электронные таблицы / Spreadsheet';
@@ -184,6 +223,8 @@ begin
   // Комбобокс выравнивания добавляется после кнопок команд, чтобы
   // располагаться в конце панели инструментов
   CreateAlignmentCombo;
+  // Поля размеров ячейки (ширина столбца/высота строки) — issue #1359
+  CreateDimensionFields;
 
   zcUI.TextMessage('Форма электронных таблиц создана', TMWOHistoryOut);
 end;
@@ -281,6 +322,66 @@ begin
   FillAlignmentItems(FAlignmentCombo.Items);
   FAlignmentCombo.ItemIndex := 0;
   FAlignmentCombo.OnChange := @OnAlignmentComboChange;
+end;
+
+{ Создаёт на панели инструментов вспомогательную метку. }
+function TuzvSpreadsheetForm.CreateToolbarLabel(
+  const ACaption: String): TLabel;
+begin
+  Result := TLabel.Create(Self);
+  Result.Parent := FToolBar;
+  Result.Caption := ACaption;
+  Result.Layout := tlCenter;
+  Result.AutoSize := False;
+  Result.Width := DIMENSION_LABEL_WIDTH;
+end;
+
+{ Создаёт на панели инструментов поле ввода значения размера. AReadOnly —
+  поле только для чтения (значение таблицы ACAD). AHint — подсказка. }
+function TuzvSpreadsheetForm.CreateDimensionEdit(AReadOnly: Boolean;
+  const AHint: String): TEdit;
+begin
+  Result := TEdit.Create(Self);
+  Result.Parent := FToolBar;
+  Result.Width := DIMENSION_EDIT_WIDTH;
+  Result.ReadOnly := AReadOnly;
+  Result.Hint := AHint;
+  Result.ShowHint := True;
+  if AReadOnly then
+    Result.TabStop := False;
+end;
+
+{ Создаёт поля размеров ячейки на панели инструментов (issue #1359).
+  Для ширины столбца и высоты строки создаётся по два поля: значение листа
+  (редактируемое, мм) и значение таблицы ACAD_TABLE (только чтение). При
+  редактировании значения листа размер столбца/строки меняется в листе. }
+procedure TuzvSpreadsheetForm.CreateDimensionFields;
+var
+  Separator: TToolButton;
+begin
+  // Разделитель перед группой полей размеров
+  Separator := TToolButton.Create(FToolBar);
+  Separator.Parent := FToolBar;
+  Separator.Style := tbsSeparator;
+  Separator.Width := 10;
+
+  // Поле ширины столбца: лист (мм, редактируемое) + ACAD (единицы, чтение)
+  CreateToolbarLabel('Ширина столбца:');
+  FEditColWidthWS := CreateDimensionEdit(False,
+    'Ширина столбца в листе (мм). Изменение меняет столбец листа');
+  FEditColWidthWS.OnExit := @OnColWidthEditExit;
+  FEditColWidthWS.OnKeyPress := @OnColWidthKeyPress;
+  FEditColWidthAcad := CreateDimensionEdit(True,
+    'Ширина столбца в таблице ACAD (единицы чертежа)');
+
+  // Поле высоты строки: лист (мм, редактируемое) + ACAD (единицы, чтение)
+  CreateToolbarLabel('Высота строки:');
+  FEditRowHeightWS := CreateDimensionEdit(False,
+    'Высота строки в листе (мм). Изменение меняет строку листа');
+  FEditRowHeightWS.OnExit := @OnRowHeightEditExit;
+  FEditRowHeightWS.OnKeyPress := @OnRowHeightKeyPress;
+  FEditRowHeightAcad := CreateDimensionEdit(True,
+    'Высота строки в таблице ACAD (единицы чертежа)');
 end;
 
 { Создание панели информации о ячейке }
@@ -494,6 +595,9 @@ begin
 
   // Синхронизируем комбобокс выравнивания с выделенной ячейкой
   UpdateAlignmentCombo;
+
+  // Синхронизируем поля размеров (ширина столбца/высота строки)
+  UpdateDimensionFields;
 end;
 
 { Обновление комбобокса выравнивания по выделенной ячейке }
@@ -533,6 +637,168 @@ begin
   begin
     FWorksheetGrid.Invalidate;
     FWorksheetGrid.SetFocus;
+  end;
+end;
+
+{ Возвращает активный лист книги либо nil, если он недоступен. }
+function TuzvSpreadsheetForm.GetActiveWorksheet: TsWorksheet;
+begin
+  Result := nil;
+  if (FWorkbookSource = nil) or (FWorkbookSource.Workbook = nil) then
+    Exit;
+  Result := FWorkbookSource.Workbook.ActiveWorksheet;
+end;
+
+{ Обновление полей размеров (ширина столбца/высота строки) по выделенной
+  ячейке. В каждое поле выводится два значения: размер листа (мм) и
+  соответствующий ему размер таблицы ACAD_TABLE (единицы чертежа). }
+procedure TuzvSpreadsheetForm.UpdateDimensionFields;
+var
+  worksheet: TsWorksheet;
+  row, col: Integer;
+  widthMM, heightMM: Double;
+begin
+  if (FEditColWidthWS = nil) or (FEditRowHeightWS = nil) then
+    Exit;
+
+  worksheet := GetActiveWorksheet;
+  if worksheet = nil then
+    Exit;
+
+  col := FWorksheetGrid.Col - FWorksheetGrid.FixedCols;
+  row := FWorksheetGrid.Row - FWorksheetGrid.FixedRows;
+
+  widthMM := GetWorksheetColWidthMM(worksheet, col);
+  heightMM := GetWorksheetRowHeightMM(worksheet, row);
+
+  // Обновляем поля программно, чтобы OnExit не записывал значения обратно
+  FUpdatingDimensionFields := True;
+  try
+    FEditColWidthWS.Text := Format(DIMENSION_VALUE_FORMAT, [widthMM]);
+    FEditColWidthAcad.Text :=
+      Format(DIMENSION_VALUE_FORMAT, [WorksheetToAcadSize(widthMM)]);
+    FEditRowHeightWS.Text := Format(DIMENSION_VALUE_FORMAT, [heightMM]);
+    FEditRowHeightAcad.Text :=
+      Format(DIMENSION_VALUE_FORMAT, [WorksheetToAcadSize(heightMM)]);
+  finally
+    FUpdatingDimensionFields := False;
+  end;
+end;
+
+{ Разбирает введённый размер из поля. Принимает запятую и точку как
+  десятичный разделитель. Возвращает False, если значение некорректно. }
+function ParseDimensionValue(const AText: String; out AValue: Double): Boolean;
+var
+  normalized: String;
+  fmt: TFormatSettings;
+begin
+  fmt := DefaultFormatSettings;
+  fmt.DecimalSeparator := '.';
+  normalized := StringReplace(Trim(AText), ',', '.', [rfReplaceAll]);
+  Result := TryStrToFloat(normalized, AValue, fmt);
+end;
+
+{ Записывает ширину столбца из поля FEditColWidthWS в лист (issue #1359). }
+procedure TuzvSpreadsheetForm.ApplyColWidthFromField;
+var
+  worksheet: TsWorksheet;
+  col: Integer;
+  widthMM: Double;
+begin
+  if FUpdatingDimensionFields or (FEditColWidthWS = nil) then
+    Exit;
+
+  worksheet := GetActiveWorksheet;
+  if worksheet = nil then
+    Exit;
+
+  if not ParseDimensionValue(FEditColWidthWS.Text, widthMM) then
+  begin
+    UpdateDimensionFields;  // Восстанавливаем корректное значение
+    Exit;
+  end;
+
+  col := FWorksheetGrid.Col - FWorksheetGrid.FixedCols;
+  if SetWorksheetColWidthMM(worksheet, col, widthMM) then
+  begin
+    programlog.LogOutFormatStr(
+      'Spreadsheet: ширина столбца %d изменена на %.2f мм',
+      [col, widthMM], LM_Info);
+    if FWorksheetGrid <> nil then
+      FWorksheetGrid.Invalidate;
+  end;
+
+  UpdateDimensionFields;  // Пересчитываем значение ACAD
+end;
+
+{ Записывает высоту строки из поля FEditRowHeightWS в лист (issue #1359). }
+procedure TuzvSpreadsheetForm.ApplyRowHeightFromField;
+var
+  worksheet: TsWorksheet;
+  row: Integer;
+  heightMM: Double;
+begin
+  if FUpdatingDimensionFields or (FEditRowHeightWS = nil) then
+    Exit;
+
+  worksheet := GetActiveWorksheet;
+  if worksheet = nil then
+    Exit;
+
+  if not ParseDimensionValue(FEditRowHeightWS.Text, heightMM) then
+  begin
+    UpdateDimensionFields;  // Восстанавливаем корректное значение
+    Exit;
+  end;
+
+  row := FWorksheetGrid.Row - FWorksheetGrid.FixedRows;
+  if SetWorksheetRowHeightMM(worksheet, row, heightMM) then
+  begin
+    programlog.LogOutFormatStr(
+      'Spreadsheet: высота строки %d изменена на %.2f мм',
+      [row, heightMM], LM_Info);
+    if FWorksheetGrid <> nil then
+      FWorksheetGrid.Invalidate;
+  end;
+
+  UpdateDimensionFields;  // Пересчитываем значение ACAD
+end;
+
+{ Обработчик выхода из поля ширины столбца }
+procedure TuzvSpreadsheetForm.OnColWidthEditExit(Sender: TObject);
+begin
+  ApplyColWidthFromField;
+end;
+
+{ Обработчик нажатия клавиши в поле ширины столбца }
+procedure TuzvSpreadsheetForm.OnColWidthKeyPress(Sender: TObject;
+  var Key: Char);
+begin
+  if Key = #13 then
+  begin
+    ApplyColWidthFromField;
+    Key := #0;
+    if FWorksheetGrid <> nil then
+      FWorksheetGrid.SetFocus;
+  end;
+end;
+
+{ Обработчик выхода из поля высоты строки }
+procedure TuzvSpreadsheetForm.OnRowHeightEditExit(Sender: TObject);
+begin
+  ApplyRowHeightFromField;
+end;
+
+{ Обработчик нажатия клавиши в поле высоты строки }
+procedure TuzvSpreadsheetForm.OnRowHeightKeyPress(Sender: TObject;
+  var Key: Char);
+begin
+  if Key = #13 then
+  begin
+    ApplyRowHeightFromField;
+    Key := #0;
+    if FWorksheetGrid <> nil then
+      FWorksheetGrid.SetFocus;
   end;
 end;
 

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -149,6 +149,12 @@ type
     procedure BuildsAcadTableFromCellTexts;
     // issue #1357: пустой диапазон не создаёт таблицу.
     procedure BuildFromCellTextsRejectsEmptyDimensions;
+    // issue #1359: явные ширины столбцов и высоты строк должны переноситься
+    // в таблицу ACAD_TABLE (суммарные размеры равны сумме переданных).
+    procedure BuildFromCellTextsWithSizesAppliesColWidthsAndRowHeights;
+    // issue #1359: отсутствующие или неположительные размеры заменяются
+    // значениями по умолчанию.
+    procedure BuildFromCellTextsWithSizesFallsBackToDefaults;
   end;
 
 implementation
@@ -2196,6 +2202,95 @@ begin
       'У не построенной таблицы число строк должно остаться 0');
     CheckEquals(0, Table^.ColCount,
       'У не построенной таблицы число столбцов должно остаться 0');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.
+  BuildFromCellTextsWithSizesAppliesColWidthsAndRowHeights;
+const
+  // Ожидаемая точность сравнения суммарных размеров таблицы
+  CSizeDelta = 1e-6;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  ColWidths, RowHeights: TTableSizeArray;
+  InsertPt: TzePoint3d;
+  Ok: Boolean;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 6);
+    Texts[0] := 'A1'; Texts[1] := 'B1'; Texts[2] := 'C1';
+    Texts[3] := 'A2'; Texts[4] := 'B2'; Texts[5] := 'C2';
+
+    // Явные ширины столбцов (3) и высоты строк (2)
+    System.SetLength(ColWidths, 3);
+    ColWidths[0] := 40; ColWidths[1] := 50; ColWidths[2] := 60;
+    System.SetLength(RowHeights, 2);
+    RowHeights[0] := 20; RowHeights[1] := 30;
+
+    InsertPt := NulVertex;
+    Ok := Table^.BuildFromCellTextsWithSizes(2, 3, Texts,
+      ColWidths, RowHeights, InsertPt);
+    CheckTrue(Ok, 'BuildFromCellTextsWithSizes должен построить таблицу');
+
+    // Суммарная ширина = 40+50+60, суммарная высота = 20+30
+    CheckEquals(150.0, Table^.Width, CSizeDelta,
+      'Суммарная ширина должна равняться сумме ширин столбцов');
+    CheckEquals(50.0, Table^.Height, CSizeDelta,
+      'Суммарная высота должна равняться сумме высот строк');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.BuildFromCellTextsWithSizesFallsBackToDefaults;
+const
+  CSizeDelta = 1e-6;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  ColWidths, RowHeights: TTableSizeArray;
+  InsertPt: TzePoint3d;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 3);
+    Texts[0] := 'A1'; Texts[1] := 'B1'; Texts[2] := 'C1';
+
+    // Один столбец задан, один нулевой (-> по умолчанию), один отсутствует.
+    // Массив высот строк пуст -> высота по умолчанию.
+    System.SetLength(ColWidths, 2);
+    ColWidths[0] := 45; ColWidths[1] := 0;
+    System.SetLength(RowHeights, 0);
+
+    InsertPt := NulVertex;
+    CheckTrue(Table^.BuildFromCellTextsWithSizes(1, 3, Texts,
+      ColWidths, RowHeights, InsertPt),
+      'BuildFromCellTextsWithSizes должен построить таблицу');
+
+    // Ширина = 45 (задан) + 30 (нулевой -> по умолчанию)
+    //         + 30 (отсутствует -> по умолчанию) = 105
+    CheckEquals(45.0 + CAcadTableDefaultColWidth + CAcadTableDefaultColWidth,
+      Table^.Width, CSizeDelta,
+      'Отсутствующие/нулевые ширины должны заменяться значением по умолчанию');
+    // Высота единственной строки = высота по умолчанию
+    CheckEquals(CAcadTableDefaultRowHeight, Table^.Height, CSizeDelta,
+      'Пустой массив высот должен давать высоту строки по умолчанию');
   finally
     Drawing.done;
   end;

--- a/experiments/test_dimension_mapping.pas
+++ b/experiments/test_dimension_mapping.pas
@@ -1,0 +1,130 @@
+{ Standalone test for the spreadsheet cell-size linkage logic (issue #1359).
+
+  fpspreadsheet is not exercised here; this program replicates the pure
+  conversion and fallback logic implemented in:
+    * cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+      (WorksheetToAcadSize / AcadToWorksheetSize)
+    * cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+      (SizeOrDefault, used by BuildFromCellTextsWithSizes)
+
+  It verifies:
+    * worksheet (mm) -> ACAD (drawing units) conversion at the 1:1 scale,
+    * the conversion round-trips,
+    * SizeOrDefault picks provided positive sizes and falls back to the
+      default for missing / zero / negative entries,
+    * collecting an array of widths sums to the expected total.
+
+  Build & run:
+    fpc -Mobjfpc experiments/test_dimension_mapping.pas \
+      && ./experiments/test_dimension_mapping
+}
+program test_dimension_mapping;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils;
+
+type
+  TTableSizeArray = array of Double;
+
+const
+  // Mirror of constants from the production units
+  CWorksheetToAcadScale = 1.0;
+  CAcadTableDefaultColWidth = 30.0;
+  CAcadTableDefaultRowHeight = 10.0;
+
+{ ---- logic copied verbatim from uzvspreadsheet_dimensions.pas ---- }
+
+function WorksheetToAcadSize(AWorksheetMM: Double): Double;
+begin
+  Result := AWorksheetMM * CWorksheetToAcadScale;
+end;
+
+function AcadToWorksheetSize(AAcadSize: Double): Double;
+begin
+  if CWorksheetToAcadScale = 0 then
+    Result := AAcadSize
+  else
+    Result := AAcadSize / CWorksheetToAcadScale;
+end;
+
+{ ---- logic copied verbatim from uzeacadtable_model.pas ---- }
+
+function SizeOrDefault(const ASizes: TTableSizeArray;
+  AIndex: Integer; ADefault: Double): Double;
+begin
+  if (AIndex >= 0) and (AIndex <= High(ASizes)) and (ASizes[AIndex] > 0) then
+    Result := ASizes[AIndex]
+  else
+    Result := ADefault;
+end;
+
+{ ---- test harness ---- }
+
+var
+  Failures: Integer = 0;
+
+procedure Check(aCondition: Boolean; const aMsg: string);
+begin
+  if aCondition then
+    WriteLn('  ok  : ', aMsg)
+  else
+  begin
+    WriteLn('  FAIL: ', aMsg);
+    Inc(Failures);
+  end;
+end;
+
+function NearlyEqual(a, b: Double): Boolean;
+begin
+  Result := Abs(a - b) < 1e-9;
+end;
+
+var
+  widths: TTableSizeArray;
+  total: Double;
+  i: Integer;
+begin
+  WriteLn('Testing cell-size linkage (issue #1359)');
+
+  // Conversion at 1:1 scale
+  Check(NearlyEqual(WorksheetToAcadSize(25.4), 25.4),
+    'worksheet 25.4 mm -> acad 25.4 units');
+  Check(NearlyEqual(AcadToWorksheetSize(WorksheetToAcadSize(42.0)), 42.0),
+    'conversion round-trips');
+
+  // SizeOrDefault: provided positive value is used
+  SetLength(widths, 3);
+  widths[0] := 40; widths[1] := 0; widths[2] := -5;
+  Check(NearlyEqual(SizeOrDefault(widths, 0, CAcadTableDefaultColWidth), 40),
+    'positive width used as-is');
+  Check(NearlyEqual(SizeOrDefault(widths, 1, CAcadTableDefaultColWidth),
+    CAcadTableDefaultColWidth), 'zero width -> default');
+  Check(NearlyEqual(SizeOrDefault(widths, 2, CAcadTableDefaultColWidth),
+    CAcadTableDefaultColWidth), 'negative width -> default');
+  Check(NearlyEqual(SizeOrDefault(widths, 5, CAcadTableDefaultColWidth),
+    CAcadTableDefaultColWidth), 'out-of-range index -> default');
+
+  // Empty array always yields the default (default-row-height case)
+  SetLength(widths, 0);
+  Check(NearlyEqual(SizeOrDefault(widths, 0, CAcadTableDefaultRowHeight),
+    CAcadTableDefaultRowHeight), 'empty array -> default');
+
+  // Collecting widths and summing them (model builds total this way)
+  SetLength(widths, 3);
+  widths[0] := 40; widths[1] := 50; widths[2] := 60;
+  total := 0;
+  for i := 0 to High(widths) do
+    total := total + SizeOrDefault(widths, i, CAcadTableDefaultColWidth);
+  Check(NearlyEqual(total, 150), 'sum of widths 40+50+60 = 150');
+
+  WriteLn;
+  if Failures = 0 then
+    WriteLn('ALL TESTS PASSED')
+  else
+  begin
+    WriteLn(Failures, ' TEST(S) FAILED');
+    Halt(1);
+  end;
+end.


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1359

## Что сделано

Команда создания таблицы `GDBObjAcadTable` из редактора электронных таблиц
(`uzvspreadsheet`) расширена так, чтобы размеры ячеек листа (`TsWorksheet`)
переносились в таблицу ACAD и могли управляться из интерфейса.

### Требование 1 — связь ширины ячейки листа с ячейкой `GDBObjAcadTable`
- Новый Logic-модуль `uzvspreadsheet_dimensions.pas`: перевод размеров
  «лист ↔ ACAD» (масштаб вынесен в именованную константу
  `CWorksheetToAcadScale = 1.0`, т.к. книга `fpspreadsheet` по умолчанию
  ведётся в миллиметрах) и сбор массивов ширин столбцов / высот строк
  из листа в единицах чертежа.
- В `GDBObjAcadTable` добавлен метод `BuildFromCellTextsWithSizes`,
  принимающий явные ширины столбцов и высоты строк. Существующий
  `BuildFromCellTexts` делегирует ему с пустыми массивами — поведение
  по умолчанию полностью сохранено. Отсутствующие или неположительные
  размеры заменяются значениями по умолчанию (`SizeOrDefault`).
- Новый тип `TTableSizeArray` (массив размеров в единицах чертежа).

### Требование 2 — два поля управления шириной столбца / высотой строки
На панель инструментов редактора добавлены поля размеров выделенной ячейки.
Каждое поле состоит из **двух значений**:
- значение листа `TsWorksheet` (мм, редактируемое);
- значение таблицы `GDBObjAcadTable` (единицы чертежа, только чтение).

При выделении ячейки поля заполняются её шириной столбца и высотой строки
(`UpdateDimensionFields`). Редактирование значения листа изменяет ширину
столбца / высоту строки прямо в `TsWorksheet`
(`ApplyColWidthFromField` / `ApplyRowHeightFromField`), применение — по
Enter или потере фокуса. Программное обновление полей защищено флагом
`FUpdatingDimensionFields` от обратной записи; ввод принимает как точку,
так и запятую в качестве десятичного разделителя.

### Требование 3 — корректный перенос размеров при создании таблицы
Команда `CreateAcadTableFromWorksheet` собирает ширины столбцов и высоты
строк листа (`CollectColWidths` / `CollectRowHeights`) и передаёт их в
`BuildFromCellTextsWithSizes`, поэтому размеры каждого столбца/строки
переносятся в таблицу ACAD.

## Как воспроизвести / проверить
1. Открыть редактор электронных таблиц, изменить ширину столбцов и высоту
   строк, выделить ячейку — поля на панели показывают значения листа и ACAD.
2. Изменить значение в поле листа — ширина столбца / высота строки в листе
   меняется, значение ACAD пересчитывается.
3. Создать таблицу `GDBObjAcadTable` — размеры столбцов/строк совпадают
   с листом.

## Тесты
- `cad_source/zengine/tests/uzctacadtable.pas`:
  - `BuildFromCellTextsWithSizesAppliesColWidthsAndRowHeights` — суммарные
    размеры таблицы равны сумме переданных ширин/высот;
  - `BuildFromCellTextsWithSizesFallsBackToDefaults` — отсутствующие/нулевые
    размеры заменяются значениями по умолчанию.
- `experiments/test_dimension_mapping.pas` — автономная проверка логики
  преобразования и отката к значениям по умолчанию (проходит:
  `ALL TESTS PASSED`).

## Замечания
В данном окружении не установлен пакет LCL (`Interfaces`), поэтому полный
fpcunit-тест таблицы здесь не компилируется; ключевая числовая логика
проверена автономным экспериментом и ревью кода. В репозитории нет CI,
собирающего проект.