### PR TITLE
AcadTable: привязка round-trip XRECORD разорванной таблицы через расширенный словарь (issue #1378)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-26T05:05:58.635Z for PR creation at branch issue-1378-370eaed1a0a6 for issue https://github.com/veb86/zcadvelecAI/issues/1378

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-26T05:05:58.635Z for PR creation at branch issue-1378-370eaed1a0a6 for issue https://github.com/veb86/zcadvelecAI/issues/1378

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -65,6 +65,11 @@ type
     BreakManualHeight: Boolean;
     BreakSpacing: Double;
     BreakHeight: Double;
+    { Признак главной части разорванной таблицы (есть части-продолжения).
+      Только для такой части пишется расширенный словарь ACAD_XDICTIONARY,
+      через который round-trip XRECORD (ACAD_ROUNDTRIP_2008_TABLE_ENTITY)
+      привязывается к сущности (issue #1378). }
+    HasContinuations: Boolean;
   end;
 
   TAcadTableDXFWritePartArray = array of TAcadTableDXFWritePart;
@@ -118,8 +123,18 @@ type
     BreakManualHeight: Boolean;
   end;
 
+  { Связь главной сущности таблицы с её расширенным словарём (issue #1378).
+    Хэндл словаря выделяется при записи самой сущности (секция ENTITIES),
+    а используется позже при записи round-trip XRECORD (секция OBJECTS),
+    поэтому хранится между проходами в модульной таблице. }
+  TAcadTableMainEntityDict = record
+    MainHandle: TDWGHandle;
+    DictHandle: TDWGHandle;
+  end;
+
 var
   RoundTripRecords: array of TAcadTableRoundTripRecord;
+  MainEntityDicts: array of TAcadTableMainEntityDict;
 
 procedure ResetAcadTableDXFWriteState;
 var
@@ -128,6 +143,50 @@ begin
   for I := 0 to High(RoundTripRecords) do
     System.SetLength(RoundTripRecords[I].ContinuationHandles, 0);
   System.SetLength(RoundTripRecords, 0);
+  System.SetLength(MainEntityDicts, 0);
+end;
+
+{ Регистрирует пару «главная сущность таблицы -> её расширенный словарь».
+  Вызывается при записи главной сущности (issue #1378). }
+procedure RegisterMainEntityDict(AMainHandle, ADictHandle: TDWGHandle);
+var
+  Idx: Integer;
+begin
+  Idx := Length(MainEntityDicts);
+  System.SetLength(MainEntityDicts, Idx + 1);
+  MainEntityDicts[Idx].MainHandle := AMainHandle;
+  MainEntityDicts[Idx].DictHandle := ADictHandle;
+end;
+
+{ Возвращает хэндл расширенного словаря главной сущности, если он был
+  зарегистрирован при записи сущности (issue #1378). }
+function LookupMainEntityDict(
+  AMainHandle: TDWGHandle; out ADictHandle: TDWGHandle): Boolean;
+var
+  Idx: Integer;
+begin
+  Result := False;
+  ADictHandle := 0;
+  for Idx := 0 to High(MainEntityDicts) do
+    if MainEntityDicts[Idx].MainHandle = AMainHandle then
+    begin
+      ADictHandle := MainEntityDicts[Idx].DictHandle;
+      Result := True;
+      Exit;
+    end;
+end;
+
+{ Пишет ссылку на расширенный словарь сущности (issue #1378):
+    102 {ACAD_XDICTIONARY 360 <dict> 102 }
+  Через этот словарь AutoCAD находит round-trip XRECORD с высотой разбиения.
+  Без него запись остаётся «висячей», разрыв не применяется и таблица
+  открывается цельной «длинной простынёй». }
+procedure WriteExtensionDictionaryRef(
+  var AOutStream: TZctnrVectorBytes; ADictHandle: TDWGHandle);
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 102, '{ACAD_XDICTIONARY');
+  dxfStringWithoutEncodeOut(AOutStream, 360, IntToHex(ADictHandle, 0));
+  dxfStringWithoutEncodeOut(AOutStream, 102, '}');
 end;
 
 function BoolToDXF(AValue: Boolean): Integer;
@@ -280,11 +339,22 @@ procedure WriteEntityPrefix(
   var AIODXFContext: TIODXFSaveContext;
   const APart: TAcadTableDXFWritePart;
   out AHandle: TDWGHandle);
+var
+  DictHandle: TDWGHandle;
 begin
   AHandle := EntityHandleForPart(APart, AIODXFContext);
 
   dxfStringWithoutEncodeOut(AOutStream, 0, 'ACAD_TABLE');
   dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(AHandle, 0));
+  { Главная часть разорванной таблицы получает расширенный словарь, к которому
+    привязывается round-trip XRECORD с высотой разбиения (issue #1378). Хэндл
+    словаря выделяется здесь и переиспользуется в секции OBJECTS. }
+  if APart.HasContinuations then
+  begin
+    DictHandle := NextAnonymousHandle(AIODXFContext);
+    WriteExtensionDictionaryRef(AOutStream, DictHandle);
+    RegisterMainEntityDict(AHandle, DictHandle);
+  end;
   dxfStringWithoutEncodeOut(AOutStream, 100, dxfName_AcDbEntity);
   if APart.LayerName <> '' then
     dxfStringout(AOutStream, 8, APart.LayerName,
@@ -480,14 +550,18 @@ end;
 //   330 — владелец сущности (*Model_Space);
 //   342 — стиль таблицы (по имени стиля ATableStyleName);
 //   343 — анонимный блок таблицы (по имени блока из предшествующей пары 2);
-//   блок расширенного словаря 102/ACAD_XDICTIONARY удаляется, т.к. он не
-//        круглорейсится и иначе оставляет висячую ссылку (360).
+//   исходный блок расширенного словаря 102/ACAD_XDICTIONARY всегда удаляется
+//        (его хэндлы не круглорейсятся). Если ADictHandle<>0 (главная часть
+//        разорванной таблицы, issue #1378), взамен пишется свежая ссылка на
+//        словарь, через который привязывается round-trip XRECORD с высотой
+//        разбиения — иначе AutoCAD открывает таблицу цельной.
 procedure WriteRawEntityText(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
   const ATableStyleName: String;
   const ARawEntity: String;
-  ANewHandle: TDWGHandle);
+  ANewHandle: TDWGHandle;
+  ADictHandle: TDWGHandle);
 var
   Lines: TStringList;
   I: Integer;
@@ -546,6 +620,17 @@ begin
           код 5 (хэндл сущности), значения ячеек (302="5") не затрагиваем. }
         OutValue := IntToHex(ANewHandle, 0);
         HandleRewritten := True;
+        { Сразу после хэндла сущности — ссылка на расширенный словарь главной
+          части разорванной таблицы (issue #1378). Исходный 102/ACAD_XDICTIONARY
+          уже удалён выше, поэтому дубля не будет. }
+        if ADictHandle <> 0 then
+        begin
+          AOutStream.TXTAddStringEOL(Lines[I]);
+          AOutStream.TXTAddStringEOL(OutValue);
+          WriteExtensionDictionaryRef(AOutStream, ADictHandle);
+          Inc(I, 2);
+          Continue;
+        end;
       end
       else if Code = '330' then
       begin
@@ -654,6 +739,7 @@ function WriteRawAcadTablePartsToDXF(
   const ATableStyleName: String): Boolean;
 var
   MainHandle: TDWGHandle;
+  DictHandle: TDWGHandle;
   ContinuationHandles: array of TDWGHandle;
   PartIdx: Integer;
 begin
@@ -679,14 +765,25 @@ begin
     (issue #1344). Эти же значения попадают в round-trip XRECORD (360/330/
     361), оставаясь согласованными с группой 5 сущностей. }
   MainHandle := NextAnonymousHandle(AIODXFContext);
+  { Главная часть разорванной таблицы получает расширенный словарь, к которому
+    в секции OBJECTS привязывается round-trip XRECORD (issue #1378). Части без
+    продолжений (Length=0) обрабатываются обычным сохранением и сюда не
+    попадают, поэтому словарь нужен всегда, когда есть продолжения. }
+  if Length(AContinuationRawEntities) > 0 then
+  begin
+    DictHandle := NextAnonymousHandle(AIODXFContext);
+    RegisterMainEntityDict(MainHandle, DictHandle);
+  end
+  else
+    DictHandle := 0;
   WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
-    AMainRawEntity, MainHandle);
+    AMainRawEntity, MainHandle, DictHandle);
 
   for PartIdx := 0 to High(AContinuationRawEntities) do
   begin
     ContinuationHandles[PartIdx] := NextAnonymousHandle(AIODXFContext);
     WriteRawEntityText(AOutStream, AIODXFContext, ATableStyleName,
-      AContinuationRawEntities[PartIdx], ContinuationHandles[PartIdx]);
+      AContinuationRawEntities[PartIdx], ContinuationHandles[PartIdx], 0);
   end;
 
   AddRoundTripRecord(MainHandle, ContinuationHandles,
@@ -706,10 +803,33 @@ const
   cTableBreakAllowManualHeights = 16;
 var
   ObjectHandle: TDWGHandle;
+  DictHandle: TDWGHandle;
+  HasDict: Boolean;
   HandleIdx: Integer;
   BreakOptionFlags: Integer;
 begin
   ObjectHandle := NextAnonymousHandle(AIODXFContext);
+
+  { Если для главной сущности был выделен расширенный словарь (issue #1378),
+    пишем его как объект-владелец XRECORD и привязываем запись к сущности:
+      сущность --(102 ACAD_XDICTIONARY 360)--> DICTIONARY
+      DICTIONARY --(3 ACAD_XREC_ROUNDTRIP 360)--> XRECORD
+      XRECORD --(330 владелец)--> DICTIONARY.
+    Раньше XRECORD писался «висячим» (330 0), AutoCAD его не находил, высота
+    разбиения терялась и таблица открывалась цельной. }
+  HasDict := LookupMainEntityDict(ARecord.MainHandle, DictHandle);
+  if HasDict then
+  begin
+    dxfStringWithoutEncodeOut(AOutStream, 0, 'DICTIONARY');
+    dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(DictHandle, 0));
+    dxfStringWithoutEncodeOut(AOutStream, 330,
+      IntToHex(ARecord.MainHandle, 0));
+    dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbDictionary');
+    dxfIntegerout(AOutStream, 280, 1);
+    dxfIntegerout(AOutStream, 281, 1);
+    dxfStringWithoutEncodeOut(AOutStream, 3, 'ACAD_XREC_ROUNDTRIP');
+    dxfStringWithoutEncodeOut(AOutStream, 360, IntToHex(ObjectHandle, 0));
+  end;
 
   { Восстанавливаем BreakOption-флаг из признаков ручного управления
     разрывами (issue #1339). Раньше здесь была жёстко зашита 3, из-за чего
@@ -722,7 +842,15 @@ begin
 
   dxfStringWithoutEncodeOut(AOutStream, 0, 'XRECORD');
   dxfStringWithoutEncodeOut(AOutStream, 5, IntToHex(ObjectHandle, 0));
-  dxfStringWithoutEncodeOut(AOutStream, 330, '0');
+  if HasDict then
+  begin
+    dxfStringWithoutEncodeOut(AOutStream, 102, '{ACAD_REACTORS');
+    dxfStringWithoutEncodeOut(AOutStream, 330, IntToHex(DictHandle, 0));
+    dxfStringWithoutEncodeOut(AOutStream, 102, '}');
+    dxfStringWithoutEncodeOut(AOutStream, 330, IntToHex(DictHandle, 0));
+  end
+  else
+    dxfStringWithoutEncodeOut(AOutStream, 330, '0');
   dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbXrecord');
   dxfIntegerout(AOutStream, 280, 1);
   dxfStringWithoutEncodeOut(AOutStream, 102,

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -3447,6 +3447,9 @@ begin
   APart.BreakManualHeight := FBreakManualHeight;
   APart.BreakSpacing := FBreakSpacing;
   APart.BreakHeight := FBreakHeight;
+  { Главная часть таблицы с частями-продолжениями получает расширенный словарь
+    для привязки round-trip XRECORD (issue #1378). }
+  APart.HasContinuations := Length(FContinuationParts) > 0;
 end;
 
 procedure GDBObjAcadTable.FillDXFWritePartFromContinuation(
@@ -3472,6 +3475,9 @@ begin
   APart.BreakManualHeight := ASource.BreakManualHeight;
   APart.BreakSpacing := ASource.BreakSpacing;
   APart.BreakHeight := ASource.BreakHeight;
+  { Части-продолжения собственного расширенного словаря не получают —
+    он только у главной части (issue #1378). }
+  APart.HasContinuations := False;
 end;
 
 procedure GDBObjAcadTable.BuildDXFContinuationWriteParts(

--- a/test_issue1344_acadtable_extdict_roundtrip.py
+++ b/test_issue1344_acadtable_extdict_roundtrip.py
@@ -1,41 +1,28 @@
 #!/usr/bin/env python3
 """
-Regression checks for issue 1344 AcadTable AutoCAD extension dictionary round-trip.
+Documentation check for issue 1344 AcadTable AutoCAD extension dictionary round-trip.
+
+NOTE
+----
+The original issue-1344 work tried to preserve and remap AutoCAD's full
+extension-dictionary subtree (TABLECONTENT/TABLEGEOMETRY) verbatim on save.
+That heavy approach (PR #1379 and the preceding subtree-preservation commit)
+was reverted by the maintainer because it "broke a lot". The source-contract
+tests that asserted the presence of that reverted machinery were therefore
+removed — they referenced code that no longer exists.
+
+What remains here is the still-valid structural documentation of an AutoCAD
+gold-standard file: a split table reaches its round-trip XRECORD through the
+entity's extension dictionary, and that XRECORD points back at the table's
+TABLECONTENT/TABLEGEOMETRY objects. Issue 1378 reproduces the dictionary-chain
+linkage minimally (without copying the whole subtree).
 """
 
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent
-DXF_LOADER = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxf.pas"
-DXF_SUPPORT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfsupport.pas"
-DXF_OUT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfout.pas"
-ENTITY_BASE = ROOT / "cad_source" / "zengine" / "core" / "entities" / "uzeentity.pas"
-ACADTABLE_MODEL = (
-    ROOT
-    / "cad_source"
-    / "zcad"
-    / "velec"
-    / "acadtable"
-    / "uzeacadtable_model.pas"
-)
-ACADTABLE_WRITER = (
-    ROOT
-    / "cad_source"
-    / "zcad"
-    / "velec"
-    / "acadtable"
-    / "uzeacadtable_dxf_write.pas"
-)
 SAMPLE_DXF = ROOT / "cad_source" / "test" / "acadtablerazdel2007_1.dxf"
-
-
-def read_text(path: Path) -> str:
-    return path.read_text(encoding="utf-8")
-
-
-def compact(text: str) -> str:
-    return "".join(text.split()).lower()
 
 
 def dxf_pairs(path: Path) -> list[tuple[str, str]]:
@@ -99,46 +86,6 @@ def test_sample_acad_table_contains_autocad_content_subtree():
     )
 
 
-def test_loader_prescans_table_extension_dictionary_subtrees():
-    loader = compact(read_text(DXF_LOADER))
-    support = compact(read_text(DXF_SUPPORT))
-    entity_base = compact(read_text(ENTITY_BASE))
-    model = compact(read_text(ACADTABLE_MODEL))
-
-    assert "tablerawacadtableextdictsubtrees:tstringlist" in support
-    assert "tablerawtextstylehandlenames:tstringlist" in support
-    assert "scantextstylehandlenames(" in loader
-    assert "scanacadtablerawextdictsubtrees(" in loader
-    assert "tablecontent" in loader
-    assert "tablegeometry" in loader
-    assert "setdxfrawextdictsubtree(" in entity_base
-    assert "proceduregdbobjacadtable.setdxfrawextdictsubtree(" in model
-    assert "frawextdictsubtreevalid:=arawtext<>''" in model
-
-
-def test_writer_preserves_and_remaps_tablecontent_subtree():
-    writer = compact(read_text(ACADTABLE_WRITER))
-    dxf_out = compact(read_text(DXF_OUT))
-    support = compact(read_text(DXF_SUPPORT))
-    model = compact(read_text(ACADTABLE_MODEL))
-
-    assert "textstylenamehandlemap:tstring2stringdictionary" in support
-    assert "textstylenamehandlemap.add(" in dxf_out
-    assert "frawextdictsubtree" in model
-    assert "amainextdictsubtree" in writer
-    assert "collectrawextdicthandleremaps(" in writer
-    assert "writerawextdictsubtreetodxf(" in writer
-    assert "remaprawextdicthandlevalue(" in writer
-    assert "rawacadtableextdicthandle(" in writer
-    assert "akeepextdict" in writer
-    assert "aextdicthandlenew" in writer
-    assert "findhandleremap(" in writer
-    assert "acadtablebreakoptionflags(" in writer
-    assert "aoutstream.txtaddstringeol(outvalue)" in writer
-
-
 if __name__ == "__main__":
     test_sample_acad_table_contains_autocad_content_subtree()
-    test_loader_prescans_table_extension_dictionary_subtrees()
-    test_writer_preserves_and_remaps_tablecontent_subtree()
     print("issue 1344 AcadTable extension dictionary round-trip checks passed")

--- a/test_issue1378_acadtable_extdict_split_save.py
+++ b/test_issue1378_acadtable_extdict_split_save.py
@@ -1,12 +1,27 @@
 #!/usr/bin/env python3
 """
-Regression checks for issue 1378: AutoCAD split ACAD_TABLE save.
+Regression checks for issue 1378: split ACAD_TABLE saved to DXF 2007 opens
+in AutoCAD as one whole "long sheet" instead of a broken table.
 
-The fixture tablebugheader.dxf is visually split by AutoCAD even though the
-DXF has only one ACAD_TABLE entity. The split/table content metadata is stored
-under the entity extension dictionary as TABLECONTENT/TABLEGEOMETRY. ZCAD's
-old save output generated multiple ACAD_TABLE entities but dropped that
-extension dictionary subtree, so AutoCAD opened the result as one whole table.
+Root cause
+----------
+When ZCAD saves a broken table to DXF 2007 it splits it into several
+ACAD_TABLE entities and emits an ACAD_ROUNDTRIP_2008_TABLE_ENTITY XRECORD that
+carries the break height. In the buggy output that XRECORD was written as an
+*orphan* object (``330 0``) with no extension dictionary on the main table
+entity, so AutoCAD never reached it. The entity break flag (``292 1``) still
+makes AutoCAD show the break-height grip, but without the XRECORD the break
+height is lost and the segments are merged into one long table — exactly the
+reported symptom.
+
+AutoCAD attaches the very same XRECORD through the main entity's extension
+dictionary:
+
+    ACAD_TABLE  --(102 {ACAD_XDICTIONARY 360})-->  DICTIONARY
+    DICTIONARY  --(3 ACAD_XREC_ROUNDTRIP 360)  -->  XRECORD
+    XRECORD     --(330 owner)                   -->  DICTIONARY
+
+The fix makes ZCAD emit that chain for the main part of a broken table.
 """
 
 from pathlib import Path
@@ -16,20 +31,10 @@ ROOT = Path(__file__).resolve().parent
 SOURCE_DXF = ROOT / "cad_source" / "test" / "tablebugheader.dxf"
 BROKEN_SAVE_DXF = ROOT / "cad_source" / "test" / "tablebugheader3.dxf"
 ACADTABLE_MODEL = (
-    ROOT
-    / "cad_source"
-    / "zcad"
-    / "velec"
-    / "acadtable"
-    / "uzeacadtable_model.pas"
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
 )
 ACADTABLE_WRITER = (
-    ROOT
-    / "cad_source"
-    / "zcad"
-    / "velec"
-    / "acadtable"
-    / "uzeacadtable_dxf_write.pas"
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_dxf_write.pas"
 )
 
 
@@ -41,17 +46,52 @@ def compact(text: str) -> str:
     return "".join(text.split()).lower()
 
 
-def dxf_entity_counts(path: Path) -> dict[str, int]:
+def dxf_pairs(path: Path) -> list[tuple[str, str]]:
     lines = read_text(path).splitlines()
+    return [
+        (lines[i].strip(), lines[i + 1].strip())
+        for i in range(0, len(lines) - 1, 2)
+    ]
+
+
+def dxf_entity_counts(path: Path) -> dict[str, int]:
     counts: dict[str, int] = {}
-    for i in range(0, len(lines) - 1, 2):
-        if lines[i].strip() == "0":
-            name = lines[i + 1].strip().upper()
+    for code, value in dxf_pairs(path):
+        if code == "0":
+            name = value.upper()
             counts[name] = counts.get(name, 0) + 1
     return counts
 
 
-def test_fixture_shows_missing_tablecontent_root_cause():
+def objects_by_handle(path: Path) -> dict[str, list[tuple[str, str]]]:
+    """Group every ``0``-delimited object by its first ``5`` handle value."""
+    pairs = dxf_pairs(path)
+    objects: dict[str, list[tuple[str, str]]] = {}
+    i = 0
+    while i < len(pairs):
+        if pairs[i][0] == "0":
+            start = i
+            i += 1
+            while i < len(pairs) and pairs[i][0] != "0":
+                i += 1
+            obj = pairs[start:i]
+            handle = next((v.upper() for c, v in obj if c == "5"), None)
+            if handle and handle not in objects:
+                objects[handle] = obj
+            continue
+        i += 1
+    return objects
+
+
+def extension_dictionary_handle(obj: list[tuple[str, str]]) -> str | None:
+    for idx, pair in enumerate(obj):
+        if pair == ("102", "{ACAD_XDICTIONARY"):
+            return obj[idx + 1][1].upper()
+    return None
+
+
+def test_fixture_shows_split_save_root_cause():
+    """The source is one table; the broken save explodes it into several."""
     source_counts = dxf_entity_counts(SOURCE_DXF)
     broken_counts = dxf_entity_counts(BROKEN_SAVE_DXF)
 
@@ -64,34 +104,89 @@ def test_fixture_shows_missing_tablecontent_root_cause():
     assert broken_counts.get("TABLEGEOMETRY", 0) == 0
 
 
-def test_model_preserves_raw_one_entity_extdict_save_path():
-    model = compact(read_text(ACADTABLE_MODEL))
+def test_source_table_links_roundtrip_through_extension_dictionary():
+    """AutoCAD's own file reaches the round-trip XRECORD via the entity's
+    extension dictionary — the structure the fix reproduces."""
+    objects = objects_by_handle(SOURCE_DXF)
 
-    assert "frawdxfentityvalidand(frawdxfentity<>'')" in model
-    assert "ifcansaverawdxfentitythen" in model
-    assert "elseiffrawextdictsubtreevalidand(frawextdictsubtree<>'')then" in model
-    assert "system.setlength(rawparts,0)" in model
-    assert (
-        "writerawacadtablepartstodxf(aoutstream,aiodxfcontext,"
-        "frawdxfentity,rawparts,frawextdictsubtree,frawtextstylehandlemap"
-    ) in model
+    table = next(
+        obj for obj in objects.values() if obj and obj[0] == ("0", "ACAD_TABLE")
+    )
+    dict_handle = extension_dictionary_handle(table)
+    assert dict_handle is not None, "source table must carry ACAD_XDICTIONARY"
+
+    dictionary = objects[dict_handle]
+    assert dictionary[0] == ("0", "DICTIONARY")
+    assert ("3", "ACAD_XREC_ROUNDTRIP") in dictionary
+    # The dictionary is owned by the table entity it belongs to.
+    table_handle = table[next(i for i, p in enumerate(table) if p[0] == "5")][1].upper()
+    assert ("330", table_handle) in dictionary
+
+    xrec_handle = next(v.upper() for c, v in dictionary if c == "360")
+    xrecord = objects[xrec_handle]
+    assert xrecord[0] == ("0", "XRECORD")
+    assert ("102", "ACAD_ROUNDTRIP_2008_TABLE_ENTITY") in xrecord
+    # The XRECORD is owned by the dictionary, not orphaned.
+    assert ("330", dict_handle) in xrecord
 
 
-def test_writer_keeps_and_remaps_acad_xdictionary_subtree():
+def test_broken_save_has_orphan_roundtrip_without_extension_dictionary():
+    """Documents the buggy output that the fix must eliminate: the round-trip
+    XRECORD is orphaned (``330 0``) and no table carries ACAD_XDICTIONARY."""
+    pairs = dxf_pairs(BROKEN_SAVE_DXF)
+    assert ("102", "{ACAD_XDICTIONARY") not in pairs
+
+    objects = objects_by_handle(BROKEN_SAVE_DXF)
+    xrecord = next(
+        obj
+        for obj in objects.values()
+        if ("102", "ACAD_ROUNDTRIP_2008_TABLE_ENTITY") in obj
+    )
+    # Orphan owner — AutoCAD never reaches the break height stored here.
+    assert ("330", "0") in xrecord
+
+
+def test_writer_attaches_roundtrip_through_extension_dictionary():
+    """The writer now emits the entity ACAD_XDICTIONARY, the owning DICTIONARY
+    and a dictionary-owned XRECORD instead of an orphan record."""
     writer = compact(read_text(ACADTABLE_WRITER))
 
-    assert "extdicthandle:string" in writer
+    # Per-part flag and dictionary bookkeeping.
+    assert "hascontinuations:boolean" in writer
+    assert "registermainentitydict(" in writer
+    assert "lookupmainentitydict(" in writer
+
+    # ACAD_XDICTIONARY reference written on the main entity.
     assert "dxfstringwithoutencodeout(aoutstream,102,'{acad_xdictionary')" in writer
-    assert "rawacadtableextdicthandle(" in writer
-    assert "collectrawextdicthandleremaps(" in writer
-    assert "addhandleremap(" in writer
-    assert "writerawextdictsubtreetodxf(" in writer
-    assert "remaprawextdicthandlevalue(" in writer
-    assert "aoutstream.txtaddstringeol(outvalue)" in writer
+
+    # The owning DICTIONARY with the ACAD_XREC_ROUNDTRIP entry.
+    assert "dxfstringwithoutencodeout(aoutstream,0,'dictionary')" in writer
+    assert "dxfstringwithoutencodeout(aoutstream,3,'acad_xrec_roundtrip')" in writer
+
+    # The XRECORD is owned by the dictionary (with reactors), no longer orphaned.
+    assert "dxfstringwithoutencodeout(aoutstream,102,'{acad_reactors')" in writer
+    # The orphan fallback (330 '0') only remains when no dictionary was made.
+    assert "if hasdict then" in compact_keep_spaces(read_text(ACADTABLE_WRITER))
+
+
+def test_model_marks_main_part_with_continuations():
+    """The model flags the main write-part when continuations exist so the
+    writer knows to emit the extension dictionary."""
+    model = compact(read_text(ACADTABLE_MODEL))
+    assert "apart.hascontinuations:=length(fcontinuationparts)>0" in model
+    assert "apart.hascontinuations:=false" in model
+
+
+def compact_keep_spaces(text: str) -> str:
+    """Lowercase + collapse runs of whitespace to single spaces (keeps word
+    boundaries for multi-token Pascal phrases)."""
+    return " ".join(text.split()).lower()
 
 
 if __name__ == "__main__":
-    test_fixture_shows_missing_tablecontent_root_cause()
-    test_model_preserves_raw_one_entity_extdict_save_path()
-    test_writer_keeps_and_remaps_acad_xdictionary_subtree()
+    test_fixture_shows_split_save_root_cause()
+    test_source_table_links_roundtrip_through_extension_dictionary()
+    test_broken_save_has_orphan_roundtrip_without_extension_dictionary()
+    test_writer_attaches_roundtrip_through_extension_dictionary()
+    test_model_marks_main_part_with_continuations()
     print("issue 1378 AcadTable split extension dictionary checks passed")


### PR DESCRIPTION
## Проблема (issue #1378)

Разорванная (split) таблица, сохранённая ZCAD в DXF 2007, открывается в AutoCAD как **одна цельная «длинная простынь»**, хотя ручка управления высотой разрыва показывает, что таблица должна быть разорвана. Текст внутри отображается корректно.

## Причина

При сохранении разорванной таблицы ZCAD разбивает её на несколько сущностей `ACAD_TABLE` и пишет запись `ACAD_ROUNDTRIP_2008_TABLE_ENTITY` (XRECORD), которая несёт **высоту разрыва**. В сломанном выводе этот XRECORD писался «висячим» объектом:

- `330 0` — без владельца;
- у главной сущности **не было** расширенного словаря `ACAD_XDICTIONARY`.

Флаг разрыва на сущности (`292 1`) заставляет AutoCAD показывать ручку, но саму высоту разрыва он берёт только из XRECORD, до которого без словаря не доходит → разрыв не применяется → сегменты сливаются в одну таблицу. Это в точности совпадает с симптомом.

AutoCAD привязывает тот же XRECORD через расширенный словарь сущности:

```
ACAD_TABLE  --(102 {ACAD_XDICTIONARY 360})-->  DICTIONARY
DICTIONARY  --(3 ACAD_XREC_ROUNDTRIP 360)  -->  XRECORD
XRECORD     --(330 owner / ACAD_REACTORS)  -->  DICTIONARY
```

## Решение (минимальное)

Воспроизводим именно эту цепочку, **без** тяжёлой машинерии копирования всего поддерева расширенного словаря (тот подход из PR #1379 был откатан, так как «многое сломал»):

- В `uzeacadtable_model.pas` главная часть таблицы (с частями-продолжениями) помечается `HasContinuations := Length(FContinuationParts) > 0`; части-продолжения — `False`.
- В `uzeacadtable_dxf_write.pas`:
  - при записи главной сущности выделяется хэндл словаря, пишется `102 {ACAD_XDICTIONARY}` и пара «главная сущность → словарь» регистрируется в модульной таблице (`RegisterMainEntityDict`);
  - в секции `OBJECTS` пишется `DICTIONARY` (владелец — главная сущность, запись `ACAD_XREC_ROUNDTRIP`) и сам `XRECORD`, теперь принадлежащий словарю (с `ACAD_REACTORS`), вместо `330 0`;
  - применено и к модельному пути сохранения, и к raw round-trip пути.

**Тело XRECORD не изменено** (флаги разрыва, интервал, высота, биты ручного управления #1339, перенумерация хэндлов #1344) — чтобы пересохранение zcad↔zcad продолжало работать.

## Как воспроизвести

- До: `cad_source/test/tablebugheader.dxf` (1 `ACAD_TABLE` с корректной цепочкой словаря).
- Сломанный вывод zcad: `cad_source/test/tablebugheader3.dxf` (2 `ACAD_TABLE`, висячий XRECORD `330 0`, нет `ACAD_XDICTIONARY`).
- Эталон AutoCAD: `cad_source/test/acadtablerazdel2007_1.dxf` (полная цепочка словаря с реакторами).

## Тесты

`test_issue1378_acadtable_extdict_split_save.py` (контрактные проверки, т.к. компилятора/AutoCAD в окружении нет):

- фиксирует root-cause (источник = 1 таблица; сломанный вывод = висячий XRECORD без словаря);
- проверяет цепочку словаря в эталоне AutoCAD;
- проверяет, что writer/model теперь эмитят `ACAD_XDICTIONARY` → `DICTIONARY` (`ACAD_XREC_ROUNDTRIP`) → `XRECORD` с реакторами.

`test_issue1344_acadtable_extdict_roundtrip.py` урезан до валидной проверки эталонного файла (его прежние source-контракты ссылались на откатанный код и больше не могли проходить).

Все 17 контрактных тестов в репозитории проходят.

## ⚠️ Нужна проверка в реальном AutoCAD

В окружении нет FPC/Lazarus и AutoCAD, поэтому изменения проверены контрактными тестами и ручным анализом структуры DXF. Прошу проверить пересохранение разорванной таблицы в реальном AutoCAD: таблица должна открыться **разорванной**, а не цельной «длинной простынёй».



Fixes veb86/zcadvelecAI#1378