### PR TITLE
uzvspreadsheet: одно поле размера ячейки с применением к выделению (#1359)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-22T11:59:12.137Z for PR creation at branch issue-1359-1508f38440fe for issue https://github.com/veb86/zcadvelecAI/issues/1359

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-22T11:59:12.137Z for PR creation at branch issue-1359-1508f38440fe for issue https://github.com/veb86/zcadvelecAI/issues/1359

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
@@ -77,6 +77,18 @@ function SetWorksheetColWidthMM(AWorksheet: TsWorksheet;
 function SetWorksheetRowHeightMM(AWorksheet: TsWorksheet;
   ARow: Integer; AHeightMM: Double): Boolean;
 
+{ Задаёт одинаковую ширину для диапазона столбцов листа [AStartCol..AEndCol].
+  Применяется к нескольким выделенным столбцам (issue #1359). Возвращает
+  количество фактически изменённых столбцов. }
+function SetWorksheetColWidthsMM(AWorksheet: TsWorksheet;
+  AStartCol, AEndCol: Integer; AWidthMM: Double): Integer;
+
+{ Задаёт одинаковую высоту для диапазона строк листа [AStartRow..AEndRow].
+  Применяется к нескольким выделенным строкам (issue #1359). Возвращает
+  количество фактически изменённых строк. }
+function SetWorksheetRowHeightsMM(AWorksheet: TsWorksheet;
+  AStartRow, AEndRow: Integer; AHeightMM: Double): Integer;
+
 { Собирает ширины столбцов листа в единицах чертежа (для передачи в
   GDBObjAcadTable.BuildFromCellTextsWithSizes). }
 function CollectColWidths(AWorksheet: TsWorksheet;
@@ -149,6 +161,28 @@ begin
     Exit;
   AWorksheet.WriteRowHeight(Cardinal(ARow), AHeightMM, suMillimeters);
   Result := True;
+end;
+
+function SetWorksheetColWidthsMM(AWorksheet: TsWorksheet;
+  AStartCol, AEndCol: Integer; AWidthMM: Double): Integer;
+var
+  ColIdx: Integer;
+begin
+  Result := 0;
+  for ColIdx := AStartCol to AEndCol do
+    if SetWorksheetColWidthMM(AWorksheet, ColIdx, AWidthMM) then
+      Inc(Result);
+end;
+
+function SetWorksheetRowHeightsMM(AWorksheet: TsWorksheet;
+  AStartRow, AEndRow: Integer; AHeightMM: Double): Integer;
+var
+  RowIdx: Integer;
+begin
+  Result := 0;
+  for RowIdx := AStartRow to AEndRow do
+    if SetWorksheetRowHeightMM(AWorksheet, RowIdx, AHeightMM) then
+      Inc(Result);
 end;
 
 function CollectColWidths(AWorksheet: TsWorksheet;

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
@@ -89,13 +89,12 @@ type
     // на OnChange, чтобы не перезаписывать выравнивание выделенной ячейки)
     FUpdatingAlignmentCombo: Boolean;
 
-    // Поля размеров ячейки (issue #1359). Каждое поле состоит из двух
-    // значений: размер в листе (TsWorksheet, мм, редактируемый) и размер
-    // в таблице ACAD_TABLE (GDBObjAcadTable, единицы чертежа, только чтение).
+    // Поля размеров ячейки (issue #1359). Одно поле управляет шириной
+    // выделенного столбца, второе — высотой выделенной строки (в мм листа
+    // TsWorksheet). При выделении нескольких столбцов/строк изменение
+    // применяется ко всему выделенному диапазону.
     FEditColWidthWS: TEdit;     // Ширина столбца в листе (мм)
-    FEditColWidthAcad: TEdit;   // Ширина столбца в таблице ACAD
     FEditRowHeightWS: TEdit;    // Высота строки в листе (мм)
-    FEditRowHeightAcad: TEdit;  // Высота строки в таблице ACAD
     // Флаг: поля размеров обновляются программно (не записывать изменения
     // обратно в лист при синхронизации с выделенной ячейкой)
     FUpdatingDimensionFields: Boolean;
@@ -118,8 +117,7 @@ type
     procedure CreateDimensionFields;
     // Вспомогательные конструкторы элементов панели размеров (issue #1359)
     function CreateToolbarLabel(const ACaption: String): TLabel;
-    function CreateDimensionEdit(AReadOnly: Boolean;
-      const AHint: String): TEdit;
+    function CreateDimensionEdit(const AHint: String): TEdit;
     procedure CreateSpreadsheetComponents;
     procedure CreateCellInfoPanel;
     procedure BuildCommandBar;
@@ -336,25 +334,21 @@ begin
   Result.Width := DIMENSION_LABEL_WIDTH;
 end;
 
-{ Создаёт на панели инструментов поле ввода значения размера. AReadOnly —
-  поле только для чтения (значение таблицы ACAD). AHint — подсказка. }
-function TuzvSpreadsheetForm.CreateDimensionEdit(AReadOnly: Boolean;
-  const AHint: String): TEdit;
+{ Создаёт на панели инструментов редактируемое поле ввода размера.
+  AHint — подсказка. }
+function TuzvSpreadsheetForm.CreateDimensionEdit(const AHint: String): TEdit;
 begin
   Result := TEdit.Create(Self);
   Result.Parent := FToolBar;
   Result.Width := DIMENSION_EDIT_WIDTH;
-  Result.ReadOnly := AReadOnly;
   Result.Hint := AHint;
   Result.ShowHint := True;
-  if AReadOnly then
-    Result.TabStop := False;
 end;
 
 { Создаёт поля размеров ячейки на панели инструментов (issue #1359).
-  Для ширины столбца и высоты строки создаётся по два поля: значение листа
-  (редактируемое, мм) и значение таблицы ACAD_TABLE (только чтение). При
-  редактировании значения листа размер столбца/строки меняется в листе. }
+  По одному редактируемому полю на ширину столбца и высоту строки (мм листа).
+  При выделении ячейки поля заполняются её размерами; редактирование меняет
+  ширину столбца / высоту строки в листе для всего выделенного диапазона. }
 procedure TuzvSpreadsheetForm.CreateDimensionFields;
 var
   Separator: TToolButton;
@@ -365,23 +359,19 @@ begin
   Separator.Style := tbsSeparator;
   Separator.Width := 10;
 
-  // Поле ширины столбца: лист (мм, редактируемое) + ACAD (единицы, чтение)
+  // Поле ширины столбца (мм листа, редактируемое)
   CreateToolbarLabel('Ширина столбца:');
-  FEditColWidthWS := CreateDimensionEdit(False,
-    'Ширина столбца в листе (мм). Изменение меняет столбец листа');
+  FEditColWidthWS := CreateDimensionEdit(
+    'Ширина столбца в листе (мм). Изменение меняет выделенные столбцы');
   FEditColWidthWS.OnExit := @OnColWidthEditExit;
   FEditColWidthWS.OnKeyPress := @OnColWidthKeyPress;
-  FEditColWidthAcad := CreateDimensionEdit(True,
-    'Ширина столбца в таблице ACAD (единицы чертежа)');
 
-  // Поле высоты строки: лист (мм, редактируемое) + ACAD (единицы, чтение)
+  // Поле высоты строки (мм листа, редактируемое)
   CreateToolbarLabel('Высота строки:');
-  FEditRowHeightWS := CreateDimensionEdit(False,
-    'Высота строки в листе (мм). Изменение меняет строку листа');
+  FEditRowHeightWS := CreateDimensionEdit(
+    'Высота строки в листе (мм). Изменение меняет выделенные строки');
   FEditRowHeightWS.OnExit := @OnRowHeightEditExit;
   FEditRowHeightWS.OnKeyPress := @OnRowHeightKeyPress;
-  FEditRowHeightAcad := CreateDimensionEdit(True,
-    'Высота строки в таблице ACAD (единицы чертежа)');
 end;
 
 { Создание панели информации о ячейке }
@@ -649,9 +639,9 @@ begin
   Result := FWorkbookSource.Workbook.ActiveWorksheet;
 end;
 
-{ Обновление полей размеров (ширина столбца/высота строки) по выделенной
-  ячейке. В каждое поле выводится два значения: размер листа (мм) и
-  соответствующий ему размер таблицы ACAD_TABLE (единицы чертежа). }
+{ Обновление полей размеров (ширина столбца/высота строки) по активной
+  ячейке выделения: поля заполняются её шириной столбца и высотой строки
+  в миллиметрах листа. }
 procedure TuzvSpreadsheetForm.UpdateDimensionFields;
 var
   worksheet: TsWorksheet;
@@ -675,11 +665,7 @@ begin
   FUpdatingDimensionFields := True;
   try
     FEditColWidthWS.Text := Format(DIMENSION_VALUE_FORMAT, [widthMM]);
-    FEditColWidthAcad.Text :=
-      Format(DIMENSION_VALUE_FORMAT, [WorksheetToAcadSize(widthMM)]);
     FEditRowHeightWS.Text := Format(DIMENSION_VALUE_FORMAT, [heightMM]);
-    FEditRowHeightAcad.Text :=
-      Format(DIMENSION_VALUE_FORMAT, [WorksheetToAcadSize(heightMM)]);
   finally
     FUpdatingDimensionFields := False;
   end;
@@ -698,11 +684,14 @@ begin
   Result := TryStrToFloat(normalized, AValue, fmt);
 end;
 
-{ Записывает ширину столбца из поля FEditColWidthWS в лист (issue #1359). }
+{ Записывает ширину столбца из поля FEditColWidthWS в лист (issue #1359).
+  Изменение применяется ко всем выделенным столбцам; если выделение
+  недоступно, к столбцу активной ячейки. }
 procedure TuzvSpreadsheetForm.ApplyColWidthFromField;
 var
   worksheet: TsWorksheet;
-  col: Integer;
+  startRow, endRow, startCol, endCol: Integer;
+  changed: Integer;
   widthMM: Double;
 begin
   if FUpdatingDimensionFields or (FEditColWidthWS = nil) then
@@ -718,24 +707,34 @@ begin
     Exit;
   end;
 
-  col := FWorksheetGrid.Col - FWorksheetGrid.FixedCols;
-  if SetWorksheetColWidthMM(worksheet, col, widthMM) then
+  // Диапазон выделенных столбцов; при недоступном выделении — активный столбец
+  if not GetSelectedRange(startRow, endRow, startCol, endCol) then
+  begin
+    startCol := FWorksheetGrid.Col - FWorksheetGrid.FixedCols;
+    endCol := startCol;
+  end;
+
+  changed := SetWorksheetColWidthsMM(worksheet, startCol, endCol, widthMM);
+  if changed > 0 then
   begin
     programlog.LogOutFormatStr(
-      'Spreadsheet: ширина столбца %d изменена на %.2f мм',
-      [col, widthMM], LM_Info);
+      'Spreadsheet: ширина столбцов %d..%d изменена на %.2f мм (%d шт.)',
+      [startCol, endCol, widthMM, changed], LM_Info);
     if FWorksheetGrid <> nil then
       FWorksheetGrid.Invalidate;
   end;
 
-  UpdateDimensionFields;  // Пересчитываем значение ACAD
+  UpdateDimensionFields;  // Возвращаем отформатированное значение в поле
 end;
 
-{ Записывает высоту строки из поля FEditRowHeightWS в лист (issue #1359). }
+{ Записывает высоту строки из поля FEditRowHeightWS в лист (issue #1359).
+  Изменение применяется ко всем выделенным строкам; если выделение
+  недоступно, к строке активной ячейки. }
 procedure TuzvSpreadsheetForm.ApplyRowHeightFromField;
 var
   worksheet: TsWorksheet;
-  row: Integer;
+  startRow, endRow, startCol, endCol: Integer;
+  changed: Integer;
   heightMM: Double;
 begin
   if FUpdatingDimensionFields or (FEditRowHeightWS = nil) then
@@ -751,17 +750,24 @@ begin
     Exit;
   end;
 
-  row := FWorksheetGrid.Row - FWorksheetGrid.FixedRows;
-  if SetWorksheetRowHeightMM(worksheet, row, heightMM) then
+  // Диапазон выделенных строк; при недоступном выделении — активная строка
+  if not GetSelectedRange(startRow, endRow, startCol, endCol) then
+  begin
+    startRow := FWorksheetGrid.Row - FWorksheetGrid.FixedRows;
+    endRow := startRow;
+  end;
+
+  changed := SetWorksheetRowHeightsMM(worksheet, startRow, endRow, heightMM);
+  if changed > 0 then
   begin
     programlog.LogOutFormatStr(
-      'Spreadsheet: высота строки %d изменена на %.2f мм',
-      [row, heightMM], LM_Info);
+      'Spreadsheet: высота строк %d..%d изменена на %.2f мм (%d шт.)',
+      [startRow, endRow, heightMM, changed], LM_Info);
     if FWorksheetGrid <> nil then
       FWorksheetGrid.Invalidate;
   end;
 
-  UpdateDimensionFields;  // Пересчитываем значение ACAD
+  UpdateDimensionFields;  // Возвращаем отформатированное значение в поле
 end;
 
 { Обработчик выхода из поля ширины столбца }

--- a/experiments/test_dimension_range.pas
+++ b/experiments/test_dimension_range.pas
@@ -1,0 +1,101 @@
+{ Standalone test for the multi-column / multi-row size logic (issue #1359).
+
+  fpspreadsheet is not exercised here; this program replicates the pure
+  range-setting logic implemented in
+    cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+      (SetWorksheetColWidthsMM / SetWorksheetRowHeightsMM)
+  over a plain array standing in for the worksheet columns/rows.
+
+  It verifies:
+    * applying a width across a span updates every column in the span,
+    * the function returns the count of changed entries,
+    * non-positive values are rejected (count stays 0, no entry changed),
+    * a single-cell span (start = end) updates exactly one entry.
+
+  Build & run:
+    fpc -Mobjfpc experiments/test_dimension_range.pas \
+      && ./experiments/test_dimension_range
+}
+program test_dimension_range;
+
+{$mode objfpc}{$H+}
+
+uses
+  SysUtils;
+
+type
+  TSizes = array of Double;
+
+var
+  Sheet: TSizes;
+
+{ Mirrors SetWorksheetColWidthMM/SetWorksheetRowHeightMM: rejects
+  non-positive sizes and out-of-range indices. }
+function SetOne(AIndex: Integer; AValue: Double): Boolean;
+begin
+  Result := False;
+  if (AIndex < 0) or (AIndex > High(Sheet)) or (AValue <= 0) then
+    Exit;
+  Sheet[AIndex] := AValue;
+  Result := True;
+end;
+
+{ Mirrors SetWorksheetColWidthsMM/SetWorksheetRowHeightsMM. }
+function SetRange(AStart, AEnd: Integer; AValue: Double): Integer;
+var
+  i: Integer;
+begin
+  Result := 0;
+  for i := AStart to AEnd do
+    if SetOne(i, AValue) then
+      Inc(Result);
+end;
+
+var
+  Failures: Integer = 0;
+
+procedure Check(aCondition: Boolean; const aMsg: string);
+begin
+  if aCondition then
+    WriteLn('  ok  : ', aMsg)
+  else
+  begin
+    WriteLn('  FAIL: ', aMsg);
+    Inc(Failures);
+  end;
+end;
+
+function NearlyEqual(a, b: Double): Boolean;
+begin
+  Result := Abs(a - b) < 1e-9;
+end;
+
+begin
+  WriteLn('Testing multi-column/row size logic (issue #1359)');
+
+  // Span across several columns updates each one and reports the count.
+  SetLength(Sheet, 5);
+  Check(SetRange(1, 3, 42.0) = 3, 'span [1..3] reports 3 changed');
+  Check(NearlyEqual(Sheet[1], 42.0) and NearlyEqual(Sheet[2], 42.0)
+    and NearlyEqual(Sheet[3], 42.0), 'columns 1..3 set to 42');
+  Check(NearlyEqual(Sheet[0], 0.0) and NearlyEqual(Sheet[4], 0.0),
+    'columns outside span untouched');
+
+  // Single-cell span updates exactly one entry.
+  Check(SetRange(0, 0, 15.0) = 1, 'single-cell span reports 1 changed');
+  Check(NearlyEqual(Sheet[0], 15.0), 'column 0 set to 15');
+
+  // Non-positive value rejected: nothing changed.
+  Check(SetRange(1, 3, 0.0) = 0, 'zero value -> 0 changed');
+  Check(SetRange(1, 3, -7.0) = 0, 'negative value -> 0 changed');
+  Check(NearlyEqual(Sheet[1], 42.0), 'rejected value leaves column intact');
+
+  WriteLn;
+  if Failures = 0 then
+    WriteLn('ALL TESTS PASSED')
+  else
+  begin
+    WriteLn(Failures, ' TEST(S) FAILED');
+    Halt(1);
+  end;
+end.

--- a/test_issue1359_dimension_fields.py
+++ b/test_issue1359_dimension_fields.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1359 follow-up feedback.
+
+The author requested two changes to the spreadsheet cell-size linkage:
+  1. Drop the duplicate read-only ACAD-value field; keep a single editable
+     field for column width and a single one for row height.
+  2. Apply a width/height change to every selected column/row, not only the
+     active cell's column/row.
+
+These are static source checks (the Lazarus GUI cannot be exercised
+head-less here); the pure range logic is covered by the standalone Pascal
+test experiments/test_dimension_range.pas.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+GUI_PAS = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvspreadsheet"
+    / "uzvspreadsheet_gui.pas"
+)
+DIMENSIONS_PAS = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvspreadsheet"
+    / "uzvspreadsheet_dimensions.pas"
+)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_duplicate_acad_fields_removed():
+    gui = read_text(GUI_PAS)
+    # The read-only ACAD-value duplicate fields must be gone entirely.
+    assert "FEditColWidthAcad" not in gui
+    assert "FEditRowHeightAcad" not in gui
+    # Exactly one editable field remains for each dimension.
+    assert gui.count("FEditColWidthWS: TEdit") == 1
+    assert gui.count("FEditRowHeightWS: TEdit") == 1
+    # Only two dimension edits are constructed (col width + row height).
+    assert gui.count(":= CreateDimensionEdit(") == 2
+
+
+def test_dimensions_unit_exposes_range_setters():
+    dimensions = read_text(DIMENSIONS_PAS)
+    assert "function SetWorksheetColWidthsMM(" in dimensions
+    assert "function SetWorksheetRowHeightsMM(" in dimensions
+    # Range setters iterate over the requested span.
+    assert "for ColIdx := AStartCol to AEndCol do" in dimensions
+    assert "for RowIdx := AStartRow to AEndRow do" in dimensions
+
+
+def test_apply_uses_selection_range():
+    gui = read_text(GUI_PAS)
+    # Column width is applied across the selected column range.
+    assert "SetWorksheetColWidthsMM(worksheet, startCol, endCol, widthMM)" in gui
+    # Row height is applied across the selected row range.
+    assert (
+        "SetWorksheetRowHeightsMM(worksheet, startRow, endRow, heightMM)" in gui
+    )
+    # Both apply procedures consult the grid selection.
+    assert gui.count("GetSelectedRange(startRow, endRow, startCol, endCol)") == 2
+
+
+if __name__ == "__main__":
+    test_duplicate_acad_fields_removed()
+    test_dimensions_unit_exposes_range_setters()
+    test_apply_uses_selection_range()
+    print("ALL TESTS PASSED")


### PR DESCRIPTION
## 🤖 AI-Powered Solution

Fixes veb86/zcadvelecAI#1359 (follow-up to author feedback).

### 📋 Контекст

Базовая функциональность связывания размеров ячеек редактора таблиц с
`GDBObjAcadTable` уже была реализована в `master`. Этот PR закрывает два
замечания автора из комментария к issue:

> 1. Убери дублирующее поле, оно не к чему. Одного поля вполне достаточно
>    одного поля для ширины столбца и одного поля для высоты строки.
> 2. Необходимо добавить возможность изменения полями сразу несколько
>    столбцов или строк, в зависимости от выделенных ячеек.

### 🔧 Изменения

1. **Убрано дублирующее поле.** На панели инструментов остаётся по одному
   редактируемому полю на ширину столбца и высоту строки (значение листа
   `TsWorksheet`, мм). Поля только для чтения со значениями `ACAD_TABLE`
   (`FEditColWidthAcad` / `FEditRowHeightAcad`) удалены.
2. **Применение к выделению.** Изменение ширины/высоты теперь применяется ко
   всем выделенным столбцам/строкам (диапазон `GetSelectedRange`), а не
   только к активной ячейке. При недоступном выделении меняется столбец/
   строка активной ячейки.
3. В `uzvspreadsheet_dimensions` добавлены чистые функции
   `SetWorksheetColWidthsMM` / `SetWorksheetRowHeightsMM`, задающие
   одинаковый размер диапазону и возвращающие количество изменённых
   элементов (вынесены отдельно для покрытия тестами).

### ✅ Тесты

- `experiments/test_dimension_range.pas` — автономный тест логики применения
  размера к диапазону (счётчик изменений, отбраковка неположительных
  значений, односекционный диапазон). Собирается `fpc` и проходит.
- `test_issue1359_dimension_fields.py` — статические проверки исходников:
  дублирующие поля удалены, объявлены функции диапазона, обе процедуры
  применения используют выделение. Проходит.

### Как проверить

1. Открыть редактор электронных таблиц.
2. Выделить несколько столбцов (или строк), ввести значение в поле
   «Ширина столбца» / «Высота строки» и нажать Enter.
3. Все выделенные столбцы/строки изменят размер; на панели остаётся одно
   поле на каждый размер.
