### PR TITLE
uzvspreadsheet. Перенос выравнивания ячеек редактора в GDBObjAcadTable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T19:17:14.035Z for PR creation at branch issue-1363-66082c1a324b for issue https://github.com/veb86/zcadvelecAI/issues/1363

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T19:17:14.035Z for PR creation at branch issue-1363-66082c1a324b for issue https://github.com/veb86/zcadvelecAI/issues/1363

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -370,6 +370,20 @@ type
       const ACellTexts: TTableTextArray;
       const AColWidths, ARowHeights: TTableSizeArray;
       const AInsertPoint: TzePoint3d): Boolean; virtual;
+    // Полный вариант программного построения таблицы из текстов ячеек
+    // с явными ширинами столбцов, высотами строк и выравниванием ячеек
+    // (issue #1363). ACellAlignments индексируется как строка*AColCount +
+    // столбец и содержит код выравнивания AutoCAD (group 170, 1..9); 0 или
+    // отсутствующий элемент означает наследование выравнивания от стиля
+    // таблицы. BuildFromCellTexts и BuildFromCellTextsWithSizes делегируют
+    // сюда (с пустыми массивами размеров/выравниваний). Возвращает True при
+    // успехе.
+    function BuildFromCellTextsWithSizesAndAlignments(
+      ARowCount, AColCount: Integer;
+      const ACellTexts: TTableTextArray;
+      const AColWidths, ARowHeights: TTableSizeArray;
+      const ACellAlignments: TTableAlignmentArray;
+      const AInsertPoint: TzePoint3d): Boolean; virtual;
 
     // Публичные свойства для инспектора объектов
     property InsertPoint: TzePoint3d read FInsertPoint;
@@ -419,6 +433,10 @@ type
     // некорректных индексов возвращает пустую строку.
     function ContinuationPartCellText(
       APartIndex, ARow, ACol: Integer): string;
+    // Код выравнивания AutoCAD (group 170, 1..9) ячейки главной части
+    // таблицы; 0 — выравнивание не задано (наследуется от стиля). Для
+    // некорректных индексов возвращает 0 (для инспекции/тестов, issue #1363).
+    function CellAlignmentAt(ARow, ACol: Integer): Integer;
     // Повторно определяет признак повтора верхних меток по текущим данным
     // частей-продолжений и возвращает результат (issue #1309). Используется
     // для проверки детекции после программных изменений модели.
@@ -561,6 +579,33 @@ function GDBObjAcadTable.BuildFromCellTextsWithSizes(
   const AColWidths, ARowHeights: TTableSizeArray;
   const AInsertPoint: TzePoint3d): Boolean;
 var
+  EmptyAlignments: TTableAlignmentArray;
+begin
+  // Делегируем полному варианту без явного выравнивания — все ячейки
+  // наследуют выравнивание от стиля таблицы (issue #1363).
+  System.SetLength(EmptyAlignments, 0);
+  Result := BuildFromCellTextsWithSizesAndAlignments(ARowCount, AColCount,
+    ACellTexts, AColWidths, ARowHeights, EmptyAlignments, AInsertPoint);
+end;
+
+{ Возвращает код выравнивания из массива по индексу, либо 0 (наследование от
+  стиля таблицы), если индекс вне диапазона. }
+function AlignmentOrZero(const AAlignments: TTableAlignmentArray;
+  AIndex: Integer): Integer;
+begin
+  if (AIndex >= 0) and (AIndex <= High(AAlignments)) then
+    Result := AAlignments[AIndex]
+  else
+    Result := 0;
+end;
+
+function GDBObjAcadTable.BuildFromCellTextsWithSizesAndAlignments(
+  ARowCount, AColCount: Integer;
+  const ACellTexts: TTableTextArray;
+  const AColWidths, ARowHeights: TTableSizeArray;
+  const ACellAlignments: TTableAlignmentArray;
+  const AInsertPoint: TzePoint3d): Boolean;
+var
   RowIdx, ColIdx, CellIndex: Integer;
 begin
   Result := False;
@@ -634,8 +679,10 @@ begin
       FCells[RowIdx][ColIdx].Text := GetCellTextLocal(RowIdx, ColIdx);
       FCells[RowIdx][ColIdx].Value := 0;
       FCells[RowIdx][ColIdx].Formula := '';
-      FCells[RowIdx][ColIdx].BlockName := '';
-      FCells[RowIdx][ColIdx].CellAlignment := 0;
+      // Выравнивание ячейки из электронной таблицы (issue #1363): код
+      // AutoCAD 1..9, либо 0 — наследование от стиля таблицы.
+      FCells[RowIdx][ColIdx].CellAlignment :=
+        AlignmentOrZero(ACellAlignments, RowIdx * FColCount + ColIdx);
       FCells[RowIdx][ColIdx].ColSpan := 1;
       FCells[RowIdx][ColIdx].RowSpan := 1;
       InitCellStyle(FCells[RowIdx][ColIdx].Style);
@@ -1586,6 +1633,15 @@ begin
     if (Idx >= 0) and (Idx <= High(CellTexts)) then
       Result := CellTexts[Idx];
   end;
+end;
+
+function GDBObjAcadTable.CellAlignmentAt(ARow, ACol: Integer): Integer;
+begin
+  Result := 0;
+  if (ARow < 0) or (ARow >= FRowCount) then Exit;
+  if (ACol < 0) or (ACol >= FColCount) then Exit;
+  if (Length(FCells) > ARow) and (Length(FCells[ARow]) > ACol) then
+    Result := FCells[ARow][ACol].CellAlignment;
 end;
 
 // Признак разрыва вычисляется по двум источникам (issue #1305, часть 2a):

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
@@ -170,6 +170,14 @@ type
   // Используется для переноса размеров ячеек из электронной таблицы
   // (TsWorksheet) в таблицу ACAD_TABLE при её создании (issue #1359).
   TTableSizeArray = array of Double;
+  // Массив выравниваний ячеек в кодировке AutoCAD (group 170, значения 1..9:
+  // 1=TopLeft, 2=TopCenter, 3=TopRight, 4=MiddleLeft, 5=MiddleCenter,
+  // 6=MiddleRight, 7=BottomLeft, 8=BottomCenter, 9=BottomRight). 0 = не задано
+  // (ячейка наследует выравнивание из стиля таблицы). Индексируется как
+  // строка*количество_столбцов + столбец. Используется для переноса
+  // выравнивания ячеек из электронной таблицы (TsWorksheet) в таблицу
+  // ACAD_TABLE при её создании (issue #1363).
+  TTableAlignmentArray = array of Integer;
 
 implementation
 

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
@@ -170,6 +170,7 @@ var
   cell: PCell;
   texts: TTableTextArray;
   colWidths, rowHeights: TTableSizeArray;
+  cellAlignments: TTableAlignmentArray;
   rowCount, colCount: Integer;
   insPt: TzePoint3d;
   dc: TDrawContext;
@@ -216,17 +217,21 @@ begin
   colWidths := CollectColWidths(worksheet, colCount);
   rowHeights := CollectRowHeights(worksheet, rowCount);
 
+  // Собираем выравнивание ячеек листа в кодировке AutoCAD, чтобы перенести
+  // его в таблицу ACAD_TABLE при создании (issue #1363)
+  cellAlignments := CollectCellAlignments(worksheet, rowCount, colCount);
+
   // Создаём сущность и помещаем её в конструктивный root чертежа
   pt := AllocAndInitAcadTable(
     PGDBObjGenericWithSubordinated(@drawings.CurrentDWG^.ConstructObjRoot));
   drawings.CurrentDWG^.ConstructObjRoot.ObjArray.AddPEntity(pt^);
 
   // Строим таблицу из текстов ячеек с переносом размеров столбцов/строк
-  // (точка вставки временная, нулевая — окончательное положение
-  // пользователь укажет при перемещении из root)
+  // и выравнивания ячеек (точка вставки временная, нулевая — окончательное
+  // положение пользователь укажет при перемещении из root)
   insPt := NulVertex;
-  if not pt^.BuildFromCellTextsWithSizes(rowCount, colCount, texts,
-       colWidths, rowHeights, insPt) then
+  if not pt^.BuildFromCellTextsWithSizesAndAlignments(rowCount, colCount,
+       texts, colWidths, rowHeights, cellAlignments, insPt) then
   begin
     programlog.LogOutFormatStr(
       'CreateAcadTableFromWorksheet: BuildFromCellTexts failed', [], LM_Info);

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
@@ -86,6 +86,20 @@ function CollectColWidths(AWorksheet: TsWorksheet;
 function CollectRowHeights(AWorksheet: TsWorksheet;
   ARowCount: Integer): TTableSizeArray;
 
+{ Преобразует пару выравниваний fpspreadsheet (горизонтальное и вертикальное)
+  в код выравнивания AutoCAD (group 170, значения 1..9). Значения "по
+  умолчанию" (haDefault/vaDefault) трактуются как левое/верхнее — так же, как
+  в комбобоксе выравнивания редактора (issue #1352). }
+function WorksheetAlignmentToAcad(AHor: TsHorAlignment;
+  AVert: TsVertAlignment): Integer;
+
+{ Собирает выравнивания ячеек листа в кодировке AutoCAD для передачи в
+  GDBObjAcadTable.BuildFromCellTextsWithSizesAndAlignments (issue #1363).
+  Ячейкам без явно заданного выравнивания (оба значения "по умолчанию")
+  присваивается 0 — наследование выравнивания от стиля таблицы. }
+function CollectCellAlignments(AWorksheet: TsWorksheet;
+  ARowCount, AColCount: Integer): TTableAlignmentArray;
+
 implementation
 
 function WorksheetToAcadSize(AWorksheetMM: Double): Double;
@@ -163,6 +177,67 @@ begin
   for RowIdx := 0 to ARowCount - 1 do
     Result[RowIdx] :=
       WorksheetToAcadSize(GetWorksheetRowHeightMM(AWorksheet, RowIdx));
+end;
+
+{ Группа горизонтального выравнивания: 0 - левое, 1 - центр, 2 - правое.
+  Совпадает с логикой комбобокса выравнивания редактора (issue #1352). }
+function HorAlignToGroup(AHor: TsHorAlignment): Integer;
+begin
+  case AHor of
+    haCenter: Result := 1;
+    haRight:  Result := 2;
+    else      Result := 0;  // haLeft, haDefault
+  end;
+end;
+
+{ Группа вертикального выравнивания: 0 - верх, 1 - центр, 2 - низ. }
+function VertAlignToGroup(AVert: TsVertAlignment): Integer;
+begin
+  case AVert of
+    vaCenter: Result := 1;
+    vaBottom: Result := 2;
+    else      Result := 0;  // vaTop, vaDefault
+  end;
+end;
+
+function WorksheetAlignmentToAcad(AHor: TsHorAlignment;
+  AVert: TsVertAlignment): Integer;
+begin
+  // Код AutoCAD (group 170): 1..9 = вертикаль*3 + горизонталь + 1,
+  // где 1=TopLeft .. 9=BottomRight.
+  Result := VertAlignToGroup(AVert) * 3 + HorAlignToGroup(AHor) + 1;
+end;
+
+function CollectCellAlignments(AWorksheet: TsWorksheet;
+  ARowCount, AColCount: Integer): TTableAlignmentArray;
+var
+  RowIdx, ColIdx: Integer;
+  Cell: PCell;
+  Hor: TsHorAlignment;
+  Vert: TsVertAlignment;
+begin
+  System.SetLength(Result, 0);
+  if (AWorksheet = nil) or (ARowCount <= 0) or (AColCount <= 0) then
+    Exit;
+  System.SetLength(Result, ARowCount * AColCount);
+  for RowIdx := 0 to ARowCount - 1 do
+    for ColIdx := 0 to AColCount - 1 do
+    begin
+      // По умолчанию выравнивание не задано — ячейка наследует его от стиля
+      // таблицы. Это сохраняет прежнее поведение для ячеек, которым в
+      // редакторе явно не назначали выравнивание.
+      Result[RowIdx * AColCount + ColIdx] := 0;
+      Cell := AWorksheet.FindCell(Cardinal(RowIdx), Cardinal(ColIdx));
+      if Cell = nil then
+        Continue;
+      Hor := AWorksheet.ReadHorAlignment(Cell);
+      Vert := AWorksheet.ReadVertAlignment(Cell);
+      // Переносим выравнивание только если оно задано в ячейке листа явно;
+      // иначе оставляем 0 (наследование от стиля таблицы).
+      if (Hor <> haDefault) or (Vert <> vaDefault) then
+        Result[RowIdx * AColCount + ColIdx] :=
+          WorksheetAlignmentToAcad(Hor, Vert);
+    end;
 end;
 
 end.

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -155,6 +155,9 @@ type
     // issue #1359: отсутствующие или неположительные размеры заменяются
     // значениями по умолчанию.
     procedure BuildFromCellTextsWithSizesFallsBackToDefaults;
+    // issue #1363: выравнивание ячеек (код AutoCAD 1..9) переносится в
+    // таблицу ACAD_TABLE; отсутствующие коды дают 0 (наследование от стиля).
+    procedure BuildFromCellTextsAppliesCellAlignments;
   end;
 
 implementation
@@ -2291,6 +2294,57 @@ begin
     // Высота единственной строки = высота по умолчанию
     CheckEquals(CAcadTableDefaultRowHeight, Table^.Height, CSizeDelta,
       'Пустой массив высот должен давать высоту строки по умолчанию');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.BuildFromCellTextsAppliesCellAlignments;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  ColWidths, RowHeights: TTableSizeArray;
+  Alignments: TTableAlignmentArray;
+  InsertPt: TzePoint3d;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 6);
+    Texts[0] := 'A1'; Texts[1] := 'B1'; Texts[2] := 'C1';
+    Texts[3] := 'A2'; Texts[4] := 'B2'; Texts[5] := 'C2';
+
+    System.SetLength(ColWidths, 0);
+    System.SetLength(RowHeights, 0);
+
+    // Коды AutoCAD: 1=TopLeft, 5=MiddleCenter, 9=BottomRight.
+    // Последняя ячейка (индекс 5) не задана в массиве -> 0 (наследование).
+    System.SetLength(Alignments, 5);
+    Alignments[0] := 1; Alignments[1] := 5; Alignments[2] := 9;
+    Alignments[3] := 4; Alignments[4] := 0;
+
+    InsertPt := NulVertex;
+    CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(2, 3, Texts,
+      ColWidths, RowHeights, Alignments, InsertPt),
+      'BuildFromCellTextsWithSizesAndAlignments должен построить таблицу');
+
+    CheckEquals(1, Table^.CellAlignmentAt(0, 0),
+      'Ячейка [0,0] должна получить выравнивание TopLeft (1)');
+    CheckEquals(5, Table^.CellAlignmentAt(0, 1),
+      'Ячейка [0,1] должна получить выравнивание MiddleCenter (5)');
+    CheckEquals(9, Table^.CellAlignmentAt(0, 2),
+      'Ячейка [0,2] должна получить выравнивание BottomRight (9)');
+    CheckEquals(4, Table^.CellAlignmentAt(1, 0),
+      'Ячейка [1,0] должна получить выравнивание MiddleLeft (4)');
+    CheckEquals(0, Table^.CellAlignmentAt(1, 1),
+      'Ячейка [1,1] с явным 0 должна наследовать выравнивание (0)');
+    CheckEquals(0, Table^.CellAlignmentAt(1, 2),
+      'Ячейка [1,2] вне массива должна наследовать выравнивание (0)');
   finally
     Drawing.done;
   end;

--- a/experiments/test_cell_alignment_transfer.pas
+++ b/experiments/test_cell_alignment_transfer.pas
@@ -1,0 +1,171 @@
+{ Standalone test for the spreadsheet -> ACAD_TABLE cell-alignment linkage
+  logic (issue #1363).
+
+  fpspreadsheet is not installed in this environment, so this program
+  replicates the enum order from fpsTypes:
+      TsHorAlignment  = (haDefault, haLeft, haCenter, haRight);
+      TsVertAlignment = (vaDefault, vaTop, vaCenter, vaBottom);
+  and the pure conversion / collection logic implemented in
+  cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+      (WorksheetAlignmentToAcad / CollectCellAlignments)
+  together with the AutoCAD-code -> hor/vert decoding in
+  cad_source/zcad/velec/acadtable/uzeacadtable_styles.pas
+      (DXFAlignToHorz / DXFAlignToVert).
+
+  It verifies:
+    * each fpspreadsheet (hor, vert) pair maps to the expected AutoCAD code
+      (group 170, 1..9),
+    * the AutoCAD code decodes back to the same hor/vert groups (round-trip),
+    * "default" alignments are treated as left/top, matching the editor
+      combobox convention (issue #1352),
+    * cells without an explicit alignment collect to 0 (inherit from style).
+
+  Build & run:
+    fpc -Mobjfpc experiments/test_cell_alignment_transfer.pas \
+      && ./experiments/test_cell_alignment_transfer
+}
+program test_cell_alignment_transfer;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils;
+
+type
+  // Mirror of fpsTypes enums (same declaration order!)
+  TsHorAlignment = (haDefault, haLeft, haCenter, haRight);
+  TsVertAlignment = (vaDefault, vaTop, vaCenter, vaBottom);
+  // Mirror of uzeacadtable_types
+  THorzAlign = (zhaLeft, zhaCenter, zhaRight);
+  TVertAlign = (zvaTop, zvaMiddle, zvaBottom);
+
+{ ---- logic copied verbatim from uzvspreadsheet_dimensions.pas ---- }
+
+function HorAlignToGroup(AHor: TsHorAlignment): Integer;
+begin
+  case AHor of
+    haCenter: Result := 1;
+    haRight:  Result := 2;
+    else      Result := 0;  // haLeft, haDefault
+  end;
+end;
+
+function VertAlignToGroup(AVert: TsVertAlignment): Integer;
+begin
+  case AVert of
+    vaCenter: Result := 1;
+    vaBottom: Result := 2;
+    else      Result := 0;  // vaTop, vaDefault
+  end;
+end;
+
+function WorksheetAlignmentToAcad(AHor: TsHorAlignment;
+  AVert: TsVertAlignment): Integer;
+begin
+  Result := VertAlignToGroup(AVert) * 3 + HorAlignToGroup(AHor) + 1;
+end;
+
+{ Collects the AutoCAD code for one cell the way CollectCellAlignments does:
+  0 (inherit) when both alignments are default, otherwise the encoded code. }
+function CollectOne(AHor: TsHorAlignment; AVert: TsVertAlignment): Integer;
+begin
+  if (AHor <> haDefault) or (AVert <> vaDefault) then
+    Result := WorksheetAlignmentToAcad(AHor, AVert)
+  else
+    Result := 0;
+end;
+
+{ ---- logic copied verbatim from uzeacadtable_styles.pas ---- }
+
+function DXFAlignToHorz(Alignment: Integer): THorzAlign;
+var
+  HorzPart: Integer;
+begin
+  HorzPart := (Alignment - 1) mod 3;
+  case HorzPart of
+    1: Result := zhaCenter;
+    2: Result := zhaRight;
+  else
+    Result := zhaLeft;
+  end;
+end;
+
+function DXFAlignToVert(Alignment: Integer): TVertAlign;
+var
+  VertPart: Integer;
+begin
+  VertPart := (Alignment - 1) div 3;
+  case VertPart of
+    1: Result := zvaMiddle;
+    2: Result := zvaBottom;
+  else
+    Result := zvaTop;
+  end;
+end;
+
+{ ---- test harness ---- }
+
+var
+  Failures: Integer = 0;
+
+procedure Check(aCondition: Boolean; const aMsg: string);
+begin
+  if aCondition then
+    WriteLn('  ok  : ', aMsg)
+  else
+  begin
+    WriteLn('  FAIL: ', aMsg);
+    Inc(Failures);
+  end;
+end;
+
+procedure ExpectCode(aHor: TsHorAlignment; aVert: TsVertAlignment;
+  aCode: Integer; aHorz: THorzAlign; aVert2: TVertAlign; const aName: string);
+begin
+  Check(WorksheetAlignmentToAcad(aHor, aVert) = aCode,
+    aName + ': hor/vert -> AutoCAD code ' + IntToStr(aCode));
+  Check(DXFAlignToHorz(aCode) = aHorz, aName + ': code -> horizontal group');
+  Check(DXFAlignToVert(aCode) = aVert2, aName + ': code -> vertical group');
+end;
+
+begin
+  WriteLn('Testing cell alignment transfer (issue #1363)');
+
+  // The 9 combinations, AutoCAD codes 1..9 (1=TopLeft .. 9=BottomRight)
+  ExpectCode(haLeft,   vaTop,    1, zhaLeft,   zvaTop,    'left-top');
+  ExpectCode(haCenter, vaTop,    2, zhaCenter, zvaTop,    'center-top');
+  ExpectCode(haRight,  vaTop,    3, zhaRight,  zvaTop,    'right-top');
+  ExpectCode(haLeft,   vaCenter, 4, zhaLeft,   zvaMiddle, 'left-center');
+  ExpectCode(haCenter, vaCenter, 5, zhaCenter, zvaMiddle, 'center-center');
+  ExpectCode(haRight,  vaCenter, 6, zhaRight,  zvaMiddle, 'right-center');
+  ExpectCode(haLeft,   vaBottom, 7, zhaLeft,   zvaBottom, 'left-bottom');
+  ExpectCode(haCenter, vaBottom, 8, zhaCenter, zvaBottom, 'center-bottom');
+  ExpectCode(haRight,  vaBottom, 9, zhaRight,  zvaBottom, 'right-bottom');
+
+  // Defaults are treated as left/top (matching editor combobox, issue #1352)
+  Check(WorksheetAlignmentToAcad(haDefault, vaDefault) = 1,
+    'haDefault/vaDefault -> AutoCAD code 1 (TopLeft)');
+  Check(WorksheetAlignmentToAcad(haDefault, vaCenter) = 4,
+    'haDefault/vaCenter -> AutoCAD code 4 (MiddleLeft)');
+  Check(WorksheetAlignmentToAcad(haRight, vaDefault) = 3,
+    'haRight/vaDefault -> AutoCAD code 3 (TopRight)');
+
+  // Collection emits 0 (inherit) only when BOTH alignments are default
+  Check(CollectOne(haDefault, vaDefault) = 0,
+    'fully default cell -> 0 (inherit from style)');
+  Check(CollectOne(haCenter, vaDefault) = 2,
+    'explicit horizontal only -> code 2 (TopCenter)');
+  Check(CollectOne(haDefault, vaBottom) = 7,
+    'explicit vertical only -> code 7 (BottomLeft)');
+  Check(CollectOne(haCenter, vaCenter) = 5,
+    'explicit hor+vert -> code 5 (MiddleCenter)');
+
+  WriteLn;
+  if Failures = 0 then
+    WriteLn('ALL TESTS PASSED')
+  else
+  begin
+    WriteLn(Failures, ' TEST(S) FAILED');
+    Halt(1);
+  end;
+end.


### PR DESCRIPTION
## Связывание выравнивания ячеек редактора таблиц с ACAD_TABLE

Решает veb86/zcadvelecAI#1363.

### 📋 Задача
Связать выравнивание текста внутри ячейки электронной таблицы (`TsWorksheet`)
с выравниванием внутри ячейки `GDBObjAcadTable` при её создании командой
создания таблицы ACAD_TABLE из редактора.

### 🔧 Реализация
Выравнивание (горизонтальное + вертикальное), заданное пользователем в ячейках
редактора, теперь переносится в созданную таблицу ACAD_TABLE.

- **`uzeacadtable_types.pas`** — добавлен тип `TTableAlignmentArray` — массив
  кодов выравнивания AutoCAD (group 170, значения `1..9`: `1=TopLeft` …
  `9=BottomRight`; `0` = наследование от стиля таблицы). Индексируется как
  `строка * количество_столбцов + столбец`.
- **`uzeacadtable_model.pas`** — новый метод
  `BuildFromCellTextsWithSizesAndAlignments`, который дополнительно заполняет
  `FCells[r][c].CellAlignment`. Прежний `BuildFromCellTextsWithSizes` теперь
  делегирует ему (с пустым массивом выравниваний → наследование от стиля), что
  сохраняет поведение существующих вызовов. Добавлен публичный аксессор
  `CellAlignmentAt(ARow, ACol)` для проверки в тестах.
- **`uzvspreadsheet_dimensions.pas`** — функции `WorksheetAlignmentToAcad`
  (кодирование пары `TsHorAlignment`/`TsVertAlignment` в group 170) и
  `CollectCellAlignments` (чтение `ReadHorAlignment`/`ReadVertAlignment` ячеек
  листа). Значения «по умолчанию» трактуются как левое/верхнее — так же, как
  в комбобоксе выравнивания редактора (issue #1352). Ячейки без явного
  выравнивания (оба значения по умолчанию) получают `0` — наследование от
  стиля таблицы, чтобы не менять рендеринг нетронутых ячеек.
- **`uzvspreadsheet_cmdcreateacadtable.pas`** — команда собирает выравнивания
  через `CollectCellAlignments` и передаёт их в новый метод построения.

### 🔁 Поток данных
`TsWorksheet` ячейка (Hor/Vert) → `WorksheetAlignmentToAcad` (group 170) →
`FCells[r][c].CellAlignment` → `ResolveCellStyleForBaseRow` (при
`CellAlignment > 0` переопределяет `HorzAlign`/`VertAlign` через
`DXFAlignToHorz`/`DXFAlignToVert`) → выключка MText и позиционирование X/Y в
`RenderCurrentTable`.

### ✅ Проверка
- **Юнит-тест** (`cad_source/zengine/tests/uzctacadtable.pas`):
  `BuildFromCellTextsAppliesCellAlignments` строит таблицу 2×3 с массивом
  выравниваний `[1,5,9,4,0]` (короче числа ячеек) и проверяет, что
  `CellAlignmentAt` возвращает `1,5,9,4,0,0` (последние две ячейки —
  наследование `0`).
- **Автономный тест** (`experiments/test_cell_alignment_transfer.pas`):
  воспроизводит логику кодирования/декодирования (fpspreadsheet не установлен
  в окружении сборки) и проверяет все 9 комбинаций выравнивания с обратным
  round-trip, обработку значений по умолчанию и сбор `0` для нетронутых ячеек.
  Запуск: `fpc -Mobjfpc experiments/test_cell_alignment_transfer.pas &&
  ./experiments/test_cell_alignment_transfer` → **ALL TESTS PASSED**.

---
*This PR was created automatically by the AI issue solver*



Fixes veb86/zcadvelecAI#1363