### PR TITLE
AcadTable: preserve extension dictionary split data

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-24T17:19:09.475Z for PR creation at branch issue-1378-2050f96033f2 for issue https://github.com/veb86/zcadvelecAI/issues/1378

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-24T17:19:09.475Z for PR creation at branch issue-1378-2050f96033f2 for issue https://github.com/veb86/zcadvelecAI/issues/1378

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -41,6 +41,7 @@ type
 
   TAcadTableDXFWritePart = record
     HandleKey: Pointer;
+    ExtDictHandle: String;
     LayerName: String;
     Color: Integer;
     LineWeight: Integer;
@@ -90,6 +91,7 @@ function WriteRawAcadTablePartsToDXF(
   var AIODXFContext: TIODXFSaveContext;
   const AMainRawEntity: String;
   const AContinuationRawEntities: array of String;
+  const AMainExtDictSubtree, ARawTextStyleHandleMap: String;
   ABreakSpacing, ABreakHeight: Double;
   ABreakManualPosition, ABreakManualHeight: Boolean;
   const ATableStyleName: String): Boolean;
@@ -105,9 +107,23 @@ uses
   SysUtils, Classes, uzeffdxfout;
 
 type
+  TAcadTableHandleRemap = record
+    OldHandle: String;
+    NewHandle: String;
+  end;
+
+  TAcadTableHandleRemapArray = array of TAcadTableHandleRemap;
+
   TAcadTableRoundTripRecord = record
     MainHandle: TDWGHandle;
     ContinuationHandles: array of TDWGHandle;
+    RawExtDictSubtree: String;
+    RawExtDictSubtreeValid: Boolean;
+    RawTextStyleHandleMap: String;
+    HandleRemaps: TAcadTableHandleRemapArray;
+    ExtDictHandleNew: String;
+    MainTableStyleHandle: String;
+    TableStyleName: String;
     BreakSpacing: Double;
     BreakHeight: Double;
     { Признаки ручного управления разрывами (issue #1339). Влияют на
@@ -126,7 +142,12 @@ var
   I: Integer;
 begin
   for I := 0 to High(RoundTripRecords) do
+  begin
     System.SetLength(RoundTripRecords[I].ContinuationHandles, 0);
+    System.SetLength(RoundTripRecords[I].HandleRemaps, 0);
+    RoundTripRecords[I].RawExtDictSubtree := '';
+    RoundTripRecords[I].RawTextStyleHandleMap := '';
+  end;
   System.SetLength(RoundTripRecords, 0);
 end;
 
@@ -300,6 +321,12 @@ begin
       AIODXFContext.Header);
   if APart.LineTypeScale <> 1 then
     dxfDoubleout(AOutStream, 48, APart.LineTypeScale);
+  if APart.ExtDictHandle <> '' then
+  begin
+    dxfStringWithoutEncodeOut(AOutStream, 102, '{ACAD_XDICTIONARY');
+    dxfStringWithoutEncodeOut(AOutStream, 360, APart.ExtDictHandle);
+    dxfStringWithoutEncodeOut(AOutStream, 102, '}');
+  end;
 end;
 
 procedure WriteBlockReference(
@@ -413,24 +440,45 @@ begin
         RowIdx, ColIdx);
 end;
 
+function NormalizeRawHandle(const S: String): String; forward;
+
 procedure AddRoundTripRecord(
   AMainHandle: TDWGHandle;
   const AContinuationHandles: array of TDWGHandle;
+  const AMainExtDictSubtree, ARawTextStyleHandleMap: String;
+  const AHandleRemaps: TAcadTableHandleRemapArray;
+  const AExtDictHandleNew, AMainTableStyleHandle, ATableStyleName: String;
   ABreakSpacing, ABreakHeight: Double;
   ABreakManualPosition, ABreakManualHeight: Boolean);
 var
   RecIdx, HandleIdx: Integer;
 begin
-  if Length(AContinuationHandles) = 0 then
+  if (Length(AContinuationHandles) = 0) and (AMainExtDictSubtree = '') then
     Exit;
 
   RecIdx := Length(RoundTripRecords);
   System.SetLength(RoundTripRecords, RecIdx + 1);
   RoundTripRecords[RecIdx].MainHandle := AMainHandle;
+  RoundTripRecords[RecIdx].RawExtDictSubtree := AMainExtDictSubtree;
+  RoundTripRecords[RecIdx].RawExtDictSubtreeValid :=
+    AMainExtDictSubtree <> '';
+  RoundTripRecords[RecIdx].RawTextStyleHandleMap :=
+    ARawTextStyleHandleMap;
+  RoundTripRecords[RecIdx].ExtDictHandleNew :=
+    NormalizeRawHandle(AExtDictHandleNew);
+  RoundTripRecords[RecIdx].MainTableStyleHandle :=
+    NormalizeRawHandle(AMainTableStyleHandle);
+  RoundTripRecords[RecIdx].TableStyleName := ATableStyleName;
   RoundTripRecords[RecIdx].BreakSpacing := ABreakSpacing;
   RoundTripRecords[RecIdx].BreakHeight := ABreakHeight;
   RoundTripRecords[RecIdx].BreakManualPosition := ABreakManualPosition;
   RoundTripRecords[RecIdx].BreakManualHeight := ABreakManualHeight;
+  System.SetLength(
+    RoundTripRecords[RecIdx].HandleRemaps,
+    Length(AHandleRemaps));
+  for HandleIdx := 0 to High(AHandleRemaps) do
+    RoundTripRecords[RecIdx].HandleRemaps[HandleIdx] :=
+      AHandleRemaps[HandleIdx];
   System.SetLength(
     RoundTripRecords[RecIdx].ContinuationHandles,
     Length(AContinuationHandles));
@@ -474,20 +522,243 @@ begin
   end;
 end;
 
+function NormalizeRawHandle(const S: String): String;
+var
+  I: Integer;
+begin
+  Result := UpperCase(Trim(S));
+  I := 1;
+  while (I < Length(Result)) and (Result[I] = '0') do
+    Inc(I);
+  if I > 1 then
+    Result := Copy(Result, I, Length(Result) - I + 1);
+end;
+
+function RawDxfGroupValue(
+  const ARawText, AGroupCode: String; out AValue: String): Boolean;
+var
+  Lines: TStringList;
+  I: Integer;
+begin
+  Result := False;
+  AValue := '';
+  if ARawText = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ARawText;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if Trim(Lines[I]) = AGroupCode then
+      begin
+        AValue := NormalizeRawHandle(Lines[I + 1]);
+        Result := AValue <> '';
+        Exit;
+      end;
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+function RawAcadTableExtDictHandle(
+  const ARawEntity: String; out AHandle: String): Boolean;
+var
+  Lines: TStringList;
+  I: Integer;
+  Code, Value: String;
+  InExtDict: Boolean;
+begin
+  Result := False;
+  AHandle := '';
+  if ARawEntity = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ARawEntity;
+    InExtDict := False;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      Code := Trim(Lines[I]);
+      Value := Trim(Lines[I + 1]);
+
+      if (Code = '102') and (Value = '{ACAD_XDICTIONARY') then
+        InExtDict := True
+      else if InExtDict and (Code = '102') and (Value = '}') then
+        Break
+      else if InExtDict and (Code = '360') then
+      begin
+        AHandle := NormalizeRawHandle(Value);
+        Result := AHandle <> '';
+        Break;
+      end;
+
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure AddHandleRemap(
+  var AHandleRemaps: TAcadTableHandleRemapArray;
+  const AOldHandle, ANewHandle: String);
+var
+  Idx: Integer;
+begin
+  if (AOldHandle = '') or (ANewHandle = '') then
+    Exit;
+
+  Idx := Length(AHandleRemaps);
+  System.SetLength(AHandleRemaps, Idx + 1);
+  AHandleRemaps[Idx].OldHandle := NormalizeRawHandle(AOldHandle);
+  AHandleRemaps[Idx].NewHandle := NormalizeRawHandle(ANewHandle);
+end;
+
+function FindHandleRemap(
+  const AHandleRemaps: TAcadTableHandleRemapArray;
+  const AOldHandle: String; out ANewHandle: String): Boolean;
+var
+  Idx: Integer;
+  OldHandle: String;
+begin
+  Result := False;
+  ANewHandle := '';
+  OldHandle := NormalizeRawHandle(AOldHandle);
+  for Idx := 0 to High(AHandleRemaps) do
+    if AHandleRemaps[Idx].OldHandle = OldHandle then
+    begin
+      ANewHandle := AHandleRemaps[Idx].NewHandle;
+      Result := ANewHandle <> '';
+      Exit;
+    end;
+end;
+
+function CollectRawExtDictHandleRemaps(
+  const ARawObjects, AExtDictHandleOld: String;
+  var AIODXFContext: TIODXFSaveContext;
+  var AHandleRemaps: TAcadTableHandleRemapArray;
+  out AExtDictHandleNew: String): Boolean;
+var
+  Lines: TStringList;
+  I, J, K, ObjectStart, ObjectEnd: Integer;
+  OldHandle, NewHandle: String;
+  NewHandleValue: TDWGHandle;
+begin
+  Result := False;
+  AExtDictHandleNew := '';
+  if ARawObjects = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ARawObjects;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if Trim(Lines[I]) = '0' then
+      begin
+        ObjectStart := I;
+        ObjectEnd := Lines.Count;
+        J := I + 2;
+        while J < Lines.Count - 1 do
+        begin
+          if Trim(Lines[J]) = '0' then
+          begin
+            ObjectEnd := J;
+            Break;
+          end;
+          Inc(J, 2);
+        end;
+
+        OldHandle := '';
+        K := ObjectStart + 2;
+        while K < ObjectEnd - 1 do
+        begin
+          if Trim(Lines[K]) = '5' then
+          begin
+            OldHandle := NormalizeRawHandle(Lines[K + 1]);
+            Break;
+          end;
+          Inc(K, 2);
+        end;
+
+        if OldHandle <> '' then
+        begin
+          NewHandleValue := NextAnonymousHandle(AIODXFContext);
+          NewHandle := IntToHex(NewHandleValue, 0);
+          AddHandleRemap(AHandleRemaps, OldHandle, NewHandle);
+          if OldHandle = NormalizeRawHandle(AExtDictHandleOld) then
+            AExtDictHandleNew := NewHandle;
+        end;
+
+        I := ObjectEnd;
+        Continue;
+      end;
+      Inc(I);
+    end;
+  finally
+    Lines.Free;
+  end;
+
+  Result := (Length(AHandleRemaps) > 0) and (AExtDictHandleNew <> '');
+end;
+
+function DxfRawDoubleString(const AValue: Double): String;
+begin
+  Str(AValue:10:10, Result);
+end;
+
+function AcadTableBreakOptionFlags(
+  ABreakManualPosition, ABreakManualHeight: Boolean): Integer;
+const
+  { Базовые биты BreakOption: EnableBreaks(1) + RepeatTopLabels(2) = 3. }
+  cTableBreakBaseFlags = 3;
+  cTableBreakAllowManualPositions = 8;
+  cTableBreakAllowManualHeights = 16;
+begin
+  Result := cTableBreakBaseFlags;
+  if ABreakManualPosition then
+    Result := Result or cTableBreakAllowManualPositions;
+  if ABreakManualHeight then
+    Result := Result or cTableBreakAllowManualHeights;
+end;
+
+function IsHandleCode(const ACode: String): Boolean;
+begin
+  Result :=
+    (ACode = '5') or (ACode = '330') or (ACode = '340') or
+    (ACode = '350') or (ACode = '360') or (ACode = '361');
+end;
+
+function IsAcadTableRoundTripMarkerValue(const AValue: String): Boolean;
+begin
+  Result :=
+    UpperCase(Trim(AValue)) = 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY';
+end;
+
 // Записывает сырую (raw) сущность ACAD_TABLE, переписывая ссылки на хэндлы
 // под актуальную (перенумерованную) нумерацию сохраняемого файла (issue #1339):
 //   5   — хэндл самой сущности (перенумеровывается в ANewHandle, issue #1344);
 //   330 — владелец сущности (*Model_Space);
 //   342 — стиль таблицы (по имени стиля ATableStyleName);
 //   343 — анонимный блок таблицы (по имени блока из предшествующей пары 2);
-//   блок расширенного словаря 102/ACAD_XDICTIONARY удаляется, т.к. он не
-//        круглорейсится и иначе оставляет висячую ссылку (360).
+//   102/ACAD_XDICTIONARY — либо переписывается на новый хэндл сохранённого
+//        поддерева TABLECONTENT/TABLEGEOMETRY, либо удаляется, чтобы не
+//        оставить висячую ссылку (360).
 procedure WriteRawEntityText(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
   const ATableStyleName: String;
   const ARawEntity: String;
-  ANewHandle: TDWGHandle);
+  ANewHandle: TDWGHandle;
+  AKeepExtDict: Boolean;
+  const AExtDictHandleNew: String);
 var
   Lines: TStringList;
   I: Integer;
@@ -504,10 +775,31 @@ begin
     begin
       Code := Trim(Lines[I]);
 
-      { Удаляем блок расширенного словаря целиком (вместе с висячим 360). }
       if (Code = '102') and (I + 1 < Lines.Count)
          and (Trim(Lines[I + 1]) = '{ACAD_XDICTIONARY') then
       begin
+        if AKeepExtDict and (AExtDictHandleNew <> '') then
+        begin
+          AOutStream.TXTAddStringEOL(Lines[I]);
+          AOutStream.TXTAddStringEOL(Lines[I + 1]);
+          Inc(I, 2);
+          while I + 1 < Lines.Count do
+          begin
+            Code := Trim(Lines[I]);
+            OutValue := Lines[I + 1];
+            if Code = '360' then
+              OutValue := AExtDictHandleNew;
+            AOutStream.TXTAddStringEOL(Lines[I]);
+            AOutStream.TXTAddStringEOL(OutValue);
+            Inc(I, 2);
+            if (Code = '102') and (Trim(OutValue) = '}') then
+              Break;
+          end;
+          Continue;
+        end;
+
+        { Нет сохранённого поддерева — удаляем блок расширенного словаря
+          целиком (вместе с висячим 360). }
         Inc(I, 2);
         while I + 1 < Lines.Count do
         begin
@@ -576,6 +868,141 @@ begin
   end;
 end;
 
+function RemapRawExtDictHandleValue(
+  var AIODXFContext: TIODXFSaveContext;
+  const ARecord: TAcadTableRoundTripRecord;
+  const ACode, AValue: String;
+  ATextStyleHandleNames: TStringList;
+  out AOutValue: String): Boolean;
+var
+  NormalizedValue, MappedValue, StyleName: String;
+  TextStyleIdx: Integer;
+begin
+  Result := False;
+  AOutValue := AValue;
+  NormalizedValue := NormalizeRawHandle(AValue);
+  if NormalizedValue = '' then
+    Exit;
+
+  if FindHandleRemap(
+    ARecord.HandleRemaps, NormalizedValue, MappedValue) then
+  begin
+    AOutValue := MappedValue;
+    Result := True;
+    Exit;
+  end;
+
+  if ACode <> '340' then
+    Exit;
+
+  if (ARecord.MainTableStyleHandle <> '') and
+     (NormalizedValue = ARecord.MainTableStyleHandle) and
+     (ARecord.TableStyleName <> '') and
+     AIODXFContext.TableStyleNameHandleMap.MyGetValue(
+       ARecord.TableStyleName, MappedValue) then
+  begin
+    AOutValue := MappedValue;
+    Result := True;
+    Exit;
+  end;
+
+  if ATextStyleHandleNames <> nil then
+  begin
+    TextStyleIdx := ATextStyleHandleNames.IndexOfName(NormalizedValue);
+    if TextStyleIdx >= 0 then
+    begin
+      StyleName := ATextStyleHandleNames.ValueFromIndex[TextStyleIdx];
+      if (StyleName <> '') and
+         AIODXFContext.TextStyleNameHandleMap.MyGetValue(
+           StyleName, MappedValue) then
+      begin
+        AOutValue := MappedValue;
+        Result := True;
+      end;
+    end;
+  end;
+end;
+
+procedure WriteRawExtDictSubtreeToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var AIODXFContext: TIODXFSaveContext;
+  const ARecord: TAcadTableRoundTripRecord);
+var
+  Lines, TextStyleHandleNames: TStringList;
+  I, BreakDoubleCount, BreakOptionFlags: Integer;
+  Code, OutValue: String;
+  InRoundTripBlock, BreakOptionWritten: Boolean;
+begin
+  if (not ARecord.RawExtDictSubtreeValid) or
+     (ARecord.RawExtDictSubtree = '') then
+    Exit;
+
+  Lines := TStringList.Create;
+  TextStyleHandleNames := TStringList.Create;
+  try
+    Lines.Text := ARecord.RawExtDictSubtree;
+    TextStyleHandleNames.CaseSensitive := False;
+    TextStyleHandleNames.Text := ARecord.RawTextStyleHandleMap;
+
+    InRoundTripBlock := False;
+    BreakOptionWritten := False;
+    BreakDoubleCount := 0;
+    BreakOptionFlags := AcadTableBreakOptionFlags(
+      ARecord.BreakManualPosition, ARecord.BreakManualHeight);
+
+    I := 0;
+    while I < Lines.Count do
+    begin
+      if I + 1 >= Lines.Count then
+      begin
+        AOutStream.TXTAddStringEOL(Lines[I]);
+        Inc(I);
+        Continue;
+      end;
+
+      Code := Trim(Lines[I]);
+      OutValue := Lines[I + 1];
+
+      if Code = '0' then
+        InRoundTripBlock := False;
+
+      if IsHandleCode(Code) then
+        RemapRawExtDictHandleValue(
+          AIODXFContext, ARecord, Code, OutValue,
+          TextStyleHandleNames, OutValue);
+
+      if (Code = '102') and IsAcadTableRoundTripMarkerValue(OutValue) then
+      begin
+        InRoundTripBlock := True;
+        BreakOptionWritten := False;
+        BreakDoubleCount := 0;
+      end
+      else if InRoundTripBlock and (Code = '90') and
+              (not BreakOptionWritten) then
+      begin
+        OutValue := IntToStr(BreakOptionFlags);
+        BreakOptionWritten := True;
+      end
+      else if InRoundTripBlock and (Code = '40') and
+              (BreakDoubleCount < 2) then
+      begin
+        if BreakDoubleCount = 0 then
+          OutValue := DxfRawDoubleString(ARecord.BreakSpacing)
+        else
+          OutValue := DxfRawDoubleString(ARecord.BreakHeight);
+        Inc(BreakDoubleCount);
+      end;
+
+      AOutStream.TXTAddStringEOL(Lines[I]);
+      AOutStream.TXTAddStringEOL(OutValue);
+      Inc(I, 2);
+    end;
+  finally
+    TextStyleHandleNames.Free;
+    Lines.Free;
+  end;
+end;
+
 procedure WriteAcadTablePartToDXF(
   var AOutStream: TZctnrVectorBytes;
   var ADrawing: TDrawingDef;
@@ -620,6 +1047,7 @@ var
   MainHandle: TDWGHandle;
   ContinuationHandles: array of TDWGHandle;
   ContinuationHandle: TDWGHandle;
+  EmptyHandleRemaps: TAcadTableHandleRemapArray;
   PartIdx: Integer;
 begin
   if Length(AParts) = 0 then
@@ -639,7 +1067,9 @@ begin
     ContinuationHandles[PartIdx] := ContinuationHandle;
   end;
 
+  System.SetLength(EmptyHandleRemaps, 0);
   AddRoundTripRecord(MainHandle, ContinuationHandles,
+    '', '', EmptyHandleRemaps, '', '', '',
     AMainPart.BreakSpacing, AMainPart.BreakHeight,
     AMainPart.BreakManualPosition, AMainPart.BreakManualHeight);
 end;
@@ -649,28 +1079,34 @@ function WriteRawAcadTablePartsToDXF(
   var AIODXFContext: TIODXFSaveContext;
   const AMainRawEntity: String;
   const AContinuationRawEntities: array of String;
+  const AMainExtDictSubtree, ARawTextStyleHandleMap: String;
   ABreakSpacing, ABreakHeight: Double;
   ABreakManualPosition, ABreakManualHeight: Boolean;
   const ATableStyleName: String): Boolean;
 var
   MainHandle: TDWGHandle;
+  MainHandleOld, ContinuationHandleOld: TDWGHandle;
   ContinuationHandles: array of TDWGHandle;
   PartIdx: Integer;
+  MainExtDictHandleOld, MainExtDictHandleNew: String;
+  MainTableStyleHandle: String;
+  HandleRemaps: TAcadTableHandleRemapArray;
+  PreserveExtDict: Boolean;
+  RawExtDictSubtreeToWrite, RawTextStyleMapToWrite: String;
 begin
   Result := False;
   { Валидируем raw-сущности: у каждой части должен быть исходный хэндл
     (группа 5). Если нет — это не пригодная для round-trip сущность, и
-    управление возвращается обычному (модельному) сохранению. Сами
-    исходные значения хэндлов далее не используются — каждая часть
-    получает свежий хэндл (issue #1344). }
-  if not RawAcadTableHandle(AMainRawEntity, MainHandle) then
+    управление возвращается обычному (модельному) сохранению. Каждая часть
+    получает свежий хэндл (issue #1344), а исходные значения используются
+    только для перенумерации сохранённого OBJECTS-поддерева. }
+  if not RawAcadTableHandle(AMainRawEntity, MainHandleOld) then
     Exit;
 
   System.SetLength(ContinuationHandles, Length(AContinuationRawEntities));
   for PartIdx := 0 to High(AContinuationRawEntities) do
-    if not RawAcadTableHandle(
-      AContinuationRawEntities[PartIdx],
-      ContinuationHandles[PartIdx]) then
+    if not RawAcadTableHandle(AContinuationRawEntities[PartIdx],
+      ContinuationHandleOld) then
       Exit;
 
   { Выдаём свежие хэндлы из общего счётчика документа. К моменту записи
@@ -679,19 +1115,53 @@ begin
     (issue #1344). Эти же значения попадают в round-trip XRECORD (360/330/
     361), оставаясь согласованными с группой 5 сущностей. }
   MainHandle := NextAnonymousHandle(AIODXFContext);
+  System.SetLength(HandleRemaps, 0);
+  AddHandleRemap(
+    HandleRemaps, IntToHex(MainHandleOld, 0), IntToHex(MainHandle, 0));
+
+  RawDxfGroupValue(AMainRawEntity, '342', MainTableStyleHandle);
+  PreserveExtDict := False;
+  MainExtDictHandleOld := '';
+  MainExtDictHandleNew := '';
+  if (AMainExtDictSubtree <> '') and
+     RawAcadTableExtDictHandle(AMainRawEntity, MainExtDictHandleOld) then
+    PreserveExtDict := CollectRawExtDictHandleRemaps(
+      AMainExtDictSubtree, MainExtDictHandleOld, AIODXFContext,
+      HandleRemaps, MainExtDictHandleNew);
+
   WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
-    AMainRawEntity, MainHandle);
+    AMainRawEntity, MainHandle, PreserveExtDict, MainExtDictHandleNew);
 
   for PartIdx := 0 to High(AContinuationRawEntities) do
   begin
+    RawAcadTableHandle(AContinuationRawEntities[PartIdx],
+      ContinuationHandleOld);
     ContinuationHandles[PartIdx] := NextAnonymousHandle(AIODXFContext);
+    AddHandleRemap(HandleRemaps, IntToHex(ContinuationHandleOld, 0),
+      IntToHex(ContinuationHandles[PartIdx], 0));
     WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
-      AContinuationRawEntities[PartIdx], ContinuationHandles[PartIdx]);
+      AContinuationRawEntities[PartIdx], ContinuationHandles[PartIdx],
+      False, '');
+  end;
+
+  if PreserveExtDict then
+  begin
+    RawExtDictSubtreeToWrite := AMainExtDictSubtree;
+    RawTextStyleMapToWrite := ARawTextStyleHandleMap;
+  end
+  else
+  begin
+    RawExtDictSubtreeToWrite := '';
+    RawTextStyleMapToWrite := '';
   end;
 
   AddRoundTripRecord(MainHandle, ContinuationHandles,
+    RawExtDictSubtreeToWrite, RawTextStyleMapToWrite,
+    HandleRemaps, MainExtDictHandleNew, MainTableStyleHandle,
+    ATableStyleName,
     ABreakSpacing, ABreakHeight,
     ABreakManualPosition, ABreakManualHeight);
+  System.SetLength(HandleRemaps, 0);
   Result := True;
 end;
 
@@ -699,26 +1169,25 @@ procedure WriteRoundTripRecordToDXF(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
   const ARecord: TAcadTableRoundTripRecord);
-const
-  { Базовые биты BreakOption: EnableBreaks(1) + RepeatTopLabels(2) = 3. }
-  cTableBreakBaseFlags = 3;
-  cTableBreakAllowManualPositions = 8;
-  cTableBreakAllowManualHeights = 16;
 var
   ObjectHandle: TDWGHandle;
   HandleIdx: Integer;
   BreakOptionFlags: Integer;
 begin
+  if ARecord.RawExtDictSubtreeValid then
+  begin
+    WriteRawExtDictSubtreeToDXF(
+      AOutStream, AIODXFContext, ARecord);
+    Exit;
+  end;
+
   ObjectHandle := NextAnonymousHandle(AIODXFContext);
 
   { Восстанавливаем BreakOption-флаг из признаков ручного управления
     разрывами (issue #1339). Раньше здесь была жёстко зашита 3, из-за чего
     при пересохранении терялись AllowManualPositions/AllowManualHeights. }
-  BreakOptionFlags := cTableBreakBaseFlags;
-  if ARecord.BreakManualPosition then
-    BreakOptionFlags := BreakOptionFlags or cTableBreakAllowManualPositions;
-  if ARecord.BreakManualHeight then
-    BreakOptionFlags := BreakOptionFlags or cTableBreakAllowManualHeights;
+  BreakOptionFlags := AcadTableBreakOptionFlags(
+    ARecord.BreakManualPosition, ARecord.BreakManualHeight);
 
   dxfStringWithoutEncodeOut(AOutStream, 0, 'XRECORD');
   dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(ObjectHandle, 0));

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -92,6 +92,9 @@ type
     BreakHeight: Double;
     RawDXFEntity: String;
     RawDXFEntityValid: Boolean;
+    RawExtDictSubtree: String;
+    RawExtDictSubtreeValid: Boolean;
+    RawTextStyleHandleMap: String;
   end;
 
   TAcadTableBreakHeightArray = array of Double;
@@ -174,6 +177,11 @@ type
     // неизменённых ACAD_TABLE (issue #1317).
     FRawDXFEntity: String;
     FRawDXFEntityValid: Boolean;
+    // Сырой OBJECTS-поддерево extension dictionary (TABLECONTENT/TABLEGEOMETRY)
+    // для неизменённых таблиц AutoCAD (issues #1344, #1378).
+    FRawExtDictSubtree: String;
+    FRawExtDictSubtreeValid: Boolean;
+    FRawTextStyleHandleMap: String;
 
     // Обёртки для делегирования к модулю layout
     function GetRowHeightLocal(RowIndex: Integer): Double;
@@ -358,6 +366,8 @@ type
     function SetTableStyleName(
       const AValue: String; var ADrawing: TDrawingDef): Boolean; virtual;
     procedure SetDXFRawEntityText(const ARawText: string); virtual;
+    procedure SetDXFRawExtDictSubtree(
+      const ARawText, ARawTextStyleHandleMap: string); virtual;
     // Программно строит таблицу из текстов ячеек редактора электронных
     // таблиц (issue #1357). Все ячейки имеют тип cdtText и оформляются
     // стилем Data, объединения отсутствуют. ACellTexts индексируется как
@@ -794,6 +804,9 @@ begin
   System.SetLength(FContinuationParts, 0);
   FRawDXFEntity := '';
   FRawDXFEntityValid := False;
+  FRawExtDictSubtree := '';
+  FRawExtDictSubtreeValid := False;
+  FRawTextStyleHandleMap := '';
 end;
 
 destructor GDBObjAcadTable.done;
@@ -809,6 +822,9 @@ begin
   System.SetLength(FMerges, 0);
   FRawDXFEntity := '';
   FRawDXFEntityValid := False;
+  FRawExtDictSubtree := '';
+  FRawExtDictSubtreeValid := False;
+  FRawTextStyleHandleMap := '';
   for PartIdx := 0 to High(FContinuationParts) do
     ClearPart(FContinuationParts[PartIdx]);
   System.SetLength(FContinuationParts, 0);
@@ -821,10 +837,16 @@ var
 begin
   FRawDXFEntity := '';
   FRawDXFEntityValid := False;
+  FRawExtDictSubtree := '';
+  FRawExtDictSubtreeValid := False;
+  FRawTextStyleHandleMap := '';
   for PartIdx := 0 to High(FContinuationParts) do
   begin
     FContinuationParts[PartIdx].RawDXFEntity := '';
     FContinuationParts[PartIdx].RawDXFEntityValid := False;
+    FContinuationParts[PartIdx].RawExtDictSubtree := '';
+    FContinuationParts[PartIdx].RawExtDictSubtreeValid := False;
+    FContinuationParts[PartIdx].RawTextStyleHandleMap := '';
   end;
 end;
 
@@ -1471,6 +1493,9 @@ begin
 
   TmpRaw := FRawDXFEntity; FRawDXFEntity := APart.RawDXFEntity; APart.RawDXFEntity := TmpRaw;
   TmpRawValid := FRawDXFEntityValid; FRawDXFEntityValid := APart.RawDXFEntityValid; APart.RawDXFEntityValid := TmpRawValid;
+  TmpRaw := FRawExtDictSubtree; FRawExtDictSubtree := APart.RawExtDictSubtree; APart.RawExtDictSubtree := TmpRaw;
+  TmpRawValid := FRawExtDictSubtreeValid; FRawExtDictSubtreeValid := APart.RawExtDictSubtreeValid; APart.RawExtDictSubtreeValid := TmpRawValid;
+  TmpRaw := FRawTextStyleHandleMap; FRawTextStyleHandleMap := APart.RawTextStyleHandleMap; APart.RawTextStyleHandleMap := TmpRaw;
 end;
 
 // Строит визуальное представление всей таблицы: сначала главная часть
@@ -1542,6 +1567,9 @@ begin
   APart.BreakHeight := ASource.FBreakHeight;
   APart.RawDXFEntity := ASource.FRawDXFEntity;
   APart.RawDXFEntityValid := ASource.FRawDXFEntityValid;
+  APart.RawExtDictSubtree := ASource.FRawExtDictSubtree;
+  APart.RawExtDictSubtreeValid := ASource.FRawExtDictSubtreeValid;
+  APart.RawTextStyleHandleMap := ASource.FRawTextStyleHandleMap;
 
   APart.RowHeights.initnul;
   for Idx := 0 to ASource.FRowHeights.Count - 1 do
@@ -1598,6 +1626,9 @@ begin
   ADest.BreakHeight := ASource.BreakHeight;
   ADest.RawDXFEntity := ASource.RawDXFEntity;
   ADest.RawDXFEntityValid := ASource.RawDXFEntityValid;
+  ADest.RawExtDictSubtree := ASource.RawExtDictSubtree;
+  ADest.RawExtDictSubtreeValid := ASource.RawExtDictSubtreeValid;
+  ADest.RawTextStyleHandleMap := ASource.RawTextStyleHandleMap;
 
   ADest.RowHeights.initnul;
   for Idx := 0 to ASource.RowHeights.Count - 1 do
@@ -1638,6 +1669,9 @@ begin
   APart.RowBaseIndex := 0;
   APart.RawDXFEntity := '';
   APart.RawDXFEntityValid := False;
+  APart.RawExtDictSubtree := '';
+  APart.RawExtDictSubtreeValid := False;
+  APart.RawTextStyleHandleMap := '';
   APart.RowHeights.done;
   APart.ColWidths.done;
   System.SetLength(APart.CellTexts, 0);
@@ -1959,6 +1993,9 @@ begin
   ADest.BreakHeight := ASource.BreakHeight;
   ADest.RawDXFEntity := '';
   ADest.RawDXFEntityValid := False;
+  ADest.RawExtDictSubtree := '';
+  ADest.RawExtDictSubtreeValid := False;
+  ADest.RawTextStyleHandleMap := '';
 
   // Высоты строк диапазона
   ADest.RowHeights.initnul;
@@ -2831,6 +2868,9 @@ begin
   APart.BreakHeight := Src.BreakHeight;
   APart.RawDXFEntity := '';
   APart.RawDXFEntityValid := False;
+  APart.RawExtDictSubtree := '';
+  APart.RawExtDictSubtreeValid := False;
+  APart.RawTextStyleHandleMap := '';
 
   // Высоты строк: сверху L строк главной части, затем строки исходной части.
   APart.RowHeights.initnul;
@@ -3002,6 +3042,14 @@ procedure GDBObjAcadTable.SetDXFRawEntityText(const ARawText: string);
 begin
   FRawDXFEntity := ARawText;
   FRawDXFEntityValid := ARawText <> '';
+end;
+
+procedure GDBObjAcadTable.SetDXFRawExtDictSubtree(
+  const ARawText, ARawTextStyleHandleMap: string);
+begin
+  FRawExtDictSubtree := ARawText;
+  FRawExtDictSubtreeValid := ARawText <> '';
+  FRawTextStyleHandleMap := ARawTextStyleHandleMap;
 end;
 
 // --- Трансформация объекта (issue #1305, часть 1) ---
@@ -3414,6 +3462,7 @@ procedure GDBObjAcadTable.FillDXFWritePartFromSelf(
   var APart: TAcadTableDXFWritePart);
 begin
   APart.HandleKey := @Self;
+  APart.ExtDictHandle := '';
   if vp.Layer <> nil then
     APart.LayerName := vp.Layer^.Name
   else
@@ -3525,7 +3574,7 @@ var
   RawParts: array of String;
   PartIdx: Integer;
 begin
-  if CanSaveRawDXFEntity then
+  if FRawDXFEntityValid and (FRawDXFEntity <> '') then
   begin
     // Перед сохранением гарантируем, что имя стиля таблицы определено.
     // Для raw-таблиц (issue #1339) BuildGeometry мог ещё не выполняться
@@ -3537,18 +3586,38 @@ begin
       uzeacadtable_stylemanager.ApplyDXFTableStyle(
         FTableStyle, FTableStyleHandle, ADrawing);
 
-    System.SetLength(RawParts, Length(FContinuationParts));
-    for PartIdx := 0 to High(FContinuationParts) do
-      RawParts[PartIdx] := FContinuationParts[PartIdx].RawDXFEntity;
     // Признаки ручного управления разрывами должны попасть в roundtrip-запись
     // (issue #1339), иначе при пересохранении BreakOption теряет манульные биты.
     DetectBreakManualPosition;
     DetectBreakManualHeight;
-    if uzeacadtable_dxf_write.WriteRawAcadTablePartsToDXF(
-      AOutStream, AIODXFContext, FRawDXFEntity, RawParts,
-      FBreakSpacing, FBreakHeight,
-      FBreakManualPosition, FBreakManualHeight, Self.TableStyleName) then
-      Exit;
+
+    if CanSaveRawDXFEntity then
+    begin
+      System.SetLength(RawParts, Length(FContinuationParts));
+      for PartIdx := 0 to High(FContinuationParts) do
+        RawParts[PartIdx] := FContinuationParts[PartIdx].RawDXFEntity;
+      if uzeacadtable_dxf_write.WriteRawAcadTablePartsToDXF(
+        AOutStream, AIODXFContext, FRawDXFEntity, RawParts,
+        FRawExtDictSubtree, FRawTextStyleHandleMap,
+        FBreakSpacing, FBreakHeight,
+        FBreakManualPosition, FBreakManualHeight, Self.TableStyleName) then
+        Exit;
+    end
+    else if FRawExtDictSubtreeValid and (FRawExtDictSubtree <> '') then
+    begin
+      { AutoCAD 2007 can store a visually split ACAD_TABLE as one entity
+        whose extension dictionary owns TABLECONTENT/TABLEGEOMETRY (issue
+        #1378). ZCAD may synthesize continuation parts for display, but for
+        an unchanged raw table the safest save form is the original one-entity
+        representation with the preserved dictionary subtree. }
+      System.SetLength(RawParts, 0);
+      if uzeacadtable_dxf_write.WriteRawAcadTablePartsToDXF(
+        AOutStream, AIODXFContext, FRawDXFEntity, RawParts,
+        FRawExtDictSubtree, FRawTextStyleHandleMap,
+        FBreakSpacing, FBreakHeight,
+        FBreakManualPosition, FBreakManualHeight, Self.TableStyleName) then
+        Exit;
+    end;
   end;
 
   inherited DXFOut(AOutStream, ADrawing, AIODXFContext);
@@ -3587,6 +3656,9 @@ begin
   NewTable^.FRotate := FRotate;
   NewTable^.FRawDXFEntity := FRawDXFEntity;
   NewTable^.FRawDXFEntityValid := FRawDXFEntityValid;
+  NewTable^.FRawExtDictSubtree := FRawExtDictSubtree;
+  NewTable^.FRawExtDictSubtreeValid := FRawExtDictSubtreeValid;
+  NewTable^.FRawTextStyleHandleMap := FRawTextStyleHandleMap;
 
   for Idx := 0 to FRowHeights.Count - 1 do
     NewTable^.FRowHeights.PushBackData(

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -109,6 +109,9 @@ type
     { Передаёт сущности исходный текст DXF-entity, если загрузчик сохранил
       его для round-trip экспорта. Базовая реализация ничего не делает. }
     procedure SetDXFRawEntityText(const ARawText:string);virtual;
+    { Передаёт сущности исходное поддерево расширенного словаря DXF-entity
+      для round-trip экспорта. Базовая реализация ничего не делает. }
+    procedure SetDXFRawExtDictSubtree(const ARawText,ARawTextStyleHandleMap:string);virtual;
     procedure postload(var context:TIODXFLoadContext);virtual;
     procedure createfield;virtual;
     function AddExtAttrib:PTExtAttrib;
@@ -489,6 +492,10 @@ begin
 end;
 
 procedure GDBObjEntity.SetDXFRawEntityText(const ARawText:string);
+begin
+end;
+
+procedure GDBObjEntity.SetDXFRawExtDictSubtree(const ARawText,ARawTextStyleHandleMap:string);
 begin
 end;
 

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -280,6 +280,381 @@ begin
   end;
 end;
 
+procedure AddNameValue(AList: TStringList; const AName, AValue: string);
+var
+  Idx: Integer;
+begin
+  if (AList = nil) or (AName = '') then
+    Exit;
+
+  Idx := AList.IndexOfName(AName);
+  if Idx >= 0 then
+    AList.ValueFromIndex[Idx] := AValue
+  else
+    AList.Add(AName + '=' + AValue);
+end;
+
+function TryGetNameValue(AList: TStringList; const AName: string;
+  out AValue: string): Boolean;
+var
+  Idx: Integer;
+begin
+  Result := False;
+  AValue := '';
+  if (AList = nil) or (AName = '') then
+    Exit;
+
+  Idx := AList.IndexOfName(AName);
+  if Idx < 0 then
+    Exit;
+
+  AValue := AList.ValueFromIndex[Idx];
+  Result := True;
+end;
+
+procedure ScanTextStyleHandleNames(const RawTablesSection: string;
+  AHandleNames: TStringList);
+var
+  Lines: TStringList;
+  I, J, K, Code, ObjectEnd: Integer;
+  Value, Handle, StyleName: string;
+begin
+  if (RawTablesSection = '') or (AHandleNames = nil) then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := RawTablesSection;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if TryReadDxfPair(Lines, I, Code, Value) and
+         (Code = 0) and (UpperCase(Trim(Value)) = dxfName_Style) then
+      begin
+        ObjectEnd := Lines.Count;
+        J := I + 2;
+        while J < Lines.Count - 1 do
+        begin
+          if TryReadDxfPair(Lines, J, Code, Value) and (Code = 0) then
+          begin
+            ObjectEnd := J;
+            Break;
+          end;
+          Inc(J, 2);
+        end;
+
+        Handle := '';
+        StyleName := '';
+        K := I + 2;
+        while K < ObjectEnd - 1 do
+        begin
+          if TryReadDxfPair(Lines, K, Code, Value) then
+          begin
+            if Code = 5 then
+              Handle := NormalizeHandle(Value)
+            else if (Code = 2) and (StyleName = '') then
+              StyleName := Trim(Value);
+          end;
+          Inc(K, 2);
+        end;
+
+        if (Handle <> '') and (StyleName <> '') then
+          AddNameValue(AHandleNames, Handle, StyleName);
+
+        I := ObjectEnd;
+        Continue;
+      end;
+      Inc(I);
+    end;
+
+    if AHandleNames.Count > 0 then
+      programlog.LogOutFormatStr(
+        'uzeffdxf: ScanTextStyleHandleNames: найдено %d STYLE handle(s)',
+        [AHandleNames.Count], LM_Info);
+  finally
+    Lines.Free;
+  end;
+end;
+
+function IsAcadTableExtDictObjectType(const ATypeName: string): Boolean;
+var
+  TypeName: string;
+begin
+  TypeName := UpperCase(Trim(ATypeName));
+  Result :=
+    (TypeName = 'DICTIONARY') or
+    (TypeName = 'XRECORD') or
+    (TypeName = 'TABLECONTENT') or
+    (TypeName = 'TABLEGEOMETRY');
+end;
+
+procedure ScanDxfRawObjects(const RawObjectsSection: string;
+  RawObjects, RawObjectTypes: TStringList);
+var
+  Lines: TStringList;
+  I, J, K, Code, ObjectStart, ObjectEnd: Integer;
+  Value, Handle, TypeName, RawText: string;
+begin
+  if (RawObjectsSection = '') or (RawObjects = nil) or
+     (RawObjectTypes = nil) then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := RawObjectsSection;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if TryReadDxfPair(Lines, I, Code, Value) and (Code = 0) then
+      begin
+        TypeName := UpperCase(Trim(Value));
+        ObjectStart := I;
+        ObjectEnd := Lines.Count;
+        J := I + 2;
+        while J < Lines.Count - 1 do
+        begin
+          if TryReadDxfPair(Lines, J, Code, Value) and (Code = 0) then
+          begin
+            ObjectEnd := J;
+            Break;
+          end;
+          Inc(J, 2);
+        end;
+
+        if IsAcadTableExtDictObjectType(TypeName) then
+        begin
+          Handle := '';
+          K := ObjectStart + 2;
+          while K < ObjectEnd - 1 do
+          begin
+            if TryReadDxfPair(Lines, K, Code, Value) and (Code = 5) then
+            begin
+              Handle := NormalizeHandle(Value);
+              Break;
+            end;
+            Inc(K, 2);
+          end;
+
+          if Handle <> '' then
+          begin
+            RawText := '';
+            for K := ObjectStart to ObjectEnd - 1 do
+            begin
+              if K > ObjectStart then
+                RawText := RawText + LineEnding;
+              RawText := RawText + Lines[K];
+            end;
+            StoreRawAcadTableEntity(RawObjects, Handle, RawText);
+            AddNameValue(RawObjectTypes, Handle, TypeName);
+          end;
+        end;
+
+        I := ObjectEnd;
+        Continue;
+      end;
+      Inc(I);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+function ExtractAcadTableExtDictHandle(const ARawEntity: string;
+  out AExtDictHandle: string): Boolean;
+var
+  Lines: TStringList;
+  I: Integer;
+  Code, Value: string;
+  InExtDict: Boolean;
+begin
+  Result := False;
+  AExtDictHandle := '';
+  if ARawEntity = '' then
+    Exit;
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ARawEntity;
+    InExtDict := False;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      Code := Trim(Lines[I]);
+      Value := Trim(Lines[I + 1]);
+
+      if (Code = '102') and (Value = '{ACAD_XDICTIONARY') then
+        InExtDict := True
+      else if InExtDict and (Code = '102') and (Value = '}') then
+        Break
+      else if InExtDict and (Code = '360') then
+      begin
+        AExtDictHandle := NormalizeHandle(Value);
+        Result := AExtDictHandle <> '';
+        Break;
+      end;
+
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure AppendRawText(var ADest: string; const AText: string);
+begin
+  if AText = '' then
+    Exit;
+  if ADest <> '' then
+    ADest := ADest + LineEnding;
+  ADest := ADest + AText;
+end;
+
+procedure CollectAcadTableExtDictObject(const AHandle: string;
+  RawObjects, RawObjectTypes, Visited: TStringList; var ARawText: string);
+var
+  Handle, TypeName, ObjText, Value: string;
+  ObjIdx, I, Code: Integer;
+  Lines: TStringList;
+begin
+  Handle := NormalizeHandle(AHandle);
+  if (Handle = '') or (Visited = nil) or (Visited.IndexOf(Handle) >= 0) then
+    Exit;
+  if (RawObjects = nil) or (RawObjectTypes = nil) then
+    Exit;
+
+  ObjIdx := RawObjects.IndexOf(Handle);
+  if ObjIdx < 0 then
+    Exit;
+  if not TryGetNameValue(RawObjectTypes, Handle, TypeName) or
+     (not IsAcadTableExtDictObjectType(TypeName)) then
+    Exit;
+
+  Visited.Add(Handle);
+  ObjText := TDXFRawTextObject(RawObjects.Objects[ObjIdx]).Text;
+  AppendRawText(ARawText, ObjText);
+
+  Lines := TStringList.Create;
+  try
+    Lines.Text := ObjText;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if TryReadDxfPair(Lines, I, Code, Value) and
+         ((Code = 350) or (Code = 360) or (Code = 361)) then
+        CollectAcadTableExtDictObject(
+          NormalizeHandle(Value), RawObjects, RawObjectTypes,
+          Visited, ARawText);
+      Inc(I, 2);
+    end;
+  finally
+    Lines.Free;
+  end;
+end;
+
+procedure ScanAcadTableRawExtDictSubtrees(
+  const RawEntitiesSection, RawObjectsSection: string;
+  RawExtDictSubtrees: TStringList);
+var
+  Lines, RawObjects, RawObjectTypes, Visited: TStringList;
+  I, J, K, EntityStart, EntityEnd, Code: Integer;
+  Value, Handle, ExtDictHandle, RawEntity, RawSubtree: string;
+begin
+  if (RawEntitiesSection = '') or (RawObjectsSection = '') or
+     (RawExtDictSubtrees = nil) then
+    Exit;
+
+  RawObjects := TStringList.Create;
+  RawObjectTypes := TStringList.Create;
+  Lines := TStringList.Create;
+  try
+    RawObjects.CaseSensitive := False;
+    RawObjects.Sorted := True;
+    RawObjects.Duplicates := dupIgnore;
+    RawObjectTypes.CaseSensitive := False;
+    RawObjectTypes.Sorted := True;
+    RawObjectTypes.Duplicates := dupIgnore;
+    ScanDxfRawObjects(RawObjectsSection, RawObjects, RawObjectTypes);
+
+    Lines.Text := RawEntitiesSection;
+    I := 0;
+    while I < Lines.Count - 1 do
+    begin
+      if TryReadDxfPair(Lines, I, Code, Value) and
+         (Code = 0) and (UpperCase(Trim(Value)) = 'ACAD_TABLE') then
+      begin
+        EntityStart := I;
+        EntityEnd := Lines.Count;
+        J := I + 2;
+        while J < Lines.Count - 1 do
+        begin
+          if TryReadDxfPair(Lines, J, Code, Value) and (Code = 0) then
+          begin
+            EntityEnd := J;
+            Break;
+          end;
+          Inc(J, 2);
+        end;
+
+        Handle := '';
+        RawEntity := '';
+        for K := EntityStart to EntityEnd - 1 do
+        begin
+          if K > EntityStart then
+            RawEntity := RawEntity + LineEnding;
+          RawEntity := RawEntity + Lines[K];
+        end;
+
+        K := EntityStart + 2;
+        while K < EntityEnd - 1 do
+        begin
+          if TryReadDxfPair(Lines, K, Code, Value) and
+             (Code = 5) then
+          begin
+            Handle := NormalizeHandle(Value);
+            Break;
+          end;
+          Inc(K, 2);
+        end;
+
+        if (Handle <> '') and
+           ExtractAcadTableExtDictHandle(RawEntity, ExtDictHandle) then
+        begin
+          Visited := TStringList.Create;
+          try
+            Visited.CaseSensitive := False;
+            Visited.Sorted := True;
+            Visited.Duplicates := dupIgnore;
+            RawSubtree := '';
+            CollectAcadTableExtDictObject(
+              ExtDictHandle, RawObjects, RawObjectTypes,
+              Visited, RawSubtree);
+            if RawSubtree <> '' then
+              StoreRawAcadTableEntity(
+                RawExtDictSubtrees, Handle, RawSubtree);
+          finally
+            Visited.Free;
+          end;
+        end;
+
+        I := EntityEnd;
+        Continue;
+      end;
+      Inc(I);
+    end;
+
+    if RawExtDictSubtrees.Count > 0 then
+      programlog.LogOutFormatStr(
+        'uzeffdxf: ScanAcadTableRawExtDictSubtrees: найдено %d subtree(s)',
+        [RawExtDictSubtrees.Count], LM_Info);
+  finally
+    for I := 0 to RawObjects.Count - 1 do
+      RawObjects.Objects[I].Free;
+    RawObjects.Free;
+    RawObjectTypes.Free;
+    Lines.Free;
+  end;
+end;
+
 { Сканирует секцию OBJECTS, находит XRECORD'ы с маркером
   ACAD_ROUNDTRIP_2008_TABLE_ENTITY и собирает из них хэндлы
   ACAD_TABLE-сущностей, являющихся продолжениями разделённой таблицы.
@@ -834,6 +1209,19 @@ begin
           PGDBObjEntity(pobj)^.SetDXFRawEntityText(
             TDXFRawTextObject(
               context.TableRawAcadTableEntities.Objects[rawIdx]).Text);
+
+        if context.TableRawAcadTableExtDictSubtrees<>nil then
+        begin
+          rawIdx := context.TableRawAcadTableExtDictSubtrees.IndexOf(
+            NormalizeHandle(inttohex(
+              PGDBObjEntity(pobj)^.PExtAttrib^.dwgHandle,0)));
+          if (rawIdx >= 0) and
+             (context.TableRawAcadTableExtDictSubtrees.Objects[rawIdx]<>nil) then
+            PGDBObjEntity(pobj)^.SetDXFRawExtDictSubtree(
+              TDXFRawTextObject(
+                context.TableRawAcadTableExtDictSubtrees.Objects[rawIdx]).Text,
+              context.TableRawTextStyleHandleNames.Text);
+        end;
       end;
 
       { Если ACAD_TABLE имеет handle из списка продолжений разделённой
@@ -1827,6 +2215,7 @@ var
   rdr:TZMemReader;
   globalTimer: TTimeMeter;
   RawEntitiesSection: string;
+  RawTablesSection: string;
 const
    ffs='%s (%s)';
 begin
@@ -1869,10 +2258,21 @@ begin
           ExtractDxfRawSection(AFileName, 'OBJECTS');
         RawEntitiesSection :=
           ExtractDxfRawSection(AFileName, 'ENTITIES');
+        RawTablesSection :=
+          ExtractDxfRawSection(AFileName, 'TABLES');
 
         ScanAcadTableRawEntities(
           RawEntitiesSection,
           fileCtx.TableRawAcadTableEntities);
+
+        ScanTextStyleHandleNames(
+          RawTablesSection,
+          fileCtx.TableRawTextStyleHandleNames);
+
+        ScanAcadTableRawExtDictSubtrees(
+          RawEntitiesSection,
+          dwgCtx.PDrawing^.RawObjectsSection,
+          fileCtx.TableRawAcadTableExtDictSubtrees);
 
         { Сканируем OBJECTS, собираем handles ACAD_TABLE-продолжений.
           Хранятся в fileCtx, используются в addentitiesfromdxf для отбрасывания

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -1161,6 +1161,10 @@ begin
                   p:=pcurrtextstyle;
 
                   IODXFContext.p2h.MyGetOrCreateValue(pcurrtextstyle,IODXFContext.handle,temphandle);
+                  if (pcurrtextstyle^.Name<>'') and
+                     (not IODXFContext.TextStyleNameHandleMap.MyContans(pcurrtextstyle^.Name)) then
+                    IODXFContext.TextStyleNameHandleMap.Add(
+                      pcurrtextstyle^.Name,inttohex(temphandle,0));
                   outstream.TXTAddStringEOL(dxfGroupCode(5));
                   outstream.TXTAddStringEOL(inttohex(temphandle,0));
                   Inc(IODXFContext.handle);
@@ -1203,6 +1207,10 @@ begin
 
                   p:=pcurrtextstyle;
                   IODXFContext.p2h.MyGetOrCreateValue(p,IODXFContext.handle,temphandle);
+                  if (pcurrtextstyle^.Name<>'') and
+                     (not IODXFContext.TextStyleNameHandleMap.MyContans(pcurrtextstyle^.Name)) then
+                    IODXFContext.TextStyleNameHandleMap.Add(
+                      pcurrtextstyle^.Name,inttohex(temphandle,0));
                   outstream.TXTAddStringEOL(inttohex(temphandle,0));
 
                   outstream.TXTAddStringEOL(dxfGroupCode(330));

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -112,10 +112,13 @@ type
       сущности на актуальные новые хэндлы:
         AcadTableOwnerHandle  — новый хэндл владельца (*Model_Space) для 330;
         BlockNameHandleMap    — имя блока -> новый хэндл BLOCK_RECORD для 343;
-        TableStyleNameHandleMap — имя стиля таблицы -> новый хэндл для 342. }
+        TableStyleNameHandleMap — имя стиля таблицы -> новый хэндл для 342;
+        TextStyleNameHandleMap  — имя текстового стиля -> новый хэндл для
+                                  TABLECONTENT/340. }
     AcadTableOwnerHandle:TDWGHandle;
     BlockNameHandleMap:TString2StringDictionary;
     TableStyleNameHandleMap:TString2StringDictionary;
+    TextStyleNameHandleMap:TString2StringDictionary;
 
     procedure InitRec;
     procedure Done;
@@ -155,6 +158,18 @@ type
       флаги ячеек, которые модель ZCAD пока не реконструирует полностью
       (issue #1317). }
     TableRawAcadTableEntities:TStringList;
+
+    { Сырые OBJECTS-поддеревья расширенных словарей ACAD_TABLE, индексированные
+      по handle главной таблицы. В них AutoCAD хранит TABLECONTENT и
+      TABLEGEOMETRY, необходимые для корректного открытия разделённых таблиц
+      и первичного отображения текста без принудительной регенерации
+      (issues #1344, #1378). }
+    TableRawAcadTableExtDictSubtrees:TStringList;
+
+    { Карта старый handle STYLE -> имя текстового стиля из исходной секции
+      TABLES. Нужна, чтобы при сохранении TABLECONTENT/340 ссылался на
+      актуальные новые STYLE-хэндлы, а не на хэндлы исходного файла. }
+    TableRawTextStyleHandleNames:TStringList;
 
     { Параметры разбиения разделённой таблицы, прочитанные из XRECORD
       ACAD_ROUNDTRIP_2008_TABLE_ENTITY (две группы 40: 1-я — интервал
@@ -403,6 +418,7 @@ begin
   AcadTableOwnerHandle:=0;
   BlockNameHandleMap:=TString2StringDictionary.create;
   TableStyleNameHandleMap:=TString2StringDictionary.create;
+  TextStyleNameHandleMap:=TString2StringDictionary.create;
 
   Header.InitRec;
 end;
@@ -412,6 +428,7 @@ begin
   VarsDict.Free;
   BlockNameHandleMap.Free;
   TableStyleNameHandleMap.Free;
+  TextStyleNameHandleMap.Free;
 end;
 
 procedure TIODXFLoadContext.InitRec;
@@ -432,6 +449,16 @@ begin
   TableRawAcadTableEntities.CaseSensitive:=False;
   TableRawAcadTableEntities.Sorted:=True;
   TableRawAcadTableEntities.Duplicates:=dupIgnore;
+
+  TableRawAcadTableExtDictSubtrees:=TStringList.Create;
+  TableRawAcadTableExtDictSubtrees.CaseSensitive:=False;
+  TableRawAcadTableExtDictSubtrees.Sorted:=True;
+  TableRawAcadTableExtDictSubtrees.Duplicates:=dupIgnore;
+
+  TableRawTextStyleHandleNames:=TStringList.Create;
+  TableRawTextStyleHandleNames.CaseSensitive:=False;
+  TableRawTextStyleHandleNames.Sorted:=True;
+  TableRawTextStyleHandleNames.Duplicates:=dupIgnore;
 
   TableBreakSpacing:=0;
   TableBreakHeight:=0;
@@ -465,6 +492,12 @@ begin
       TableRawAcadTableEntities.Objects[I].Free;
     FreeAndNil(TableRawAcadTableEntities);
   end;
+  if TableRawAcadTableExtDictSubtrees<>nil then begin
+    for I:=0 to TableRawAcadTableExtDictSubtrees.Count-1 do
+      TableRawAcadTableExtDictSubtrees.Objects[I].Free;
+    FreeAndNil(TableRawAcadTableExtDictSubtrees);
+  end;
+  FreeAndNil(TableRawTextStyleHandleNames);
   SetLength(TableRowStyleTypes,0);
 end;
 

--- a/test_issue1378_acadtable_extdict_split_save.py
+++ b/test_issue1378_acadtable_extdict_split_save.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1378: AutoCAD split ACAD_TABLE save.
+
+The fixture tablebugheader.dxf is visually split by AutoCAD even though the
+DXF has only one ACAD_TABLE entity. The split/table content metadata is stored
+under the entity extension dictionary as TABLECONTENT/TABLEGEOMETRY. ZCAD's
+old save output generated multiple ACAD_TABLE entities but dropped that
+extension dictionary subtree, so AutoCAD opened the result as one whole table.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SOURCE_DXF = ROOT / "cad_source" / "test" / "tablebugheader.dxf"
+BROKEN_SAVE_DXF = ROOT / "cad_source" / "test" / "tablebugheader3.dxf"
+ACADTABLE_MODEL = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_model.pas"
+)
+ACADTABLE_WRITER = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_dxf_write.pas"
+)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def dxf_entity_counts(path: Path) -> dict[str, int]:
+    lines = read_text(path).splitlines()
+    counts: dict[str, int] = {}
+    for i in range(0, len(lines) - 1, 2):
+        if lines[i].strip() == "0":
+            name = lines[i + 1].strip().upper()
+            counts[name] = counts.get(name, 0) + 1
+    return counts
+
+
+def test_fixture_shows_missing_tablecontent_root_cause():
+    source_counts = dxf_entity_counts(SOURCE_DXF)
+    broken_counts = dxf_entity_counts(BROKEN_SAVE_DXF)
+
+    assert source_counts["ACAD_TABLE"] == 1
+    assert source_counts["TABLECONTENT"] == 1
+    assert source_counts["TABLEGEOMETRY"] == 1
+
+    assert broken_counts["ACAD_TABLE"] > source_counts["ACAD_TABLE"]
+    assert broken_counts.get("TABLECONTENT", 0) == 0
+    assert broken_counts.get("TABLEGEOMETRY", 0) == 0
+
+
+def test_model_preserves_raw_one_entity_extdict_save_path():
+    model = compact(read_text(ACADTABLE_MODEL))
+
+    assert "frawdxfentityvalidand(frawdxfentity<>'')" in model
+    assert "ifcansaverawdxfentitythen" in model
+    assert "elseiffrawextdictsubtreevalidand(frawextdictsubtree<>'')then" in model
+    assert "system.setlength(rawparts,0)" in model
+    assert (
+        "writerawacadtablepartstodxf(aoutstream,aiodxfcontext,"
+        "frawdxfentity,rawparts,frawextdictsubtree,frawtextstylehandlemap"
+    ) in model
+
+
+def test_writer_keeps_and_remaps_acad_xdictionary_subtree():
+    writer = compact(read_text(ACADTABLE_WRITER))
+
+    assert "extdicthandle:string" in writer
+    assert "dxfstringwithoutencodeout(aoutstream,102,'{acad_xdictionary')" in writer
+    assert "rawacadtableextdicthandle(" in writer
+    assert "collectrawextdicthandleremaps(" in writer
+    assert "addhandleremap(" in writer
+    assert "writerawextdictsubtreetodxf(" in writer
+    assert "remaprawextdicthandlevalue(" in writer
+    assert "aoutstream.txtaddstringeol(outvalue)" in writer
+
+
+if __name__ == "__main__":
+    test_fixture_shows_missing_tablecontent_root_cause()
+    test_model_preserves_raw_one_entity_extdict_save_path()
+    test_writer_keeps_and_remaps_acad_xdictionary_subtree()
+    print("issue 1378 AcadTable split extension dictionary checks passed")


### PR DESCRIPTION
Fixes veb86/zcadvelecAI#1378

## Summary
- Preserve the raw ACAD_TABLE extension-dictionary subtree on DXF load/save, including DICTIONARY, XRECORD, TABLECONTENT, and TABLEGEOMETRY objects.
- Remap saved handles inside the preserved subtree, including ACAD_TABLE entity handles, extension dictionary object handles, table styles, block references, and text styles.
- Keep AutoCAD 2007 split tables that are stored as one ACAD_TABLE entity in their original one-entity form, instead of saving unlinked continuation entities without TABLECONTENT/TABLEGEOMETRY metadata.

## Reproduction
1. Open `cad_source/test/tablebugheader.dxf` and save it as DXF 2007.
2. Before this change, the saved output matched the broken shape of `cad_source/test/tablebugheader3.dxf`: multiple ACAD_TABLE entities, but no TABLECONTENT/TABLEGEOMETRY objects in OBJECTS, so AutoCAD opened the table as one whole table.
3. After this change, the saved table keeps the ACAD_XDICTIONARY subtree that carries AutoCAD's split/table-content metadata.

## Tests
- `python3 test_issue1378_acadtable_extdict_split_save.py`
- `python3 test_issue1344_acadtable_extdict_roundtrip.py`
- `python3 test_issue1373_acadtable_multiheader_contract.py`
- `python3 test_issue1375_acadtable_repeat_top_labels.py`
- `python3 test_issue1342_acadtable_compile_contract.py`
- `for t in test_issue*.py; do python3 "$t" || exit 1; done`
- `git diff --check`

Not run locally: FPUnit/Lazarus suite, because this container has no `fpc` or `lazbuild`.
