### PR TITLE
AcadTable: fix multi-header break grip preview

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-24T10:35:21.972Z for PR creation at branch issue-1375-44a28c8d76b4 for issue https://github.com/veb86/zcadvelecAI/issues/1375

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-24T10:35:21.972Z for PR creation at branch issue-1375-44a28c8d76b4 for issue https://github.com/veb86/zcadvelecAI/issues/1375

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -3568,6 +3568,7 @@ begin
   NewTable^.FInsertPoint := FInsertPoint;
   NewTable^.FRowCount := FRowCount;
   NewTable^.FColCount := FColCount;
+  NewTable^.FForceDataStyleAllRows := FForceDataStyleAllRows;
   NewTable^.FTableStyleHandle := FTableStyleHandle;
   NewTable^.FTableFlags := FTableFlags;
   NewTable^.FBreakEnabled := FBreakEnabled;
@@ -3578,6 +3579,7 @@ begin
   NewTable^.FBreakManualPosition := FBreakManualPosition;
   NewTable^.FBreakManualPositionExplicit := FBreakManualPositionExplicit;
   NewTable^.FBreakManualHeight := FBreakManualHeight;
+  NewTable^.FBreakFlagsKnown := FBreakFlagsKnown;
   NewTable^.FBreakSpacing := FBreakSpacing;
   NewTable^.FBreakHeight := FBreakHeight;
   // Трансформация объекта (issue #1305, часть 1)
@@ -3597,6 +3599,10 @@ begin
     Length(FCellTexts));
   for Idx := 0 to High(FCellTexts) do
     NewTable^.FCellTexts[Idx] := FCellTexts[Idx];
+
+  System.SetLength(NewTable^.FRowStyleTypes, Length(FRowStyleTypes));
+  for Idx := 0 to High(FRowStyleTypes) do
+    NewTable^.FRowStyleTypes[Idx] := FRowStyleTypes[Idx];
 
   NewTable^.FTableStyle := FTableStyle;
   NewTable^.Local := Local;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -83,6 +83,10 @@ type
     // issue #1332: временный клон для интерактивного редактирования должен
     // начинать отрисовку в текущем положении таблицы, а не в начале координат.
     procedure ClonedPreviewKeepsRenderedTableAtSourceLocation;
+    // issue #1375: временный клон для интерактивного редактирования должен
+    // сохранять явные типы строк Title/Header/Data, иначе предпросмотр ручки
+    // высоты разбиения возвращается к legacy-паре Title+Header.
+    procedure ClonedPreviewPreservesExplicitRowStyleTypes;
     // issue #1305, часть 2b: снятие признака разрыва объединяет
     // части-продолжения в единую непрерывную таблицу.
     procedure ClearingBreakMergesContinuationParts;
@@ -1290,6 +1294,37 @@ begin
         'Клон предпросмотра должен сохранить нижнюю границу таблицы');
       CheckEquals(SrcMaxY, CloneMaxY, 1e-6,
         'Клон предпросмотра должен сохранить верхнюю границу таблицы');
+    finally
+      PreviewTable^.done;
+      FreeMem(Pointer(PreviewTable));
+    end;
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.ClonedPreviewPreservesExplicitRowStyleTypes;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable, PreviewTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablebugheader.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(2),
+      'Исходная таблица должна иметь вторую строку Header');
+
+    PreviewTable := PGDBObjAcadTable(AcadTable^.Clone(nil));
+    AssertNotNull(
+      'AcadTable.Clone должен вернуть временный объект предпросмотра',
+      PreviewTable);
+    try
+      CheckEquals(1, PreviewTable^.RowStyleTypeAt(2),
+        'Клон предпросмотра должен сохранить вторую строку Header');
+      CheckEquals(2, PreviewTable^.RowStyleTypeAt(3),
+        'Клон предпросмотра должен сохранить первую строку Data');
     finally
       PreviewTable^.done;
       FreeMem(Pointer(PreviewTable));

--- a/test_issue1375_acadtable_repeat_top_labels.py
+++ b/test_issue1375_acadtable_repeat_top_labels.py
@@ -44,15 +44,25 @@ def test_compute_top_label_row_count_uses_explicit_row_styles():
     assert "length(frowstyletypes)=0" in body
 
 
+def test_clone_preserves_explicit_row_style_types_for_rt_preview():
+    body = compact(_extract_function(read_text(MODEL), "Clone"))
+
+    assert "frowstyletypes" in body
+    assert "system.setlength(newtable^.frowstyletypes,length(frowstyletypes))" in body
+    assert "newtable^.frowstyletypes[idx]:=frowstyletypes[idx]" in body
+
+
 def test_fpunit_covers_title_header_header_repeat_top_case():
     test_src = read_text(FPUNIT)
     assert "procedure BreakRepeatTopUsesAllLeadingTitleHeaderRows;" in test_src
     assert "Table^.SetRowStyleTypes([0, 1, 1, 2, 2, 2])" in test_src
     assert "Header 2" in test_src
     assert "ContinuationPartCellText(0, 2, 0)" in test_src
+    assert "procedure ClonedPreviewPreservesExplicitRowStyleTypes;" in test_src
 
 
 if __name__ == "__main__":
     test_compute_top_label_row_count_uses_explicit_row_styles()
+    test_clone_preserves_explicit_row_style_types_for_rt_preview()
     test_fpunit_covers_title_header_header_repeat_top_case()
     print("issue 1375 AcadTable repeat-top label checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1375

## Summary
- Preserve explicit AcadTable row-style metadata in temporary preview clones.
- Keep related row-style/break flag state when cloning tables for real-time grip edits.
- Add regressions for the clone-preview path so multi-row Title/Header repeat zones do not fall back to the legacy Title+Header pair during break-height drag.

## Reproduction
1. Create or load an AcadTable with leading rows `Title / Header / Header / Data...`.
2. Enable repeated top labels and drag the break-height grip.
3. Before this change, the live drag preview used a clone without `FRowStyleTypes`, so it repeated only the first two top rows. When the drag ended, the original table still had the metadata and displayed correctly.
4. After this change, the preview clone keeps the explicit row types and repeats all leading Title/Header rows until the first Data row.

## Tests
- `python3 test_issue1375_acadtable_repeat_top_labels.py`
- `python3 test_issue1373_acadtable_multiheader_contract.py`
- `python3 test_issue1368_cell_style.py`
- `python3 test_issue1342_acadtable_compile_contract.py`
- `git diff --check`

Not run locally: FPUnit/Lazarus suite, because this container has no `fpc` or `lazbuild`.
