### PR TITLE
fix(uzvspreadsheet): ошибки компиляции Duplicate identifier "Changed" (#1369)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-22T12:44:15.857Z for PR creation at branch issue-1369-0491293fbd5c for issue https://github.com/veb86/zcadvelecAI/issues/1369

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-22T12:44:15.857Z for PR creation at branch issue-1369-0491293fbd5c for issue https://github.com/veb86/zcadvelecAI/issues/1369

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
@@ -691,7 +691,7 @@ procedure TuzvSpreadsheetForm.ApplyColWidthFromField;
 var
   worksheet: TsWorksheet;
   startRow, endRow, startCol, endCol: Integer;
-  changed: Integer;
+  changedCount: Integer;
   widthMM: Double;
 begin
   if FUpdatingDimensionFields or (FEditColWidthWS = nil) then
@@ -714,12 +714,12 @@ begin
     endCol := startCol;
   end;
 
-  changed := SetWorksheetColWidthsMM(worksheet, startCol, endCol, widthMM);
-  if changed > 0 then
+  changedCount := SetWorksheetColWidthsMM(worksheet, startCol, endCol, widthMM);
+  if changedCount > 0 then
   begin
     programlog.LogOutFormatStr(
       'Spreadsheet: ширина столбцов %d..%d изменена на %.2f мм (%d шт.)',
-      [startCol, endCol, widthMM, changed], LM_Info);
+      [startCol, endCol, widthMM, changedCount], LM_Info);
     if FWorksheetGrid <> nil then
       FWorksheetGrid.Invalidate;
   end;
@@ -734,7 +734,7 @@ procedure TuzvSpreadsheetForm.ApplyRowHeightFromField;
 var
   worksheet: TsWorksheet;
   startRow, endRow, startCol, endCol: Integer;
-  changed: Integer;
+  changedCount: Integer;
   heightMM: Double;
 begin
   if FUpdatingDimensionFields or (FEditRowHeightWS = nil) then
@@ -757,12 +757,12 @@ begin
     endRow := startRow;
   end;
 
-  changed := SetWorksheetRowHeightsMM(worksheet, startRow, endRow, heightMM);
-  if changed > 0 then
+  changedCount := SetWorksheetRowHeightsMM(worksheet, startRow, endRow, heightMM);
+  if changedCount > 0 then
   begin
     programlog.LogOutFormatStr(
       'Spreadsheet: высота строк %d..%d изменена на %.2f мм (%d шт.)',
-      [startRow, endRow, heightMM, changed], LM_Info);
+      [startRow, endRow, heightMM, changedCount], LM_Info);
     if FWorksheetGrid <> nil then
       FWorksheetGrid.Invalidate;
   end;


### PR DESCRIPTION
## Исправление ошибок компиляции uzvspreadsheet

Fixes veb86/zcadvelecAI#1369

### Проблема
Компилятор FPC выдавал ошибки:
```
uzvspreadsheet_gui.pas(694,3) Error: Duplicate identifier "Changed"
uzvspreadsheet_gui.pas(737,3) Error: Duplicate identifier "Changed"
```

### Причина
В методах `TuzvSpreadsheetForm.ApplyColWidthFromField` и
`TuzvSpreadsheetForm.ApplyRowHeightFromField` (добавлены в #1359) объявлена
локальная переменная `changed`. Идентификаторы в Pascal регистронезависимы, а
`TuzvSpreadsheetForm` наследуется от `TForm` → `TControl`, где уже есть метод
`Changed`. Внутри тела метода имя метода класса находится в области видимости,
поэтому локальная переменная `changed` конфликтовала с ним.

### Решение
Локальная переменная `changed` переименована в `changedCount` в обоих методах.
Это устраняет конфликт имён и заодно делает назначение переменной (количество
изменённых столбцов/строк) более понятным.

### Изменённые файлы
- `cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas`
