### PR TITLE
fix(acadtable): load tables with multiple header rows (#1373)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-22T19:21:35.482Z for PR creation at branch issue-1373-a8f2fb4bc44b for issue https://github.com/veb86/zcadvelecAI/issues/1373

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-22T19:21:35.482Z for PR creation at branch issue-1373-a8f2fb4bc44b for issue https://github.com/veb86/zcadvelecAI/issues/1373

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -399,7 +399,7 @@ type
     // позиционный/принудительный выбор стиля). Вызывается при экспорте из
     // редактора электронных таблиц после построения геометрии, чтобы строки,
     // целиком состоящие из ячеек Title/Header, получили соответствующий стиль.
-    procedure SetRowStyleTypes(const ATypes: array of Integer); override;
+    procedure SetRowStyleTypes(const ATypes: array of Integer); virtual;
     // Возвращает явно заданный индекс базового стиля для строки ARow
     // (0=Title, 1=Header, 2=Data) либо -1, если тип строки не задан или
     // строка вне диапазона (issue #1368).

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -399,7 +399,7 @@ type
     // позиционный/принудительный выбор стиля). Вызывается при экспорте из
     // редактора электронных таблиц после построения геометрии, чтобы строки,
     // целиком состоящие из ячеек Title/Header, получили соответствующий стиль.
-    procedure SetRowStyleTypes(const ATypes: array of Integer);
+    procedure SetRowStyleTypes(const ATypes: array of Integer); override;
     // Возвращает явно заданный индекс базового стиля для строки ARow
     // (0=Title, 1=Header, 2=Data) либо -1, если тип строки не задан или
     // строка вне диапазона (issue #1368).

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -99,6 +99,13 @@ type
       ACAD_ROUNDTRIP_2008_TABLE_ENTITY. Base implementation does nothing;
       table entities override it (issue #1339). }
     procedure SetBreakOptionFlags(AManualPosition,AManualHeight:boolean);virtual;
+    { Передаёт сущности явные типы строк, прочитанные загрузчиком DXF из
+      современного объекта AcDbTableContent (TABLEROW_BEGIN group 90).
+      ATypes индексируется по номеру строки (0=Title, 1=Header, 2=Data;
+      значение < 0 — тип не задан). Базовая реализация ничего не делает;
+      GDBObjAcadTable переопределяет метод, чтобы строки с несколькими
+      заголовками загружались с правильным стилем (issue #1373). }
+    procedure SetRowStyleTypes(const ATypes:array of integer);virtual;
     { Передаёт сущности исходный текст DXF-entity, если загрузчик сохранил
       его для round-trip экспорта. Базовая реализация ничего не делает. }
     procedure SetDXFRawEntityText(const ARawText:string);virtual;
@@ -474,6 +481,10 @@ begin
 end;
 
 procedure GDBObjEntity.SetBreakOptionFlags(AManualPosition,AManualHeight:boolean);
+begin
+end;
+
+procedure GDBObjEntity.SetRowStyleTypes(const ATypes:array of integer);
 begin
 end;
 

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -455,6 +455,96 @@ begin
   end;
 end;
 
+{ Сканирует секцию OBJECTS и извлекает явные типы строк первой (главной)
+  таблицы из современного объекта AcDbTableContent.
+
+  Внутри AcDbTableContent данные строк хранятся повторяющимися блоками,
+  каждый из которых начинается строковым маркером TABLEROW_BEGIN (значение
+  группы 1). Сразу за маркером идёт группа 90 с типом строки в соглашении
+  AutoCAD: 1=Title, 2=Header, 3=Data. Эти типы — единственный надёжный
+  источник информации о числе строк-заголовков: позиционная логика legacy
+  AcDbTable-парсера жёстко предполагает ровно одну строку Title и одну
+  Header и не может представить таблицу с несколькими заголовками
+  (issue #1373).
+
+  Содержимое объекта распознаётся по маркеру подкласса (группа 100) =
+  'AcDbLinkedTableData'. Собираются строки только первого встретившегося
+  content-объекта (до начала следующего), что соответствует главной
+  таблице. Значения маппятся в соглашение ZCAD: 1->0, 2->1, 3->2, иное->-1.
+
+  ARowStyleTypes получает массив типов строк по порядку, AValid=True,
+  если собрана хотя бы одна строка. }
+procedure ScanTableRowStyleTypes(const RawObjectsSection: string;
+  out ARowStyleTypes: TDXFRowStyleTypeArray; out AValid: Boolean);
+var
+  Lines: TStringList;
+  I, Code, Count, DxfType, ZType: Integer;
+  Value: string;
+  InContent, PendingRowType: Boolean;
+begin
+  SetLength(ARowStyleTypes, 0);
+  AValid := False;
+  if RawObjectsSection = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := RawObjectsSection;
+    InContent := False;
+    PendingRowType := False;
+    Count := 0;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if TryReadDxfPair(Lines, I, Code, Value) then
+      begin
+        if Code = 100 then
+        begin
+          if UpperCase(Value) = UpperCase('AcDbLinkedTableData') then
+          begin
+            { Начало следующего content-объекта — главная таблица собрана. }
+            if InContent then
+              Break;
+            InContent := True;
+          end;
+        end
+        else if InContent and (Code = 1) and (Value = 'TABLEROW_BEGIN') then
+          PendingRowType := True
+        else if InContent and PendingRowType and (Code = 90) then
+        begin
+          DxfType := StrToIntDef(Trim(Value), 0);
+          case DxfType of
+            1: ZType := 0; { Title  }
+            2: ZType := 1; { Header }
+            3: ZType := 2; { Data   }
+          else
+            ZType := -1;
+          end;
+          if Count > High(ARowStyleTypes) then
+            SetLength(ARowStyleTypes, (Count + 1) * 2);
+          ARowStyleTypes[Count] := ZType;
+          Inc(Count);
+          PendingRowType := False;
+        end;
+
+        Inc(I, 2);
+      end
+      else
+        Inc(I);
+    end;
+
+    SetLength(ARowStyleTypes, Count);
+    AValid := Count > 0;
+
+    if AValid then
+      programlog.LogOutFormatStr(
+        'uzeffdxf: ScanTableRowStyleTypes: найдено %d строк(и) с явным типом',
+        [Count], LM_Info);
+  finally
+    Lines.Free;
+  end;
+end;
+
 procedure gotodxf(var rdr:TZMemReader; fcode: Integer; const fname: String);
 var
   byt: Integer;
@@ -836,6 +926,12 @@ begin
             pLastMainTable^.SetBreakOptionFlags(
               context.TableBreakManualPosition,
               context.TableBreakManualHeight);
+          { Явные типы строк из современного объекта AcDbTableContent
+            (TABLEROW_BEGIN group 90). Позволяют корректно загружать
+            таблицы с несколькими строками-заголовками, которые позиционная
+            логика legacy AcDbTable-парсера представить не может (issue #1373). }
+          if context.TableRowStyleTypesValid then
+            pLastMainTable^.SetRowStyleTypes(context.TableRowStyleTypes);
         end;
         if not(IsObjectIt(TypeOf(owner^),TypeOf(GDBObjBlockdef))) then begin
           if PGDBObjEntity(pobj)^.DXFDelayedBuildGeometry then begin
@@ -1790,6 +1886,15 @@ begin
           fileCtx.TableBreakManualPosition,
           fileCtx.TableBreakManualHeight,
           fileCtx.TableBreakFlagsValid);
+
+        { Извлекаем явные типы строк (Title/Header/Data) из современного
+          объекта AcDbTableContent. Передаются в главную ACAD_TABLE через
+          SetRowStyleTypes, чтобы таблицы с несколькими строками-заголовками
+          загружались с правильным стилем строк (issue #1373). }
+        ScanTableRowStyleTypes(
+          dwgCtx.PDrawing^.RawObjectsSection,
+          fileCtx.TableRowStyleTypes,
+          fileCtx.TableRowStyleTypesValid);
 
         lph:=lps.StartLongProcess(rsLoadDXFFile,@rdr,rdr.Size,LPSOSilent);
         case fileCtx.Header.Version of

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -929,8 +929,14 @@ begin
           { Явные типы строк из современного объекта AcDbTableContent
             (TABLEROW_BEGIN group 90). Позволяют корректно загружать
             таблицы с несколькими строками-заголовками, которые позиционная
-            логика legacy AcDbTable-парсера представить не может (issue #1373). }
-          if context.TableRowStyleTypesValid then
+            логика legacy AcDbTable-парсера представить не может (issue #1373).
+            Применяем только к цельным (не разбитым) таблицам: у разбитой на
+            части таблицы строки в AcDbTableContent перечислены с повторами
+            заголовков по каждой части, поэтому их индексы не совпадают с
+            логическими строками склеенной таблицы (issue #1300/#1373). }
+          if context.TableRowStyleTypesValid and
+             ((context.TableContinuationHandles=nil) or
+              (context.TableContinuationHandles.Count=0)) then
             pLastMainTable^.SetRowStyleTypes(context.TableRowStyleTypes);
         end;
         if not(IsObjectIt(TypeOf(owner^),TypeOf(GDBObjBlockdef))) then begin

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -130,6 +130,10 @@ type
     constructor Create(const AText:string);
   end;
 
+  { Явные типы строк таблицы в соглашении ZCAD (0=Title, 1=Header, 2=Data;
+    -1 — тип не задан), прочитанные pre-scan'ом из AcDbTableContent (#1373). }
+  TDXFRowStyleTypeArray=array of integer;
+
   TIODXFLoadContext=record
     h2p:TDXFHandle2ZCObject;
     DWGVarsDict:TString2StringDictionary;
@@ -169,6 +173,17 @@ type
     TableBreakManualPosition:boolean;
     TableBreakManualHeight:boolean;
     TableBreakFlagsValid:boolean;
+
+    { Явные типы строк первой (главной) таблицы, прочитанные pre-scan'ом
+      из современного объекта AcDbTableContent (каждый TABLEROW_BEGIN
+      несёт group 90 = тип строки: 1=Title, 2=Header, 3=Data). Маппятся в
+      соглашение ZCAD (0=Title, 1=Header, 2=Data; иное -> -1) и передаются
+      в главную ACAD_TABLE через SetRowStyleTypes. Нужны для таблиц с
+      несколькими строками-заголовками, которые позиционная логика
+      legacy-парсера AcDbTable (ровно 1 Title + 1 Header) представить не
+      может (issue #1373). }
+    TableRowStyleTypes:TDXFRowStyleTypeArray;
+    TableRowStyleTypesValid:boolean;
 
     procedure InitRec;
     procedure Done;
@@ -424,6 +439,9 @@ begin
   TableBreakManualPosition:=False;
   TableBreakManualHeight:=False;
   TableBreakFlagsValid:=False;
+
+  SetLength(TableRowStyleTypes,0);
+  TableRowStyleTypesValid:=False;
 end;
 
 procedure TDXFHeaderInfo.InitRec;
@@ -447,6 +465,7 @@ begin
       TableRawAcadTableEntities.Objects[I].Free;
     FreeAndNil(TableRawAcadTableEntities);
   end;
+  SetLength(TableRowStyleTypes,0);
 end;
 
 function DXFHandle(const sh:string):TDWGHandle;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -40,6 +40,7 @@ uses
   uzeentmtext,
   uzeentline,
   uzeentgenericsubentry,
+  uzeentsubordinated,
   uzeentcomplex,
   UGDBVisibleTreeArray,
   uzeenttext,

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -164,6 +164,11 @@ type
     // сбрасывает ранее заданные типы строк.
     procedure SetRowStyleTypesAssignsRowStyles;
     procedure RebuildResetsRowStyleTypes;
+    // issue #1373: таблица с несколькими строками-заголовками (tablebugheader.dxf:
+    // строка 0 = Title, строки 1 и 2 = Header, остальные = Data) должна
+    // загружаться с правильными типами строк, прочитанными из современного
+    // объекта AcDbTableContent (TABLEROW_BEGIN group 90).
+    procedure LoadsMultipleHeaderRowsFromDXF;
   end;
 
 implementation
@@ -2449,6 +2454,41 @@ begin
       'После перестроения строка 0 не должна иметь явного типа');
     CheckEquals(-1, Table^.RowStyleTypeAt(1),
       'После перестроения строка 1 не должна иметь явного типа');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1373. tablebugheader.dxf содержит одиночную таблицу 6×3, у которой
+// строка 0 — стиль Title, строки 1 И 2 — стиль Header, остальные — Data.
+// Позиционная логика legacy AcDbTable-парсера жёстко предполагает ровно одну
+// строку Title и одну Header, поэтому раньше третья строка (индекс 2) ошибочно
+// загружалась как Data. Числа строк-заголовков нет в legacy-потоке ячеек —
+// оно хранится только в современном объекте AcDbTableContent, где каждый
+// маркер TABLEROW_BEGIN несёт group 90 с типом строки (1=Title, 2=Header,
+// 3=Data). Загрузчик читает эти типы pre-scan'ом и передаёт в таблицу через
+// SetRowStyleTypes, так что RowStyleTypeAt отражает реальные типы строк.
+procedure TAcadTableStyleTest.LoadsMultipleHeaderRowsFromDXF;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablebugheader.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    CheckEquals(0, AcadTable^.RowStyleTypeAt(0),
+      'Строка 0 должна загружаться со стилем Title (0)');
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(1),
+      'Строка 1 должна загружаться со стилем Header (1)');
+    // Ключевая проверка issue #1373: вторая строка-заголовок раньше ошибочно
+    // определялась как Data.
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(2),
+      'Строка 2 (вторая строка-заголовок) должна загружаться со стилем Header (1)');
+    CheckEquals(2, AcadTable^.RowStyleTypeAt(3),
+      'Строка 3 должна загружаться со стилем Data (2)');
   finally
     Drawing.done;
   end;

--- a/test_issue1373_acadtable_multiheader_contract.py
+++ b/test_issue1373_acadtable_multiheader_contract.py
@@ -45,9 +45,12 @@ def test_base_entity_declares_row_style_hook():
 
 
 def test_acadtable_model_overrides_row_style_hook():
+    # GDBObjAcadTable is an old-style Pascal `object`, which overrides a virtual
+    # base method by redeclaring it `virtual` (same as SetBreakOptionFlags), not
+    # with the `override` keyword used by classes.
     model = compact(read_text(ACADTABLE_MODEL))
     assert (
-        "proceduresetrowstyletypes(constatypes:arrayofinteger);override;" in model
+        "proceduresetrowstyletypes(constatypes:arrayofinteger);virtual;" in model
     )
 
 
@@ -61,6 +64,10 @@ def test_loader_scans_and_applies_row_style_types():
     assert "scantablerowstyletypes(" in loader
     assert "plastmaintable^.setrowstyletypes(context.tablerowstyletypes)" in loader
     assert "context.tablerowstyletypesvalid" in loader
+    # row styles are applied only to whole (non-broken) tables: a table split
+    # into continuation parts lists per-part repeated header rows in
+    # AcDbTableContent, so those indices don't match the merged table's rows.
+    assert "context.tablecontinuationhandles.count=0" in loader
 
 
 def test_context_stores_row_style_types():

--- a/test_issue1373_acadtable_multiheader_contract.py
+++ b/test_issue1373_acadtable_multiheader_contract.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1373: AcadTable with multiple header rows.
+
+The legacy AcDbTable cell-stream parser assumes exactly one Title row and one
+Header row, so a table whose rows 1 and 2 are both Header style (as in
+cad_source/test/tablebugheader.dxf) used to load its third row as Data. The
+real per-row style lives only in the modern AcDbTableContent object, where each
+TABLEROW_BEGIN marker carries a group-90 style type (1=Title, 2=Header,
+3=Data). The loader pre-scans these and pushes them into the main ACAD_TABLE
+through SetRowStyleTypes, which RenderCurrentTable already honors.
+
+These checks lock the source-level wiring (mirroring the issue-1342 contract
+tests) and verify the scan extracts the expected types from the fixture.
+"""
+
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parent
+DXF_LOADER = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxf.pas"
+DXF_SUPPORT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfsupport.pas"
+ENTITY_BASE = ROOT / "cad_source" / "zengine" / "core" / "entities" / "uzeentity.pas"
+ACADTABLE_MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
+)
+FIXTURE = ROOT / "cad_source" / "test" / "tablebugheader.dxf"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def test_base_entity_declares_row_style_hook():
+    entity = compact(read_text(ENTITY_BASE))
+    assert "proceduresetrowstyletypes(constatypes:arrayofinteger);virtual;" in entity
+    assert (
+        "proceduregdbobjentity.setrowstyletypes(constatypes:arrayofinteger);"
+        in entity
+    )
+
+
+def test_acadtable_model_overrides_row_style_hook():
+    model = compact(read_text(ACADTABLE_MODEL))
+    assert (
+        "proceduresetrowstyletypes(constatypes:arrayofinteger);override;" in model
+    )
+
+
+def test_loader_scans_and_applies_row_style_types():
+    loader = compact(read_text(DXF_LOADER))
+    # the scan reads TABLEROW_BEGIN inside the AcDbTableContent object
+    assert "procedurescantablerowstyletypes(" in loader
+    assert "'tablerow_begin'" in loader
+    assert "acdblinkedtabledata" in loader
+    # the scan is invoked during pre-scan and applied to the main table
+    assert "scantablerowstyletypes(" in loader
+    assert "plastmaintable^.setrowstyletypes(context.tablerowstyletypes)" in loader
+    assert "context.tablerowstyletypesvalid" in loader
+
+
+def test_context_stores_row_style_types():
+    support = compact(read_text(DXF_SUPPORT))
+    assert "tablerowstyletypes:tdxfrowstyletypearray;" in support
+    assert "tablerowstyletypesvalid:boolean;" in support
+
+
+def _extract_objects_section(lines):
+    for i in range(len(lines) - 1):
+        if lines[i].strip() == "2" and lines[i + 1].strip() == "OBJECTS":
+            return lines[i + 2:]
+    return []
+
+
+def _scan_row_style_types(lines):
+    obj = _extract_objects_section(lines)
+
+    def try_pair(idx):
+        if idx < 0 or idx >= len(obj) - 1:
+            return None
+        try:
+            code = int(obj[idx].strip())
+        except ValueError:
+            return None
+        return code, obj[idx + 1].strip()
+
+    in_content = False
+    pending = False
+    out = []
+    i = 0
+    while i < len(obj) - 1:
+        p = try_pair(i)
+        if p:
+            code, val = p
+            if code == 100:
+                if val.upper() == "ACDBLINKEDTABLEDATA":
+                    if in_content:
+                        break
+                    in_content = True
+            elif in_content and code == 1 and val == "TABLEROW_BEGIN":
+                pending = True
+            elif in_content and pending and code == 90:
+                dxf_type = int(val) if val.lstrip("-").isdigit() else 0
+                out.append({1: 0, 2: 1, 3: 2}.get(dxf_type, -1))
+                pending = False
+            i += 2
+        else:
+            i += 1
+    return out
+
+
+def test_fixture_yields_two_header_rows():
+    lines = read_text(FIXTURE).splitlines()
+    types = _scan_row_style_types(lines)
+    # row 0 = Title, rows 1 & 2 = Header, rows 3..5 = Data
+    assert types == [0, 1, 1, 2, 2, 2], types
+
+
+if __name__ == "__main__":
+    test_base_entity_declares_row_style_hook()
+    test_acadtable_model_overrides_row_style_hook()
+    test_loader_scans_and_applies_row_style_types()
+    test_context_stores_row_style_types()
+    test_fixture_yields_two_header_rows()
+    print("issue 1373 AcadTable multi-header contract checks passed")


### PR DESCRIPTION
## Issue

Closes #1373 — AcadTable loads with the wrong number of header rows.

The reproduction file `cad_source/test/tablebugheader.dxf` contains one 6×3 table where row 1 is **Title**, rows 2 **and** 3 are **Header**, and the remaining rows are **Data**. On load the third row (which should be Header) was wrongly classified as Data.

## Root cause

The legacy `AcDbTable` cell-stream parser assumes exactly one Title row followed by exactly one Header row, so it cannot represent a table with two consecutive Header rows. The real per-row style only exists in the modern `AcDbTableContent` / `AcDbLinkedTableData` object, where every `TABLEROW_BEGIN` marker carries a group-90 style type (`1=Title`, `2=Header`, `3=Data`).

## Fix

- Pre-scan the `AcDbTableContent` object (`ScanTableRowStyleTypes`) and collect the per-row style type for each `TABLEROW_BEGIN`, mapping DXF `1/2/3` → ZCAD `0/1/2`.
- Store the result in `TIODXFLoadContext` (`TableRowStyleTypes` / `TableRowStyleTypesValid`).
- After the entity is loaded, push the types into the main table via `SetRowStyleTypes`, which `RenderCurrentTable` already honors (per-row `FRowStyleTypes`, issue #1368).
- `GDBObjAcadTable` is an old-style Pascal `object`, so `SetRowStyleTypes` overrides the base virtual by being **redeclared `virtual`** (the `override` keyword is rejected for objects, matching how `SetBreakOptionFlags` is done).
- **Scope to whole (non-broken) tables only.** A table split into continuation parts (issue #1300) lists per-part *repeated* header rows in its content object, so those indices don't match the merged table's logical rows. Applying them corrupted data-row formatting (it regressed `ClearingBreakRepeatTopKeepsDataRowFormatting`). The application is now guarded on `TableContinuationHandles` being empty.

## Reproduction & tests

Pascal unit test `LoadsMultipleHeaderRowsFromDXF` (`cad_source/zengine/tests/uzctacadtable.pas`) loads `tablebugheader.dxf` and asserts `RowStyleTypeAt` returns `0,1,1,2` for rows 0..3.

- **Without the fix** the test fails: `"Строка 0 должна загружаться со стилем Title (0)" expected: <0> but was: <-1>` (styles unset → positional fallback).
- **With the fix** it passes, and the suite returns to its 7 pre-existing (unrelated) break/manual-position failures — no regressions.

Source-level wiring is additionally locked by `test_issue1373_acadtable_multiheader_contract.py`, including a fixture scan that yields `[0,1,1,2,2,2]` for `tablebugheader.dxf`.
