### PR TITLE
AcadTable: save split table under private ZCAD marker so AutoCAD keeps parts separate

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-30T19:43:08.848Z for PR creation at branch issue-1381-2707625dcd70 for issue https://github.com/veb86/zcadvelecAI/issues/1381

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-30T19:43:08.848Z for PR creation at branch issue-1381-2707625dcd70 for issue https://github.com/veb86/zcadvelecAI/issues/1381

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -111,7 +111,7 @@ type
     BreakSpacing: Double;
     BreakHeight: Double;
     { Признаки ручного управления разрывами (issue #1339). Влияют на
-      BreakOption-флаг (первая группа 90) в ACAD_ROUNDTRIP_2008_TABLE_ENTITY:
+      BreakOption-флаг (первая группа 90) в split-XRECORD таблицы:
         8  (AllowManualPositions) <- BreakManualPosition,
         16 (AllowManualHeights)   <- BreakManualHeight. }
     BreakManualPosition: Boolean;
@@ -725,8 +725,13 @@ begin
   dxfStringWithoutEncodeOut(AOutStream, 330, '0');
   dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbXrecord');
   dxfIntegerout(AOutStream, 280, 1);
+  { Пишем приватный маркер ZCAD вместо «родного» ACAD-маркера (issue #1381).
+    AutoCAD не распознаёт его и показывает части разорванной таблицы как
+    несколько отдельных таблиц (как и было сохранено в ZCAD), а не
+    пересобирает их в одну цельную. ZCAD по этому маркеру восстанавливает
+    единую разорванную таблицу при повторной загрузке. }
   dxfStringWithoutEncodeOut(AOutStream, 102,
-    'ACAD_ROUNDTRIP_2008_TABLE_ENTITY');
+    CAcadTableSplitMarkerName);
   dxfStringWithoutEncodeOut(AOutStream, 360,
     IntToHex(ARecord.MainHandle, 0));
   dxfIntegerout(AOutStream, 70, 1);

--- a/cad_source/zengine/core/uzeconsts.pas
+++ b/cad_source/zengine/core/uzeconsts.pas
@@ -169,6 +169,24 @@ const {as_normal=0;
   { Наименование типа для прокси-объекта AutoCAD }
   ObjN_GDBObjAcdProxy='GDBObjAcdProxy';
 
+  { Маркеры XRECORD'ов, связывающих части разорванной (split) таблицы
+    ACAD_TABLE (issue #1381).
+
+    CAcadTableRoundtripMarkerName — «родной» маркер AutoCAD. AutoCAD
+    распознаёт его и пересобирает части обратно в одну цельную таблицу,
+    из-за чего разорванная таблица открывается в AutoCAD как цельная
+    (баг issue #1381). Поэтому ZCAD больше НЕ записывает этот маркер,
+    но продолжает читать его при загрузке настоящих файлов AutoCAD
+    R2007/2008, где разорванная таблица представлена несколькими
+    ACAD_TABLE + этим XRECORD.
+
+    CAcadTableSplitMarkerName — приватный маркер ZCAD той же структуры.
+    AutoCAD его не распознаёт и поэтому показывает части как несколько
+    отдельных таблиц (как и было сохранено в ZCAD), а ZCAD по нему
+    восстанавливает единую разорванную таблицу, сохраняя функциональность. }
+  CAcadTableRoundtripMarkerName='ACAD_ROUNDTRIP_2008_TABLE_ENTITY';
+  CAcadTableSplitMarkerName='ZCAD_SPLIT_TABLE_ENTITY';
+
   DevicePrefix='DEVICE_';
   DrawingDeviceBaseUnitName='drawingdevicebase';
 

--- a/cad_source/zengine/fileformats/uzeffdxf.pas
+++ b/cad_source/zengine/fileformats/uzeffdxf.pas
@@ -186,9 +186,22 @@ begin
   end;
 end;
 
+{ Распознаёт маркер XRECORD'а, связывающего части разорванной таблицы
+  (issue #1381). Принимает оба варианта:
+    * CAcadTableRoundtripMarkerName — «родной» маркер AutoCAD в файлах
+      R2007/2008, экспортированных самим AutoCAD;
+    * CAcadTableSplitMarkerName — приватный маркер ZCAD, которым теперь
+      сохраняет ZCAD (AutoCAD его игнорирует и показывает части отдельными
+      таблицами).
+  Это обеспечивает обратную совместимость чтения при том, что запись
+  больше не использует распознаваемый AutoCAD маркер. }
 function IsAcadTableRoundtripMarker(const Value: string): Boolean;
+var
+  Normalized: string;
 begin
-  Result := UpperCase(Trim(Value)) = 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY';
+  Normalized := UpperCase(Trim(Value));
+  Result := (Normalized = UpperCase(CAcadTableRoundtripMarkerName)) or
+            (Normalized = UpperCase(CAcadTableSplitMarkerName));
 end;
 
 procedure StoreRawAcadTableEntity(

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -61,6 +61,11 @@ type
     procedure LoadsBreakSettingsFromSecondSample;
     procedure RendersBrokenTableAsSeparatedFragments;
     procedure LoadsSplitTableAsSingleMergedObject;
+    // issue #1381: ZCAD сохраняет части разорванной таблицы под приватным
+    // маркером ZCAD_SPLIT_TABLE_ENTITY (AutoCAD его не пересобирает). Чтение
+    // должно по этому маркеру восстанавливать единую разорванную таблицу, как
+    // и при «родном» маркере AutoCAD.
+    procedure ReadsSplitTableFromPrivateZcadMarker;
     procedure LoadsIssue1334BreakTableAsSingleMergedObject;
     procedure AppliesTableStyleToContinuationParts;
     // issue #1317: сохранение AcadTable в DXF должно писать структурированные
@@ -280,6 +285,34 @@ begin
         'Тестовый DXF должен содержать секцию AcDbTable');
     DXFText := StringReplace(
       DXFText, AcDbTableMarker, ManualHeightFlag, [rfReplaceAll]);
+    Lines.Text := DXFText;
+    Lines.SaveToFile(Result);
+  finally
+    Lines.Free;
+  end;
+end;
+
+// issue #1381: создаёт копию tablerazdel.dxf, в которой «родной» маркер
+// AutoCAD ACAD_ROUNDTRIP_2008_TABLE_ENTITY заменён на приватный маркер ZCAD
+// ZCAD_SPLIT_TABLE_ENTITY — так файл выглядит после сохранения из ZCAD.
+function CreateSplitMarkerAcadTableDXF: String;
+var
+  SourceName, DXFText: String;
+  Lines: TStringList;
+begin
+  SourceName := ExpandFileName('../../../cad_source/test/tablerazdel.dxf');
+  Result := IncludeTrailingPathDelimiter(GetTempDir(False)) +
+    'zcad_acadtable_split_marker.dxf';
+
+  Lines := TStringList.Create;
+  try
+    Lines.LoadFromFile(SourceName);
+    DXFText := Lines.Text;
+    if Pos(CAcadTableRoundtripMarkerName, DXFText) = 0 then
+      raise Exception.Create(
+        'Тестовый DXF должен содержать round-trip маркер AutoCAD');
+    DXFText := StringReplace(DXFText,
+      CAcadTableRoundtripMarkerName, CAcadTableSplitMarkerName, [rfReplaceAll]);
     Lines.Text := DXFText;
     Lines.SaveToFile(Result);
   finally
@@ -919,6 +952,38 @@ begin
   end;
 end;
 
+// issue #1381: файл, сохранённый ZCAD, помечает связку частей разорванной
+// таблицы приватным маркером ZCAD_SPLIT_TABLE_ENTITY (AutoCAD его не
+// распознаёт и не пересобирает части). При открытии в ZCAD этот маркер должен
+// читаться так же, как «родной» round-trip маркер AutoCAD, и восстанавливать
+// единую разорванную таблицу — иначе теряется функциональность.
+procedure TAcadTableStyleTest.ReadsSplitTableFromPrivateZcadMarker;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  TableCount: Integer;
+  SplitDXF: String;
+begin
+  SplitDXF := CreateSplitMarkerAcadTableDXF;
+  try
+    LoadDrawingFromDXF(SplitDXF, Drawing);
+    try
+      TableCount := CountAcadTables(Drawing.pObjRoot);
+      CheckEquals(1, TableCount,
+        'Части, связанные приватным маркером ZCAD, должны загружаться как один объект AcadTable');
+
+      AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+      AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+      CheckEquals(2, AcadTable^.ContinuationPartCount,
+        'По приватному маркеру ZCAD в главную таблицу должны быть поглощены две части-продолжения');
+    finally
+      Drawing.done;
+    end;
+  finally
+    DeleteFile(SplitDXF);
+  end;
+end;
+
 // Разорванная на 11 частей таблица (bugbreaktable.dxf) хранит список
 // продолжений в OBJECTS/XRECORD. Эти части должны загружаться как один
 // логический AcadTable (issue #1334).
@@ -1047,10 +1112,18 @@ begin
       'Ячейки таблицы должны сохраняться как CELL_VALUE');
     CheckTrue(Pos('Zagolovok', DXFText) > 0,
       'DXF должен содержать текст ячейки из исходной таблицы');
-    CheckEquals(1,
+    // issue #1381: запись больше НЕ использует распознаваемый AutoCAD маркер
+    // ACAD_ROUNDTRIP_2008_TABLE_ENTITY (из-за него AutoCAD пересобирал части
+    // в одну цельную таблицу). Вместо него пишется приватный маркер ZCAD,
+    // который AutoCAD игнорирует и показывает части отдельными таблицами.
+    CheckEquals(0,
       CountDxfPairs(
         DXFText, '102', 'ACAD_ROUNDTRIP_2008_TABLE_ENTITY'),
-      'Для разделённой таблицы должен сохраняться round-trip XRECORD');
+      'Распознаваемый AutoCAD round-trip маркер не должен записываться (issue #1381)');
+    CheckEquals(1,
+      CountDxfPairs(
+        DXFText, '102', 'ZCAD_SPLIT_TABLE_ENTITY'),
+      'Для разделённой таблицы должен сохраняться приватный split-XRECORD ZCAD');
   finally
     Drawing.done;
   end;


### PR DESCRIPTION
## Что не так

issue veb86/zcadvelecAI#1381: разорванная (split) таблица `ACAD_TABLE`,
сохранённая ZCAD в DXF, открывалась в AutoCAD как **одна цельная** таблица,
а не как несколько отдельных частей. Текст ячеек при этом отображался верно —
ломалась именно геометрия разрыва.

## Причина

При сохранении ZCAD связывал части разорванной таблицы свободным `XRECORD`'ом
с **«родным» маркером AutoCAD** `ACAD_ROUNDTRIP_2008_TABLE_ENTITY` (группа 102).
Этот маркер — штатный механизм AutoCAD R2007/2008: открывая файл, AutoCAD
распознаёт его, находит по ссылкам `360/361/330` главную таблицу и части-
продолжения и **пересобирает их обратно в одну цельную таблицу**. Отсюда баг.

Структура XRECORD'а формируется в `WriteRoundTripRecordToDXF`
(`uzeacadtable_dxf_write.pas`).

## Решение

Задача из issue: «чтобы чертежи в AutoCAD выглядели так же, как были сохранены
в нашей программе» и «при открытии нашей программой разорванная таблица должна
открываться разорванной таблицей». Корректно рендерить разрыв в AutoCAD не
требуется.

Поэтому при записи вместо распознаваемого AutoCAD маркера используется
**приватный маркер ZCAD** `ZCAD_SPLIT_TABLE_ENTITY` той же структуры:

- AutoCAD его **не распознаёт** → не пересобирает части → показывает их как
  несколько отдельных таблиц, ровно как было сохранено в ZCAD;
- ZCAD при чтении принимает **оба** маркера (`IsAcadTableRoundtripMarker`),
  поэтому:
  - настоящие файлы AutoCAD R2007/2008 (например `tablebugheader.dxf`,
    `tablerazdel.dxf`) по-прежнему читаются корректно;
  - файлы, сохранённые ZCAD, открываются как **единая разорванная таблица** —
    функциональность сохранена.

Меняется только строка группы 102; остальная структура XRECORD'а (ссылки на
хэндлы, параметры разрыва) не тронута, поэтому валидность DXF для AutoCAD
не нарушается.

## Изменения

- `uzeconsts.pas` — общие константы `CAcadTableRoundtripMarkerName` (для чтения
  файлов AutoCAD) и `CAcadTableSplitMarkerName` (приватный маркер ZCAD).
- `uzeacadtable_dxf_write.pas` — запись приватного маркера вместо маркера AutoCAD.
- `uzeffdxf.pas` — `IsAcadTableRoundtripMarker` принимает оба маркера (обратная
  совместимость чтения).
- `uzctacadtable.pas` — тесты.

## Как воспроизвести

1. В ZCAD создать разорванную таблицу и сохранить в DXF (или см. `tablebugheader3.dxf`).
2. Открыть DXF в AutoCAD → до фикса таблица собирается в одну цельную.
3. После фикса части остаются отдельными таблицами, чертёж выглядит как в ZCAD.

## Тесты

- `ReadsSplitTableFromPrivateZcadMarker` — копия `tablerazdel.dxf` с заменой
  маркера на приватный загружается как **единая** разорванная таблица
  (2 части-продолжения). Подтверждает сохранение функциональности чтения.
- `SavesSplitAcadTableToStructuredDXF` — при записи разделённой таблицы
  пишется приватный маркер `ZCAD_SPLIT_TABLE_ENTITY` и **не** пишется
  распознаваемый AutoCAD `ACAD_ROUNDTRIP_2008_TABLE_ENTITY`.

Сборка `testacadtable_standalone` (FPC 3.2.2 / Lazarus 3.0): новый тест и
существующие тесты split-таблицы (`LoadsSplitTableAsSingleMergedObject`)
проходят. Число тестов выросло с 43 до 44, число падений не изменилось —
7 падений присутствуют и на чистом master (различия версии FPC, к данному
изменению отношения не имеют).

Fixes veb86/zcadvelecAI#1381
