### PR TITLE
AcadTable: восстановление повторяющихся верхних меток разорванной таблицы (#1373)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-01T10:10:16.882Z for PR creation at branch issue-1373-fb37d08612bc for issue https://github.com/veb86/zcadvelecAI/issues/1373

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-01T10:10:16.882Z for PR creation at branch issue-1373-fb37d08612bc for issue https://github.com/veb86/zcadvelecAI/issues/1373

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -133,6 +133,13 @@ type
     // тогда, когда ВСЕ её ячейки относятся к соответствующему типу. Имеет
     // приоритет над FForceDataStyleAllRows и позиционным выбором стиля.
     FRowStyleTypes: array of Integer;
+    // True, если типы строк заданы явно снаружи (SetRowStyleTypes из данных
+    // DXF AcDbTableContent или из редактора электронных таблиц). Для старых
+    // разорванных таблиц без объекта содержимого типы строк отсутствуют и
+    // восстанавливаются по числу повторяющихся ведущих строк-меток частей
+    // (issue #1373). Инференс не считается явной установкой, поэтому при
+    // повторном определении он пересчитывается заново.
+    FRowStyleTypesExplicit: Boolean;
     // Хэндл DXF-стиля таблицы (group code 342)
     FTableStyleHandle: String;
     // Флаги свойств таблицы (group code 90)
@@ -278,6 +285,11 @@ type
     // Фактическое число ведущих строк-меток, одинаково повторяющихся во всех
     // частях-продолжениях; 0, если повтора нет (по содержимому, issue #1309).
     function EffectiveRepeatTopRowCount: Integer;
+    // Максимальное число ведущих строк, одинаково повторяющихся в начале
+    // КАЖДОЙ части-продолжения, БЕЗ ограничения зоной меток
+    // ComputeTopLabelRowCount. Служит для восстановления типов строк старых
+    // разорванных таблиц (issue #1373): 0, если частей нет или повтора нет.
+    function DetectRepeatedTopRowCountRaw: Integer;
     // Проверяет, повторяет ли часть-продолжение первые L строк-меток главной
     // части (тексты ячеек первых L строк совпадают) (issue #1309).
     function PartRepeatsTopLabels(
@@ -704,6 +716,7 @@ begin
   // типы строк, т.к. геометрия перестраивается с нуля.
   FForceDataStyleAllRows := True;
   System.SetLength(FRowStyleTypes, 0);
+  FRowStyleTypesExplicit := False;
 
   // Инициализируем строки, столбцы и ячейки (все ячейки — текстовые)
   System.SetLength(FRows, FRowCount);
@@ -770,6 +783,9 @@ begin
   System.SetLength(FRowStyleTypes, Length(ATypes));
   for Idx := 0 to High(ATypes) do
     FRowStyleTypes[Idx] := ATypes[Idx];
+  // Явная установка снаружи (issue #1373): отключает автоматическое
+  // восстановление типов строк по повторяющимся меткам частей.
+  FRowStyleTypesExplicit := True;
 end;
 
 function GDBObjAcadTable.RowStyleTypeAt(ARow: Integer): Integer;
@@ -795,6 +811,7 @@ begin
   FGeometryBuilt := False;
   FForceDataStyleAllRows := False;
   System.SetLength(FRowStyleTypes, 0);
+  FRowStyleTypesExplicit := False;
   FTableStyleHandle := '';
   FTableFlags := 0;
   FBreakEnabled := False;
@@ -1313,12 +1330,15 @@ begin
         begin
           // По умолчанию базовый стиль строки выбирается по её позиции
           // (0=Title, 1=Header, >=2=Data). Приоритеты:
-          // 1) явно заданный тип строки через SetRowStyleTypes (issue #1368) —
-          //    строки, целиком состоящие из ячеек Title/Header, получают
-          //    соответствующий стиль при экспорте из редактора таблиц;
+          // 1) явно заданный или восстановленный тип строки (issue #1368,
+          //    #1373) — но только для главной части и повторяющих метки
+          //    частей-продолжений (ARowBaseIndex=0). У части-продолжения,
+          //    которая НЕ повторяет метки (ARowBaseIndex>0), локальные номера
+          //    строк не соответствуют типам строк главной части, поэтому там
+          //    используется позиционный стиль от логической базы (issue #1311);
           // 2) FForceDataStyleAllRows (issue #1357) — все строки как данные;
           // 3) позиционный выбор стиля по номеру строки.
-          if RowStyleTypeAt(RowIdx) >= 0 then
+          if (ARowBaseIndex = 0) and (RowStyleTypeAt(RowIdx) >= 0) then
             StyleRowIndex := RowStyleTypeAt(RowIdx)
           else if FForceDataStyleAllRows then
             StyleRowIndex := 2
@@ -2728,6 +2748,43 @@ begin
   end;
 end;
 
+// Максимальное число ведущих строк, одинаково повторяющихся в начале КАЖДОЙ
+// части-продолжения, БЕЗ ограничения зоной меток ComputeTopLabelRowCount.
+// Поиск идёт от максимально возможной длины (не больше числа строк главной
+// части и минимального числа строк среди частей) вниз до первого совпадения.
+// Используется для восстановления типов строк старой разорванной таблицы,
+// у которой нет объекта AcDbTableContent и, следовательно, явных типов строк
+// (issue #1373): число повторяющихся ведущих строк = число строк-меток
+// (Title + строки Header) перед первой строкой данных.
+function GDBObjAcadTable.DetectRepeatedTopRowCountRaw: Integer;
+var
+  L, MaxL, PartIdx: Integer;
+  AllRepeat: Boolean;
+begin
+  Result := 0;
+  if Length(FContinuationParts) = 0 then
+    Exit;
+  MaxL := FRowCount;
+  for PartIdx := 0 to High(FContinuationParts) do
+    if FContinuationParts[PartIdx].RowCount < MaxL then
+      MaxL := FContinuationParts[PartIdx].RowCount;
+  for L := MaxL downto 1 do
+  begin
+    AllRepeat := True;
+    for PartIdx := 0 to High(FContinuationParts) do
+      if not PartRepeatsTopLabels(FContinuationParts[PartIdx], L) then
+      begin
+        AllRepeat := False;
+        Break;
+      end;
+    if AllRepeat then
+    begin
+      Result := L;
+      Exit;
+    end;
+  end;
+end;
+
 // Проверяет, повторяет ли часть-продолжение первые L строк-меток главной
 // части: число столбцов должно совпадать, у части должно быть не меньше L
 // строк, а тексты ячеек первых L строк должны быть идентичны главной части.
@@ -2790,9 +2847,36 @@ end;
 // ведущие строки-метки главной части (issue #1309). Решение принимается по
 // содержимому строк, а не по флагам подавления заголовков.
 procedure GDBObjAcadTable.DetectBreakRepeatTopLabels;
+var
+  RepeatCount, Idx: Integer;
 begin
   if Length(FContinuationParts) = 0 then
     Exit;
+
+  // Старые разорванные таблицы приходят из DXF без объекта AcDbTableContent,
+  // поэтому явные типы строк отсутствуют, а legacy-логика ограничивает зону
+  // меток парой Title+Header. Из-за этого вторая (и последующие) строки
+  // заголовка ошибочно считались данными, зона повтора определялась неверно и
+  // при изменении высоты разбиения такие строки дублировались (issue #1373).
+  // Восстанавливаем типы ведущих строк по числу строк, реально повторяющихся
+  // в начале КАЖДОЙ части: строка 0 — Title, строки 1..L-1 — Header, далее —
+  // Data. Инференс выполняется только при отсутствии явных типов строк.
+  if not FRowStyleTypesExplicit then
+  begin
+    RepeatCount := DetectRepeatedTopRowCountRaw;
+    if (RepeatCount >= 2) and (RepeatCount < FRowCount) then
+    begin
+      System.SetLength(FRowStyleTypes, FRowCount);
+      for Idx := 0 to FRowCount - 1 do
+        if Idx = 0 then
+          FRowStyleTypes[Idx] := 0
+        else if Idx < RepeatCount then
+          FRowStyleTypes[Idx] := 1
+        else
+          FRowStyleTypes[Idx] := 2;
+    end;
+  end;
+
   FBreakRepeatTopLabels := EffectiveRepeatTopRowCount > 0;
   UpdateContinuationRowBaseIndexes;
 end;
@@ -3711,6 +3795,7 @@ begin
   System.SetLength(NewTable^.FRowStyleTypes, Length(FRowStyleTypes));
   for Idx := 0 to High(FRowStyleTypes) do
     NewTable^.FRowStyleTypes[Idx] := FRowStyleTypes[Idx];
+  NewTable^.FRowStyleTypesExplicit := FRowStyleTypesExplicit;
 
   NewTable^.FTableStyle := FTableStyle;
   NewTable^.Local := Local;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -190,6 +190,14 @@ type
     // загружаться с правильными типами строк, прочитанными из современного
     // объекта AcDbTableContent (TABLEROW_BEGIN group 90).
     procedure LoadsMultipleHeaderRowsFromDXF;
+    // issue #1373: разорванная (составная) таблица без объекта AcDbTableContent
+    // (tablebugheader3.dxf: строка 0 = Title, строки 1 и 2 = Header, остальные
+    // = Data) хранит типы строк только косвенно — через строки-метки, которые
+    // одинаково повторяются в начале каждой части-продолжения. При загрузке
+    // типы ведущих строк должны восстанавливаться по числу повторяющихся меток,
+    // а зона повтора должна включать обе строки Header, иначе вторая строка
+    // Header считалась данными и дублировалась при изменении высоты разбиения.
+    procedure LoadsMultipleHeaderRowsFromSplitDXF;
   end;
 
 implementation
@@ -2765,6 +2773,47 @@ begin
       'Строка 2 (вторая строка-заголовок) должна загружаться со стилем Header (1)');
     CheckEquals(2, AcadTable^.RowStyleTypeAt(3),
       'Строка 3 должна загружаться со стилем Data (2)');
+  finally
+    Drawing.done;
+  end;
+end;
+
+// issue #1373. Разорванная (составная) таблица tablebugheader3.dxf хранится как
+// несколько сущностей ACAD_TABLE без современного объекта AcDbTableContent,
+// поэтому явных типов строк в DXF нет. Строка 0 = Title, строки 1 и 2 = Header,
+// остальные = Data. Раньше legacy-логика ограничивала зону меток парой
+// Title+Header, из-за чего вторая строка-заголовок (строка 2) определялась как
+// Data: при изменении высоты разбиения она не входила в повторяющиеся верхние
+// метки и дублировалась. После исправления типы ведущих строк восстанавливаются
+// по числу строк, одинаково повторяющихся в начале каждой части-продолжения, и
+// строка 2 корректно получает стиль Header.
+procedure TAcadTableStyleTest.LoadsMultipleHeaderRowsFromSplitDXF;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablebugheader3.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckTrue(AcadTable^.ContinuationPartCount > 0,
+      'Разорванная таблица должна содержать части-продолжения');
+    CheckTrue(AcadTable^.BreakRepeatTopLabels,
+      'Повтор верхних меток должен определяться как True');
+
+    // Восстановленные по повторяющимся меткам типы ведущих строк.
+    CheckEquals(0, AcadTable^.RowStyleTypeAt(0),
+      'Строка 0 должна восстанавливаться со стилем Title (0)');
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(1),
+      'Строка 1 должна восстанавливаться со стилем Header (1)');
+    // Ключевая проверка issue #1373: вторая строка-заголовок разорванной
+    // таблицы раньше ошибочно определялась как Data и дублировалась при
+    // изменении высоты разбиения.
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(2),
+      'Строка 2 (вторая строка-заголовок) должна восстанавливаться со стилем Header (1)');
+    CheckEquals(2, AcadTable^.RowStyleTypeAt(3),
+      'Строка 3 должна восстанавливаться со стилем Data (2)');
   finally
     Drawing.done;
   end;

--- a/test_issue1373_acadtable_split_multiheader_contract.py
+++ b/test_issue1373_acadtable_split_multiheader_contract.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""
+Regression checks for issue 1373 (split-table follow-up): a legacy ACAD_TABLE
+that was broken into several parts and whose repeating top labels span more than
+the classic Title+Header pair.
+
+The original issue fixed whole (non-split) tables by reading per-row style types
+from the modern AcDbTableContent object. But a *split* table exported as several
+legacy ACAD_TABLE entities (cad_source/test/tablebugheader3.dxf) has NO
+AcDbTableContent at all, so no explicit row styles reach the model. The legacy
+top-label logic then caps the repeat zone at two rows (row 0 = Title, row 1 =
+Header), which means a table whose rows 1 AND 2 are both header labels loses the
+second header: on a break-height change only rows 0 and 1 repeat and the third
+label row is treated as data and duplicated in every continuation part.
+
+The fix infers per-row style types for such tables from the content itself: the
+number of leading rows that repeat identically at the start of *every*
+continuation part is exactly the label-row count (Title + Header rows) before the
+first data row. GDBObjAcadTable.DetectBreakRepeatTopLabels calls
+DetectRepeatedTopRowCountRaw and, when no explicit types were supplied
+(FRowStyleTypesExplicit = False), rebuilds FRowStyleTypes as
+[Title, Header * (L-1), Data * rest]. ComputeTopLabelRowCount /
+EffectiveRepeatTopRowCount then honour the true label-row count and the split
+keeps all L leading rows in the repeat zone.
+
+These checks lock the source-level wiring (mirroring the issue-1342 / issue-1373
+whole-table contract tests) and verify the fixture actually exhibits a
+three-row (not two-row) repeat zone across its parts.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+ACADTABLE_MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
+)
+FIXTURE = ROOT / "cad_source" / "test" / "tablebugheader3.dxf"
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+# --- source-contract checks ------------------------------------------------
+
+
+def test_model_tracks_explicit_row_style_flag():
+    # A boolean guard distinguishes styles set from outside (AcDbTableContent or
+    # the spreadsheet editor) from styles inferred for legacy split tables, so
+    # inference never clobbers real data.
+    model = compact(read_text(ACADTABLE_MODEL))
+    assert "frowstyletypesexplicit:boolean;" in model
+    # SetRowStyleTypes marks the styles explicit; inference is gated on the flag.
+    assert "frowstyletypesexplicit:=true;" in model
+    assert "ifnotfrowstyletypesexplicitthen" in model
+
+
+def test_model_declares_raw_repeat_detector():
+    model = compact(read_text(ACADTABLE_MODEL))
+    # The uncapped detector counts leading rows that repeat across every part.
+    assert "functiongdbobjacadtable.detectrepeatedtoprowcountraw:integer;" in model
+    # It is consumed by DetectBreakRepeatTopLabels to rebuild the row styles.
+    assert "repeatcount:=detectrepeatedtoprowcountraw;" in model
+
+
+def test_inference_rebuilds_title_header_data_rows():
+    model = compact(read_text(ACADTABLE_MODEL))
+    # Row 0 -> Title(0), rows 1..L-1 -> Header(1), rest -> Data(2).
+    assert "system.setlength(frowstyletypes,frowcount);" in model
+    assert "(repeatcount>=2)and(repeatcount<frowcount)" in model
+
+
+def test_clone_copies_explicit_flag():
+    # Cloning a table must carry the explicit/inferred distinction so a copied
+    # table does not silently re-infer over real styles.
+    model = compact(read_text(ACADTABLE_MODEL))
+    assert "newtable^.frowstyletypesexplicit:=frowstyletypesexplicit" in model
+
+
+# --- fixture behaviour check ----------------------------------------------
+
+
+def _acad_table_entities(text: str):
+    lines = text.replace("\r\n", "\n").split("\n")
+    pairs = []
+    k = 0
+    while k < len(lines) - 1:
+        pairs.append((lines[k].strip(), lines[k + 1]))
+        k += 2
+    ents, cur = [], []
+    for code, val in pairs:
+        if code == "0" and val.strip() == "ACAD_TABLE":
+            if cur:
+                ents.append(cur)
+            cur = []
+        cur.append((code, val))
+    if cur:
+        ents.append(cur)
+    return [
+        e for e in ents if any(c == "100" and v.strip() == "AcDbTable" for c, v in e)
+    ]
+
+
+def _entity_dims(entity):
+    rows = cols = None
+    for code, val in entity:
+        if code == "91" and rows is None:
+            rows = int(val.strip())
+        elif code == "92" and cols is None:
+            cols = int(val.strip())
+        if rows is not None and cols is not None:
+            break
+    return rows, cols
+
+
+def _entity_cell_texts(entity):
+    return [v for c, v in entity if c == "302"]
+
+
+def _rows_repeat_across_parts(parts_texts, cols, count):
+    """True when the first `count` rows are identical across every part."""
+    ref = parts_texts[0]
+    for texts in parts_texts[1:]:
+        if ref[: count * cols] != texts[: count * cols]:
+            return False
+    return True
+
+
+def test_fixture_is_a_legacy_split_table():
+    text = read_text(FIXTURE)
+    ents = _acad_table_entities(text)
+    # Three legacy ACAD_TABLE parts: one main + two continuations.
+    assert len(ents) == 3, len(ents)
+    # No modern content object exists, so no explicit row styles are available.
+    assert "AcDbTableContent" not in text
+    assert "ACDBLINKEDTABLEDATA" not in text
+
+
+def test_fixture_repeat_zone_is_three_rows_not_two():
+    text = read_text(FIXTURE)
+    ents = _acad_table_entities(text)
+    dims = [_entity_dims(e) for e in ents]
+    # Every part is 4 rows x 3 columns.
+    assert dims == [(4, 3), (4, 3), (4, 3)], dims
+    cols = 3
+    parts_texts = [_entity_cell_texts(e) for e in ents]
+    assert all(len(t) == 12 for t in parts_texts), [len(t) for t in parts_texts]
+
+    # The correct repeat count is the largest L for which all parts share their
+    # first L rows -- exactly what DetectRepeatedTopRowCountRaw computes.
+    detected = 0
+    for count in range(min(dims[0][0], 4), 0, -1):
+        if _rows_repeat_across_parts(parts_texts, cols, count):
+            detected = count
+            break
+    # Rows 0 (Title "Титул"), 1 ("1 2 3") and 2 ("a b c") repeat in every part;
+    # only row 3 (the data value 2/3/4) differs.
+    assert detected == 3, detected
+    # The legacy Title+Header cap of two rows would wrongly drop the second
+    # header row into the data zone -- the exact bug this fix removes.
+    assert detected > 2
+
+
+if __name__ == "__main__":
+    test_model_tracks_explicit_row_style_flag()
+    test_model_declares_raw_repeat_detector()
+    test_inference_rebuilds_title_header_data_rows()
+    test_clone_copies_explicit_flag()
+    test_fixture_is_a_legacy_split_table()
+    test_fixture_repeat_zone_is_three_rows_not_two()
+    print("issue 1373 AcadTable split multi-header contract checks passed")


### PR DESCRIPTION
## Итог

Исправляет veb86/zcadvelecAI#1373 — разорванная (составная) таблица загружалась с
неправильно определёнными повторяющимися верхними метками: при нескольких строках
заголовка вторая строка Header ошибочно считалась данными и **дублировалась**
внутри таблицы при изменении высоты разбиения.

## Причина

Задача состояла из двух частей:

1. **Целая (неразорванная) таблица** (`cad_source/test/tablebugheader.dxf`) — уже
   исправлено ранее в master: типы строк читаются из современного объекта
   `AcDbTableContent` (маркеры `TABLEROW_BEGIN`, group 90) и применяются к таблице
   через `SetRowStyleTypes`.

2. **Разорванная таблица** (`cad_source/test/tablebugheader3.dxf`) — данная правка.
   Такая таблица хранится как несколько legacy-сущностей `ACAD_TABLE` **без**
   объекта `AcDbTableContent`, поэтому явные типы строк в модель не поступают.
   Legacy-логика ограничивала зону верхних меток парой Title + один Header. Когда
   строки 1 и 2 обе являются заголовками, вторая строка Header попадала в зону
   данных, а при изменении высоты разбиения дублировалась в каждой
   части-продолжении.

## Решение

`GDBObjAcadTable.DetectBreakRepeatTopLabels` теперь восстанавливает типы ведущих
строк по самому содержимому:

- Новый `DetectRepeatedTopRowCountRaw` считает число ведущих строк, одинаково
  повторяющихся в начале **каждой** части-продолжения (без ограничения зоной
  меток). Это и есть реальное число строк-меток (Title + строки Header) перед
  первой строкой данных.
- Из этого числа `L` перестраивается `FRowStyleTypes` как
  `[Title, Header×(L-1), Data×остальные]`.
- Инференс выполняется только когда типы **не** заданы явно
  (`FRowStyleTypesExplicit` = False), поэтому реальные стили из
  `AcDbTableContent` или редактора таблиц не затираются. Флаг переносится при
  клонировании таблицы.
- Ограничитель в рендере применяет типы строк только к главной части и частям,
  реально повторяющим метки (`ARowBaseIndex = 0`); часть-продолжение без повтора
  меток сохраняет позиционный стиль от своей логической базы (без регрессии
  #1311/#1368).

После правки `ComputeTopLabelRowCount` / `EffectiveRepeatTopRowCount` возвращают
истинное число строк-меток, и `SplitMainTableByBreakHeight` повторяет все `L`
ведущих строк — вторая строка Header больше не дублируется.

## Как воспроизвести

Загрузить `cad_source/test/tablebugheader3.dxf` (строка 0 = Title, строки 1 и 2 =
Header, далее Data) и изменить высоту разбиения — до правки третья строка (вторая
строка Header) дублировалась в частях.

## Тесты

- **fpcunit** `LoadsMultipleHeaderRowsFromSplitDXF`
  (`cad_source/zengine/tests/uzctacadtable.pas`): после загрузки
  `tablebugheader3.dxf` типы строк должны быть Title/Header/**Header**/Data —
  ключевая проверка, что вторая строка заголовка не считается данными.
- **Контрактный тест** `test_issue1373_acadtable_split_multiheader_contract.py`:
  запускаемая регрессия, фиксирующая исходную «проводку» правки и проверяющая,
  что фикстура действительно имеет зону повтора из **трёх** строк (а не двух)
  среди трёх частей `ACAD_TABLE`.

```
$ python3 test_issue1373_acadtable_split_multiheader_contract.py
issue 1373 AcadTable split multi-header contract checks passed
$ python3 test_issue1373_acadtable_multiheader_contract.py
issue 1373 AcadTable multi-header contract checks passed
```

> Примечание: полная сборка Pascal-тестов требует подмодулей и LCL (Lazarus),
> которые недоступны в среде решателя, поэтому проверка выполнена запускаемыми
> контрактными тестами уровня исходников (тот же подход, что в контрактных тестах
> #1342/#1373) и разбором фикстуры.

---
*PR подготовлен AI-решателем задач.*



Fixes veb86/zcadvelecAI#1373