### PR TITLE
Fix uzvspreadsheet_dimensions compile error (issue #1365)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-21T20:42:44.253Z for PR creation at branch issue-1365-ad5fde7cc5ad for issue https://github.com/veb86/zcadvelecAI/issues/1365

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-21T20:42:44.253Z for PR creation at branch issue-1365-ad5fde7cc5ad for issue https://github.com/veb86/zcadvelecAI/issues/1365

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
@@ -183,20 +183,27 @@ end;
   Совпадает с логикой комбобокса выравнивания редактора (issue #1352). }
 function HorAlignToGroup(AHor: TsHorAlignment): Integer;
 begin
+  // Константы выравнивания квалифицируем именем модуля fpsTypes: модуль
+  // uzeacadtable_types объявляет одноимённые THorzAlign (haLeft/haCenter/
+  // haRight), которые перекрывают значения TsHorAlignment и без квалификации
+  // ломают сборку ("Constant and CASE types do not match").
   case AHor of
-    haCenter: Result := 1;
-    haRight:  Result := 2;
-    else      Result := 0;  // haLeft, haDefault
+    fpsTypes.haCenter: Result := 1;
+    fpsTypes.haRight:  Result := 2;
+    else               Result := 0;  // haLeft, haDefault
   end;
 end;
 
 { Группа вертикального выравнивания: 0 - верх, 1 - центр, 2 - низ. }
 function VertAlignToGroup(AVert: TsVertAlignment): Integer;
 begin
+  // Аналогично горизонтали: uzeacadtable_types объявляет TVertAlign
+  // (vaTop/vaMiddle/vaBottom), перекрывающий TsVertAlignment, поэтому
+  // квалифицируем константы именем модуля fpsTypes.
   case AVert of
-    vaCenter: Result := 1;
-    vaBottom: Result := 2;
-    else      Result := 0;  // vaTop, vaDefault
+    fpsTypes.vaCenter: Result := 1;
+    fpsTypes.vaBottom: Result := 2;
+    else               Result := 0;  // vaTop, vaDefault
   end;
 end;
 
@@ -234,7 +241,7 @@ begin
       Vert := AWorksheet.ReadVertAlignment(Cell);
       // Переносим выравнивание только если оно задано в ячейке листа явно;
       // иначе оставляем 0 (наследование от стиля таблицы).
-      if (Hor <> haDefault) or (Vert <> vaDefault) then
+      if (Hor <> fpsTypes.haDefault) or (Vert <> fpsTypes.vaDefault) then
         Result[RowIdx * AColCount + ColIdx] :=
           WorksheetAlignmentToAcad(Hor, Vert);
     end;

--- a/experiments/issue1365/README.md
+++ b/experiments/issue1365/README.md
@@ -1,0 +1,20 @@
+# Reproduction for issue #1365 — uzvspreadsheet compile error
+
+`uzvspreadsheet_dimensions.pas` uses both `fpsTypes` (TsHorAlignment /
+TsVertAlignment) and `uzeacadtable_types`. The latter declares
+`THorzAlign = (haLeft, haCenter, haRight)` and
+`TVertAlign = (vaTop, vaMiddle, vaBottom)`, whose member names collide with
+the fpspreadsheet constants. Because `uzeacadtable_types` is listed last in
+the `uses` clause, the unqualified `haCenter` / `haRight` / `vaBottom` case
+labels resolve to the acadtable enum, producing:
+
+    Error: Constant and CASE types do not match
+    Error: Duplicate case label   (vaBottom ord 2 == vaCenter ord 2)
+
+## Run
+
+    fpc -Mobjfpc repro_bug.pas      # fails with the issue's errors
+    fpc -Mobjfpc repro_fixed.pas && ./repro_fixed   # PASS
+
+The fix qualifies the constants with the `fpsTypes` unit name
+(`fpsTypes.haCenter`, ...), matching what was applied in the source file.

--- a/experiments/issue1365/acadtable_stub.pas
+++ b/experiments/issue1365/acadtable_stub.pas
@@ -1,0 +1,10 @@
+{ Minimal stub mirroring uzeacadtable_types: declares the SAME identifiers
+  haLeft/haCenter/haRight and vaTop/vaBottom that collide with fpsTypes. }
+unit acadtable_stub;
+{$mode objfpc}{$H+}
+interface
+type
+  THorzAlign = (haLeft, haCenter, haRight);
+  TVertAlign = (vaTop, vaMiddle, vaBottom);
+implementation
+end.

--- a/experiments/issue1365/fpstypes_stub.pas
+++ b/experiments/issue1365/fpstypes_stub.pas
@@ -1,0 +1,9 @@
+{ Minimal stub mirroring the relevant fpsTypes alignment enums (same order). }
+unit fpstypes_stub;
+{$mode objfpc}{$H+}
+interface
+type
+  TsHorAlignment = (haDefault, haLeft, haCenter, haRight);
+  TsVertAlignment = (vaDefault, vaTop, vaCenter, vaBottom);
+implementation
+end.

--- a/experiments/issue1365/repro_bug.pas
+++ b/experiments/issue1365/repro_bug.pas
@@ -1,0 +1,24 @@
+{ Reproduces issue #1365: unqualified alignment constants resolve to the
+  colliding acadtable_stub enum -> compile error. }
+program repro_bug;
+{$mode objfpc}{$H+}
+uses fpstypes_stub, acadtable_stub;
+function HorAlignToGroup(AHor: TsHorAlignment): Integer;
+begin
+  case AHor of
+    haCenter: Result := 1;
+    haRight:  Result := 2;
+    else      Result := 0;
+  end;
+end;
+function VertAlignToGroup(AVert: TsVertAlignment): Integer;
+begin
+  case AVert of
+    vaCenter: Result := 1;
+    vaBottom: Result := 2;
+    else      Result := 0;
+  end;
+end;
+begin
+  WriteLn(HorAlignToGroup(haCenter), VertAlignToGroup(vaBottom));
+end.

--- a/experiments/issue1365/repro_fixed.pas
+++ b/experiments/issue1365/repro_fixed.pas
@@ -1,0 +1,33 @@
+{ The fix from PR: qualify fpspreadsheet alignment constants with the unit name. }
+program repro_fixed;
+{$mode objfpc}{$H+}
+uses fpstypes_stub, acadtable_stub;
+function HorAlignToGroup(AHor: TsHorAlignment): Integer;
+begin
+  case AHor of
+    fpstypes_stub.haCenter: Result := 1;
+    fpstypes_stub.haRight:  Result := 2;
+    else                    Result := 0;
+  end;
+end;
+function VertAlignToGroup(AVert: TsVertAlignment): Integer;
+begin
+  case AVert of
+    fpstypes_stub.vaCenter: Result := 1;
+    fpstypes_stub.vaBottom: Result := 2;
+    else                    Result := 0;
+  end;
+end;
+begin
+  if (HorAlignToGroup(fpstypes_stub.haCenter) = 1)
+     and (HorAlignToGroup(fpstypes_stub.haRight) = 2)
+     and (HorAlignToGroup(fpstypes_stub.haLeft) = 0)
+     and (VertAlignToGroup(fpstypes_stub.vaCenter) = 1)
+     and (VertAlignToGroup(fpstypes_stub.vaBottom) = 2)
+     and (VertAlignToGroup(fpstypes_stub.vaTop) = 0) then
+    WriteLn('PASS: all alignment groups map correctly')
+  else
+  begin
+    WriteLn('FAIL'); Halt(1);
+  end;
+end.


### PR DESCRIPTION
## Summary

Fixes veb86/zcadvelecAI#1365 — `uzvspreadsheet_dimensions.pas` failed to compile:

```
uzvspreadsheet_dimensions.pas(187,13) Error: Constant and CASE types do not match
uzvspreadsheet_dimensions.pas(188,12) Error: Constant and CASE types do not match
uzvspreadsheet_dimensions.pas(198,13) Error: Constant and CASE types do not match
uzvspreadsheet_dimensions.pas(198,13) Error: Duplicate case label
```

## Root cause

The unit's `uses` clause lists `fpsTypes` and then `uzeacadtable_types`. The
latter declares enums whose member names collide with the fpspreadsheet
alignment constants:

- `THorzAlign = (haLeft, haCenter, haRight)`
- `TVertAlign = (vaTop, vaMiddle, vaBottom)`

Because `uzeacadtable_types` is listed **last**, the unqualified labels in the
`case` statements resolved to the acadtable enum instead of fpspreadsheet's
`TsHorAlignment` / `TsVertAlignment`:

- `haCenter` / `haRight` / `vaBottom` get the wrong type → *Constant and CASE types do not match*.
- `vaBottom` (TVertAlign ordinal 2) collides with `vaCenter` (TsVertAlignment ordinal 2) → *Duplicate case label*.

## Fix

Qualify the fpspreadsheet alignment constants with the unit name
(`fpsTypes.haCenter`, `fpsTypes.haRight`, `fpsTypes.vaCenter`,
`fpsTypes.vaBottom`, plus the `fpsTypes.haDefault` / `fpsTypes.vaDefault`
comparison) so they unambiguously refer to `TsHorAlignment` /
`TsVertAlignment`. The mapping logic is unchanged.

## How to reproduce / verify

A standalone FPC reproduction is added under `experiments/issue1365/`:

```
fpc -Mobjfpc repro_bug.pas      # reproduces the exact errors from the issue
fpc -Mobjfpc repro_fixed.pas && ./repro_fixed   # prints: PASS: all alignment groups map correctly
```

`repro_bug.pas` produces the same `Constant and CASE types do not match` +
`duplicate case label` errors; `repro_fixed.pas` applies the same
unit-qualification fix and compiles/passes.