### PR TITLE
AcadTable: repeat all leading Title/Header rows

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-24T07:13:34.739Z for PR creation at branch issue-1375-733f9be83170 for issue https://github.com/veb86/zcadvelecAI/issues/1375

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-24T07:13:34.739Z for PR creation at branch issue-1375-733f9be83170 for issue https://github.com/veb86/zcadvelecAI/issues/1375

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -261,8 +261,9 @@ type
       APartNumber: Integer; const ALocalOffset: TzePoint3d): Double;
     function DecodeBreakHeightGripVertex(
       AVertexNum: Integer; out APartNumber: Integer): Boolean;
-    // Верхняя граница зоны ведущих строк-меток (Title/Header) по индексу
-    // строки: 0, 1 или 2. Тип строки определяется индексом (issue #1309).
+    // Число ведущих строк-меток (Title/Header) до первой строки Data.
+    // При наличии явных типов строк они определяют зону повтора; иначе
+    // используется legacy-позиция Title+Header (issue #1309, #1375).
     function ComputeTopLabelRowCount: Integer;
     // Фактическое число ведущих строк-меток, одинаково повторяющихся во всех
     // частях-продолжениях; 0, если повтора нет (по содержимому, issue #1309).
@@ -2537,11 +2538,11 @@ end;
 
 // --- Повтор верхних строк-меток в частях разорванной таблицы (issue #1309) ---
 
-// Максимальное число ведущих строк-меток (Title/Header), которые могут
-// повторяться в начале каждой части разорванной таблицы. Тип строки в таблице
-// AutoCAD определяется её индексом: строка 0 — Title, строка 1 — Header,
-// строки >=2 — Data. Зона повтора — это ведущие строки Title/Header от начала
-// таблицы до первой строки Data, то есть не более двух строк (issue #1309).
+// Число ведущих строк-меток (Title/Header), которые могут повторяться в начале
+// каждой части разорванной таблицы. Если доступны явные типы строк
+// (SetRowStyleTypes: 0=Title, 1=Header, 2=Data), зона повтора идёт от начала
+// таблицы до первой строки Data и может содержать любое количество строк
+// Title/Header в любой последовательности (issue #1375).
 //
 // Прежняя реализация опиралась на биты подавления TableFlags (бит 2 — Title,
 // бит 4 — Header), но реальные DXF (например, test/tablerazdel.dxf) приходят с
@@ -2549,14 +2550,45 @@ end;
 // присутствуют и повторяются в каждой части. Поэтому признак повтора
 // определяется не флагами, а сравнением содержимого строк частей с главной
 // частью (см. EffectiveRepeatTopRowCount), а здесь возвращается лишь верхняя
-// граница зоны меток по индексу строки. Возвращает 0, 1 или 2.
+// граница зоны меток. Для старых таблиц без явных типов строк сохраняется
+// legacy-логика: строка 0 — Title, строка 1 — Header, строки >=2 — Data.
 function GDBObjAcadTable.ComputeTopLabelRowCount: Integer;
+var
+  RowIdx, StyleType: Integer;
 begin
   Result := 0;
-  if FRowCount > 0 then
-    Inc(Result);
-  if FRowCount > 1 then
-    Inc(Result);
+  if FRowCount <= 0 then
+    Exit;
+
+  if Length(FRowStyleTypes) = 0 then
+  begin
+    if FRowCount > 0 then
+      Inc(Result);
+    if FRowCount > 1 then
+      Inc(Result);
+    Exit;
+  end;
+
+  for RowIdx := 0 to FRowCount - 1 do
+  begin
+    StyleType := RowStyleTypeAt(RowIdx);
+    if StyleType < 0 then
+    begin
+      if RowIdx = 0 then
+        StyleType := 0
+      else if RowIdx = 1 then
+        StyleType := 1
+      else
+        StyleType := 2;
+    end;
+
+    if StyleType = 2 then
+      Break;
+    if (StyleType = 0) or (StyleType = 1) then
+      Inc(Result)
+    else
+      Break;
+  end;
 end;
 
 // Фактическое число ведущих строк-меток, которые ОДИНАКОВО повторяются в начале

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -133,6 +133,10 @@ type
     // issue #1309, часть 2: снятие признака повтора удаляет повторяющиеся
     // строки-метки из всех частей, а возврат — добавляет их обратно.
     procedure TogglingBreakRepeatTopAddsAndRemovesLabelRows;
+    // issue #1375: повторяемая верхняя зона определяется всеми ведущими
+    // строками Title/Header до первой Data, а не фиксированной парой
+    // Title+Header.
+    procedure BreakRepeatTopUsesAllLeadingTitleHeaderRows;
     // issue #1311: строка данных, смещённая на место удалённых верхних меток,
     // должна сохранять своё форматирование.
     procedure ClearingBreakRepeatTopKeepsDataRowFormatting;
@@ -1985,6 +1989,62 @@ begin
       'После возврата повтора часть 0 снова начинается с «Zagolovok»');
     CheckEquals('A', AcadTable^.ContinuationPartCellText(0, 1, 0),
       'После возврата повтора часть 0 снова содержит шапку «A..E»');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1375. При повторе верхних меток зона повтора должна включать все
+// ведущие строки со стилями Title/Header до первой строки Data. Таблица
+// Title/Header/Header/Data раньше повторяла только первые две строки, потому
+// что ComputeTopLabelRowCount жёстко ограничивал зону парой Title+Header.
+procedure TAcadTableStyleTest.BreakRepeatTopUsesAllLeadingTitleHeaderRows;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  ColWidths, RowHeights: TTableSizeArray;
+  Alignments: TTableAlignmentArray;
+  InsertPt: TzePoint3d;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 6);
+    Texts[0] := 'Title';
+    Texts[1] := 'Header 1';
+    Texts[2] := 'Header 2';
+    Texts[3] := 'Data 1';
+    Texts[4] := 'Data 2';
+    Texts[5] := 'Data 3';
+    System.SetLength(ColWidths, 0);
+    System.SetLength(RowHeights, 0);
+    System.SetLength(Alignments, 0);
+
+    InsertPt := NulVertex;
+    CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(6, 1, Texts,
+      ColWidths, RowHeights, Alignments, InsertPt),
+      'Построение тестовой таблицы должно завершиться успешно');
+
+    Table^.SetRowStyleTypes([0, 1, 1, 2, 2, 2]);
+    Table^.BreakRepeatTopLabels := True;
+    Table^.BreakHeight := CAcadTableDefaultRowHeight * 4;
+    Table^.BreakEnabled := True;
+
+    CheckTrue(Table^.ContinuationPartCount > 0,
+      'Малая высота разбиения должна создать часть-продолжение');
+    CheckEquals('Title', Table^.ContinuationPartCellText(0, 0, 0),
+      'Часть-продолжение должна повторять строку Title');
+    CheckEquals('Header 1', Table^.ContinuationPartCellText(0, 1, 0),
+      'Часть-продолжение должна повторять первую строку Header');
+    CheckEquals('Header 2', Table^.ContinuationPartCellText(0, 2, 0),
+      'Часть-продолжение должна повторять вторую строку Header');
+    CheckEquals('Data 2', Table^.ContinuationPartCellText(0, 3, 0),
+      'Первая строка данных продолжения должна идти после всех верхних меток');
   finally
     Drawing.done;
   end;

--- a/test_issue1375_acadtable_repeat_top_labels.py
+++ b/test_issue1375_acadtable_repeat_top_labels.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1375: AcadTable repeat-top labels.
+
+AcadTableBreakRepeatTop must repeat every leading Title/Header row until the
+first Data row. A table with row styles Title/Header/Header/Data used to repeat
+only Title/Header because the model capped top labels at two positional rows.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
+)
+FPUNIT = ROOT / "cad_source" / "zengine" / "tests" / "uzctacadtable.pas"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def _extract_function(src: str, name: str) -> str:
+    marker = f"function GDBObjAcadTable.{name}"
+    start = src.index(marker)
+    next_marker = src.index("\nfunction GDBObjAcadTable.", start + 1)
+    return src[start:next_marker]
+
+
+def test_compute_top_label_row_count_uses_explicit_row_styles():
+    body = compact(_extract_function(read_text(MODEL), "ComputeTopLabelRowCount"))
+
+    assert "rowstyletypeat(rowidx)" in body
+    assert "styletype=2" in body
+    assert "styletype=0)or(styletype=1" in body
+    assert "inc(result)" in body
+    # Keep the legacy positional fallback for old tables without explicit row
+    # style metadata, but do not cap explicitly styled tables at two rows.
+    assert "length(frowstyletypes)=0" in body
+
+
+def test_fpunit_covers_title_header_header_repeat_top_case():
+    test_src = read_text(FPUNIT)
+    assert "procedure BreakRepeatTopUsesAllLeadingTitleHeaderRows;" in test_src
+    assert "Table^.SetRowStyleTypes([0, 1, 1, 2, 2, 2])" in test_src
+    assert "Header 2" in test_src
+    assert "ContinuationPartCellText(0, 2, 0)" in test_src
+
+
+if __name__ == "__main__":
+    test_compute_top_label_row_count_uses_explicit_row_styles()
+    test_fpunit_covers_title_header_header_repeat_top_case()
+    print("issue 1375 AcadTable repeat-top label checks passed")


### PR DESCRIPTION
## Summary

Fixes veb86/zcadvelecAI#1375.

- Update `ComputeTopLabelRowCount` so `AcadTableBreakRepeatTop` uses explicit row styles: every leading Title/Header row is repeatable until the first Data row.
- Keep the legacy positional fallback (`Title`, `Header`, then `Data`) for tables that do not have explicit row-style metadata.
- Add regression coverage for the `Title/Header/Header/Data` case in both the AcadTable FPUnit suite and a fast Python contract test.

## Reproduction

1. Create an AcadTable whose leading row styles are `Title`, `Header`, `Header`, followed by `Data` rows.
2. Enable repeat top labels and split the table by break height.
3. Before this change, continuation parts repeated only rows 1 and 2 (`Title` + first `Header`).
4. After this change, continuation parts repeat rows 1, 2, and 3, stopping only when the first `Data` row is reached.

## Testing

- `python3 test_issue1375_acadtable_repeat_top_labels.py`
- `python3 test_issue1373_acadtable_multiheader_contract.py`
- `python3 test_issue1368_cell_style.py`
- `python3 test_issue1342_acadtable_compile_contract.py`
- `python3 test_issue1336_acadtable_style_inspector.py`
- `git diff --check`

Not run locally:

- `make -C cad_source/zengine/tests` cannot run in this workspace because `/home/box/lazarus/lazbuild` is not installed.
- `python3 -m pytest ...` cannot run because `pytest` is not installed; the standalone scripts above were run directly instead.

Observed unrelated local failure:

- `python3 test_issue1344_acadtable_extdict_roundtrip.py` currently fails on an existing assertion for `tablerawacadtableextdictsubtrees` in `uzeffdxfsupport.pas`, which is outside this change.
