### PR TITLE
fix(uzvspreadsheet): обновлять отображение высоты строк в TsWorksheetGrid (#1359)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-22T13:11:12.242Z for PR creation at branch issue-1359-a45c5bb4da25 for issue https://github.com/veb86/zcadvelecAI/issues/1359

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-22T13:11:12.242Z for PR creation at branch issue-1359-a45c5bb4da25 for issue https://github.com/veb86/zcadvelecAI/issues/1359

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas
@@ -764,7 +764,17 @@ begin
       'Spreadsheet: высота строк %d..%d изменена на %.2f мм (%d шт.)',
       [startRow, endRow, heightMM, changedCount], LM_Info);
     if FWorksheetGrid <> nil then
+    begin
+      // TsWorksheetGrid не перестраивает высоту строки по уведомлению при
+      // программной записи WriteRowHeight: его обработчик lniRow обновляет
+      // строку только для НЕ-rhtCustom строк (см. fpspreadsheetgrid.pas,
+      // ListenerNotification), а WriteRowHeight как раз помечает строку
+      // rhtCustom. Поэтому, в отличие от ширины столбца (lniCol всегда
+      // вызывает UpdateColWidth), высота визуально не менялась. Принудительно
+      // пересчитываем высоты строк сетки из записей листа (issue #1359).
+      FWorksheetGrid.UpdateRowHeights;
       FWorksheetGrid.Invalidate;
+    end;
   end;
 
   UpdateDimensionFields;  // Возвращаем отформатированное значение в поле

--- a/test_issue1359_dimension_fields.py
+++ b/test_issue1359_dimension_fields.py
@@ -72,8 +72,24 @@ def test_apply_uses_selection_range():
     assert gui.count("GetSelectedRange(startRow, endRow, startCol, endCol)") == 2
 
 
+def test_row_height_forces_grid_rebuild():
+    """Issue 1359 follow-up: changing a row height did not visually update
+    TsWorksheetGrid because its lniRow notification skips rhtCustom rows
+    (set by WriteRowHeight). The apply procedure must force a row-height
+    rebuild so the display matches the stored value."""
+    gui = read_text(GUI_PAS)
+    apply_start = gui.index("procedure TuzvSpreadsheetForm.ApplyRowHeightFromField")
+    apply_end = gui.index(
+        "procedure TuzvSpreadsheetForm.OnColWidthEditExit", apply_start
+    )
+    apply_body = gui[apply_start:apply_end]
+    # Row-height apply must rebuild grid row heights from the sheet records.
+    assert "FWorksheetGrid.UpdateRowHeights" in apply_body
+
+
 if __name__ == "__main__":
     test_duplicate_acad_fields_removed()
     test_dimensions_unit_exposes_range_setters()
     test_apply_uses_selection_range()
+    test_row_height_forces_grid_rebuild()
     print("ALL TESTS PASSED")


### PR DESCRIPTION
## 🎯 Issue

Fixes veb86/zcadvelecAI#1359 (follow-up feedback).

В комментарии к issue сообщено: **при изменении высоты строки через поле размера `TsWorksheetGrid` визуально не перестраивает высоту строки.** Число в поле корректное, выгрузка в чертёж (ACAD_TABLE) правильная — но отображение сетки не меняется. При изменении ширины столбца всё работает.

## 🔍 Причина

В `fpspreadsheetgrid.pas` обработчик уведомлений `TsCustomWorksheetGrid.ListenerNotification` обрабатывает строки и столбцы по-разному:

- **`lniCol`** (ширина столбца) — **всегда** вызывает `UpdateColWidth(gcol)`, поэтому ширина обновляется.
- **`lniRow`** (высота строки) — вызывает `UpdateRowHeight` только если строка **не** `rhtCustom`:

```pascal
if (lRow = nil) or (lRow^.RowHeightType <> rhtCustom) then
  UpdateRowHeight(grow, true);
```

А `TsWorksheet.WriteRowHeight` по умолчанию помечает строку именно `rhtCustom`. В результате уведомление приходит, но сетка намеренно пропускает пересчёт высоты — отображение не меняется.

## 🛠 Решение

После записи высот в `ApplyRowHeightFromField` принудительно вызываем `FWorksheetGrid.UpdateRowHeights`, который пересчитывает высоты строк сетки из записей листа (включая `rhtCustom`). Путь для ширины столбца не трогаем — он и так работает.

## ✅ Проверка

- Добавлен регрессионный статический тест `test_row_height_forces_grid_rebuild` в `test_issue1359_dimension_fields.py` (GUI Lazarus не запускается headless, поэтому проверка контрактная — как и остальные тесты этого файла).
- `python3 test_issue1359_dimension_fields.py` → `ALL TESTS PASSED`.

## 📋 Изменённые файлы

- `cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_gui.pas` — вызов `UpdateRowHeights` после изменения высоты строк.
- `test_issue1359_dimension_fields.py` — регрессионный тест.
