### PR TITLE
AcadTable: исправить ошибки типов GPoint/GVector при сборке

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-20T02:06:35.383Z for PR creation at branch issue-1387-4c01dc792fdf for issue https://github.com/veb86/zcadvelecAI/issues/1387

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-20T02:06:35.383Z for PR creation at branch issue-1387-4c01dc792fdf for issue https://github.com/veb86/zcadvelecAI/issues/1387

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -802,7 +802,7 @@ constructor GDBObjAcadTable.initnul(
   AOwner: PGDBObjGenericWithSubordinated);
 begin
   inherited initnul;
-  FInsertPoint := NulVertex;
+  FInsertPoint := NulPoint;
   FRowCount := 0;
   FColCount := 0;
   FRowHeights.initnul;
@@ -1613,7 +1613,7 @@ begin
   BlockName := GenerateUniqueTableBlockName(ADrawing);
   BlockArr := PGDBObjBlockdefArray(ADrawing.GetBlockDefArraySimple);
   BlockDef := BlockArr^.create(BlockName);
-  BlockDef^.Base := NulVertex;
+  BlockDef^.Base := NulPoint;
   // BlockDef валиден на протяжении всего вызова RenderCurrentTable: тот
   // создаёт только сущности (не блоки), поэтому BlockDefArray не растёт и
   // BlockDef не перемещается. Держать указатель через create() нельзя —
@@ -1633,7 +1633,7 @@ begin
     BlockName := GenerateUniqueTableBlockName(ADrawing);
     BlockArr := PGDBObjBlockdefArray(ADrawing.GetBlockDefArraySimple);
     BlockDef := BlockArr^.create(BlockName);
-    BlockDef^.Base := NulVertex;
+    BlockDef^.Base := NulPoint;
     RenderCurrentTable(ADrawing, DC, BlockDef^.ObjArray, BlockDef, 0, 0,
       FContinuationParts[PartIdx].RowBaseIndex);
     SwapTableData(FContinuationParts[PartIdx]);
@@ -3203,14 +3203,15 @@ end;
 // Раскладывает objmatrix на точку вставки, базис и масштаб.
 procedure GDBObjAcadTable.decomposite;
 var
-  BX, BY, BZ, T: TzePoint3d;
+  BX, BY, BZ: TzeVector3d;
+  T: TzePoint3d;
   Mtr: TzeTypedMatrix4d;
 begin
   Mtr := objMatrix;
-  BX := PzePoint3d(@Mtr.mtr.v[0])^;
-  BY := PzePoint3d(@Mtr.mtr.v[1])^;
-  BZ := PzePoint3d(@Mtr.mtr.v[2])^;
-  T := PzePoint3d(@Mtr.mtr.v[3])^;
+  BX := Mtr.mtr.v[0].Slice;
+  BY := Mtr.mtr.v[1].Slice;
+  BZ := Mtr.mtr.v[2].Slice;
+  T := Mtr.mtr.v[3].Slice.asPoint3d;
   Local := GetPointInOCSByBasis(BX, BY, BZ, T, FScale);
 end;
 
@@ -3227,15 +3228,14 @@ end;
 // после трансформации (перенос/поворот/масштабирование).
 procedure GDBObjAcadTable.ReCalcFromObjMatrix;
 var
-  ox: TzePoint3d;
-  tv: TzePoint3d;
+  ox, tv: TzeVector3d;
 begin
   inherited;
   decomposite;
   ox := GetXfFromZ(Local.basis.oz);
   tv := Local.basis.ox;
   if FScale.x < -eps then
-    tv := VertexMulOnSc(tv, -1);
+    tv := tv * -1;
   FRotate := scalardot(tv, ox);
   FRotate := arccos(FRotate);
   if scalardot(tv, VectorDot(Local.basis.oz,
@@ -3294,7 +3294,7 @@ begin
   PDesc.selected := False;
   PDesc.PDrawable := nil;
   PDesc.attr := [];
-  PDesc.dcoord := NulVertex;
+  PDesc.dcoord := NulPoint;
   PDesc.vn := 0;
   PDesc.pointtype := os_point;
   PDesc.worldcoord := self.P_insert_in_WCS;

--- a/cad_source/zcad/velec/exporttosvg/uexpsvgblock.pas
+++ b/cad_source/zcad/velec/exporttosvg/uexpsvgblock.pas
@@ -139,7 +139,7 @@ begin
   Center := FTransformer.Transform(Ellipse^.Local.P_insert);
   
   // Большая полуось (длина вектора MajorAxis)
-  MajorRadius := oneVertexlength(Ellipse^.MajorAxis);
+  MajorRadius := oneVertexlength(Ellipse^.MajorAxis.asVector3d);
   // Малая полуось (через Ratio)
   MinorRadius := MajorRadius * Ellipse^.Ratio;
   

--- a/cad_source/zcad/velec/rotatecontrol/uzvrotate_logic.pas
+++ b/cad_source/zcad/velec/rotatecontrol/uzvrotate_logic.pas
@@ -156,7 +156,7 @@ begin
   RotationData.AngleX := 0;
   RotationData.AngleY := 0;
   RotationData.AngleZ := 0;
-  RotationData.Center := NulVertex;
+  RotationData.Center := NulPoint;
 end;
 
 {**Вычислить центр вращения (геометрический центр bounding box)}
@@ -168,7 +168,7 @@ var
   firstObject: Boolean;
   dc: TDrawContext;
 begin
-  Result := NulVertex;
+  Result := NulPoint;
   firstObject := True;
 
   dc := drawings.GetCurrentDWG^.CreateDrawingRC;

--- a/cad_source/zcad/velec/testarc.pas
+++ b/cad_source/zcad/velec/testarc.pas
@@ -44,6 +44,11 @@ begin
   Result := Format('X=%.6f, Y=%.6f, Z=%.6f', [p.x, p.y, p.z]);
 end;
 
+function Vector3DToStr(const p:TzeVector3d):string;
+begin
+  Result := Format('X=%.6f, Y=%.6f, Z=%.6f', [p.x, p.y, p.z]);
+end;
+
 function AngleToDeg(angle:double):double;
 begin
   Result := angle * 180.0 / PI;
@@ -83,9 +88,9 @@ begin
   LogMatrix(prefix + ' ', pa^.objmatrix);
 
   // Вывод локальной СК
-  LogMessage(Format('   %s Local.basis.OX: %s', [prefix, Point3DToStr(pa^.Local.basis.ox)]));
-  LogMessage(Format('   %s Local.basis.OY: %s', [prefix, Point3DToStr(pa^.Local.basis.oy)]));
-  LogMessage(Format('   %s Local.basis.OZ: %s', [prefix, Point3DToStr(pa^.Local.basis.oz)]));
+  LogMessage(Format('   %s Local.basis.OX: %s', [prefix, Vector3DToStr(pa^.Local.basis.ox)]));
+  LogMessage(Format('   %s Local.basis.OY: %s', [prefix, Vector3DToStr(pa^.Local.basis.oy)]));
+  LogMessage(Format('   %s Local.basis.OZ: %s', [prefix, Vector3DToStr(pa^.Local.basis.oz)]));
 
   // Проверка: радиус должен соответствовать масштабу по осям
   LogMessage(Format('   %s Проверка масштаба: OX.x=%.6f, OY.y=%.6f, R=%.6f', [prefix, pa^.Local.basis.ox.x, pa^.Local.basis.oy.y, pa^.R]));

--- a/cad_source/zcad/velec/testarc2.pas
+++ b/cad_source/zcad/velec/testarc2.pas
@@ -46,6 +46,11 @@ begin
   Result := Format('X=%.6f, Y=%.6f, Z=%.6f', [p.x, p.y, p.z]);
 end;
 
+function Vector3DToStr(const p:TzeVector3d):string;
+begin
+  Result := Format('X=%.6f, Y=%.6f, Z=%.6f', [p.x, p.y, p.z]);
+end;
+
 function AngleToDeg(angle:double):double;
 begin
   Result := angle * 180.0 / PI;
@@ -85,9 +90,9 @@ begin
   LogMatrix(prefix + ' ', pa^.objmatrix);
 
   // Вывод локальной СК
-  LogMessage(Format('   %s Local.basis.OX: %s', [prefix, Point3DToStr(pa^.Local.basis.ox)]));
-  LogMessage(Format('   %s Local.basis.OY: %s', [prefix, Point3DToStr(pa^.Local.basis.oy)]));
-  LogMessage(Format('   %s Local.basis.OZ: %s', [prefix, Point3DToStr(pa^.Local.basis.oz)]));
+  LogMessage(Format('   %s Local.basis.OX: %s', [prefix, Vector3DToStr(pa^.Local.basis.ox)]));
+  LogMessage(Format('   %s Local.basis.OY: %s', [prefix, Vector3DToStr(pa^.Local.basis.oy)]));
+  LogMessage(Format('   %s Local.basis.OZ: %s', [prefix, Vector3DToStr(pa^.Local.basis.oz)]));
 
   // Проверка: радиус должен соответствовать масштабу по осям
   LogMessage(Format('   %s Проверка масштаба: OX.x=%.6f, OY.y=%.6f, R=%.6f', [prefix, pa^.Local.basis.ox.x, pa^.Local.basis.oy.y, pa^.R]));

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
@@ -233,7 +233,7 @@ begin
   // Строим таблицу из текстов ячеек с переносом размеров столбцов/строк
   // и выравнивания ячеек (точка вставки временная, нулевая — окончательное
   // положение пользователь укажет при перемещении из root)
-  insPt := NulVertex;
+  insPt := NulPoint;
   if not pt^.BuildFromCellTextsWithSizesAndAlignments(rowCount, colCount,
        texts, colWidths, rowHeights, cellAlignments, insPt) then
   begin

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -2248,7 +2248,7 @@ begin
     System.SetLength(RowHeights, 0);
     System.SetLength(Alignments, 0);
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(6, 1, Texts,
       ColWidths, RowHeights, Alignments, InsertPt),
       'Построение тестовой таблицы должно завершиться успешно');
@@ -2453,7 +2453,7 @@ begin
     Texts[0] := 'A1'; Texts[1] := 'B1'; Texts[2] := 'C1';
     Texts[3] := 'A2'; Texts[4] := '';   Texts[5] := 'C2';
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     Ok := Table^.BuildFromCellTexts(2, 3, Texts, InsertPt);
     CheckTrue(Ok, 'BuildFromCellTexts должен успешно построить таблицу');
 
@@ -2493,7 +2493,7 @@ begin
     Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
 
     System.SetLength(Texts, 0);
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     CheckFalse(Table^.BuildFromCellTexts(0, 0, Texts, InsertPt),
       'Пустой диапазон не должен создавать таблицу');
     CheckEquals(0, Table^.RowCount,
@@ -2535,7 +2535,7 @@ begin
     System.SetLength(RowHeights, 2);
     RowHeights[0] := 20; RowHeights[1] := 30;
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     Ok := Table^.BuildFromCellTextsWithSizes(2, 3, Texts,
       ColWidths, RowHeights, InsertPt);
     CheckTrue(Ok, 'BuildFromCellTextsWithSizes должен построить таблицу');
@@ -2576,7 +2576,7 @@ begin
     ColWidths[0] := 45; ColWidths[1] := 0;
     System.SetLength(RowHeights, 0);
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     CheckTrue(Table^.BuildFromCellTextsWithSizes(1, 3, Texts,
       ColWidths, RowHeights, InsertPt),
       'BuildFromCellTextsWithSizes должен построить таблицу');
@@ -2623,7 +2623,7 @@ begin
     Alignments[0] := 1; Alignments[1] := 5; Alignments[2] := 9;
     Alignments[3] := 4; Alignments[4] := 0;
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(2, 3, Texts,
       ColWidths, RowHeights, Alignments, InsertPt),
       'BuildFromCellTextsWithSizesAndAlignments должен построить таблицу');
@@ -2670,7 +2670,7 @@ begin
     System.SetLength(RowHeights, 0);
     System.SetLength(Alignments, 0);
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(3, 3, Texts,
       ColWidths, RowHeights, Alignments, InsertPt),
       'BuildFromCellTextsWithSizesAndAlignments должен построить таблицу');
@@ -2720,7 +2720,7 @@ begin
     System.SetLength(RowHeights, 0);
     System.SetLength(Alignments, 0);
 
-    InsertPt := NulVertex;
+    InsertPt := NulPoint;
     CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(2, 2, Texts,
       ColWidths, RowHeights, Alignments, InsertPt),
       'Первичное построение таблицы должно завершиться успешно');

--- a/test_issue1387_acadtable_geometry_types.py
+++ b/test_issue1387_acadtable_geometry_types.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""
+Контракт компиляции AcadTable после разделения GPoint/GVector.
+
+После обновления zmath нулевая точка и вектор имеют разные типы.
+Базис матрицы состоит из векторов, а её перенос задаётся точкой.
+Проверки фиксируют этот контракт в AcadTable и зависимых модулях,
+которые компилятор достигает после исправления первых ошибок.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+ACADTABLE_MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
+)
+CREATE_ACADTABLE_COMMAND = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvspreadsheet"
+    / "uzvspreadsheet_cmdcreateacadtable.pas"
+)
+ACADTABLE_TESTS = ROOT / "cad_source" / "zengine" / "tests" / "uzctacadtable.pas"
+TEST_ARC = ROOT / "cad_source" / "zcad" / "velec" / "testarc.pas"
+TEST_ARC2 = ROOT / "cad_source" / "zcad" / "velec" / "testarc2.pas"
+ROTATE_LOGIC = (
+    ROOT / "cad_source" / "zcad" / "velec" / "rotatecontrol" / "uzvrotate_logic.pas"
+)
+SVG_BLOCK = (
+    ROOT / "cad_source" / "zcad" / "velec" / "exporttosvg" / "uexpsvgblock.pas"
+)
+
+
+def read_model() -> str:
+    return ACADTABLE_MODEL.read_text(encoding="utf-8")
+
+
+def read_create_command() -> str:
+    return CREATE_ACADTABLE_COMMAND.read_text(encoding="utf-8")
+
+
+def read_acadtable_tests() -> str:
+    return ACADTABLE_TESTS.read_text(encoding="utf-8")
+
+
+def read_test_arc() -> str:
+    return TEST_ARC.read_text(encoding="utf-8")
+
+
+def read_test_arc2() -> str:
+    return TEST_ARC2.read_text(encoding="utf-8")
+
+
+def read_rotate_logic() -> str:
+    return ROTATE_LOGIC.read_text(encoding="utf-8")
+
+
+def read_svg_block() -> str:
+    return SVG_BLOCK.read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def procedure_section(model: str, start: str, following: str) -> str:
+    compact_model = compact(model)
+    start_marker = compact(f"procedure GDBObjAcadTable.{start};")
+    following_marker = compact(f"procedure GDBObjAcadTable.{following}")
+    start_index = compact_model.index(start_marker)
+    following_index = compact_model.index(following_marker, start_index + 1)
+    return compact_model[start_index:following_index]
+
+
+def test_point_fields_use_point_zero_constant():
+    model = compact(read_model())
+
+    assert "finsertpoint:=nulpoint;" in model
+    assert model.count("blockdef^.base:=nulpoint;") == 2
+    assert "finsertpoint:=nulvertex;" not in model
+    assert "blockdef^.base:=nulvertex;" not in model
+
+
+def test_control_point_delta_uses_point_zero_constant():
+    model = compact(read_model())
+
+    assert "pdesc.dcoord:=nulpoint;" in model
+    assert "pdesc.dcoord:=nulvertex;" not in model
+
+
+def test_create_command_uses_point_zero_constant():
+    command = compact(read_create_command())
+
+    assert "inspt:=nulpoint;" in command
+    assert "inspt:=nulvertex;" not in command
+
+
+def test_pascal_acadtable_tests_use_point_zero_constant():
+    tests = compact(read_acadtable_tests())
+
+    assert tests.count("insertpt:=nulpoint;") == 8
+    assert "insertpt:=nulvertex;" not in tests
+
+
+def test_arc_basis_logging_uses_vector_formatter():
+    sources = (compact(read_test_arc()), compact(read_test_arc2()))
+
+    for source in sources:
+        assert "functionvector3dtostr(constp:tzevector3d):string;" in source
+        assert source.count("vector3dtostr(pa^.local.basis.") == 3
+        assert "point3dtostr(pa^.local.basis." not in source
+
+
+def test_rotation_centers_use_point_zero_constant():
+    source = compact(read_rotate_logic())
+
+    assert "rotationdata.center:=nulpoint;" in source
+    assert "result:=nulpoint;" in source
+    assert "rotationdata.center:=nulvertex;" not in source
+
+
+def test_svg_ellipse_axis_is_converted_to_vector_for_length():
+    source = compact(read_svg_block())
+
+    assert "onevertexlength(ellipse^.majoraxis.asvector3d)" in source
+    assert "onevertexlength(ellipse^.majoraxis)" not in source
+
+
+def test_matrix_decomposition_keeps_basis_vectors_and_translation_point():
+    section = procedure_section(read_model(), "decomposite", "setrot")
+
+    assert "bx,by,bz:tzevector3d;" in section
+    assert "t:tzepoint3d;" in section
+    assert "bx:=mtr.mtr.v[0].slice;" in section
+    assert "by:=mtr.mtr.v[1].slice;" in section
+    assert "bz:=mtr.mtr.v[2].slice;" in section
+    assert "t:=mtr.mtr.v[3].slice.aspoint3d;" in section
+    assert "pzepoint3d(@mtr.mtr.v[" not in section
+
+
+def test_rotation_recalculation_uses_basis_vectors():
+    section = procedure_section(read_model(), "ReCalcFromObjMatrix", "CalcObjMatrix")
+
+    assert "ox,tv:tzevector3d;" in section
+    assert "ox:=getxffromz(local.basis.oz);" in section
+    assert "tv:=local.basis.ox;" in section
+    assert "tv:=tv*-1;" in section
+    assert "scalardot(tv,ox)" in section
+
+
+if __name__ == "__main__":
+    test_point_fields_use_point_zero_constant()
+    test_control_point_delta_uses_point_zero_constant()
+    test_create_command_uses_point_zero_constant()
+    test_pascal_acadtable_tests_use_point_zero_constant()
+    test_arc_basis_logging_uses_vector_formatter()
+    test_rotation_centers_use_point_zero_constant()
+    test_svg_ellipse_axis_is_converted_to_vector_for_length()
+    test_matrix_decomposition_keeps_basis_vectors_and_translation_point()
+    test_rotation_recalculation_uses_basis_vectors()
+    print("issue 1387 AcadTable geometry type contract checks passed")


### PR DESCRIPTION
## Что исправлено

После разделения `GPoint` и `GVector` код AcadTable продолжал использовать
точки как векторы и наоборот. Первые пять ошибок из issue скрывали следующие
ошибки того же перехода, которые компилятор находил только после продолжения
сборки.

- Для точек вставки, баз блоков, центров вращения и контрольных точек теперь
  используется `NulPoint`.
- Базис матрицы раскладывается в `TzeVector3d`, а перенос — в `TzePoint3d`;
  небезопасные приведения указателей удалены.
- В зависимых модулях исправлены такие же несоответствия: создание и тесты
  AcadTable, диагностика дуг, RotateControl и экспорт эллипса в SVG.
- Добавлен контрактный тест, который воспроизводит все девять групп ошибок на
  исходном `master` и проходит после исправления.

## Как воспроизвести

1. На `master` запустить сборку ZCAD/zcadelectrotech после обновления zmath с
   разделёнными типами `GPoint` и `GVector`.
2. Компилятор останавливается в `uzeacadtable_model.pas` на присваиваниях
   `NulVertex` полям-точкам и на смешении точек/векторов при разложении матрицы.
3. Запустить `python3 test_issue1387_acadtable_geometry_types.py`: на исходном
   коде каждая из девяти проверок падает, на этой ветке тест проходит.

## Проверка

- `python3 test_issue1387_acadtable_geometry_types.py` — успешно.
- `python3 -m py_compile test_issue1387_acadtable_geometry_types.py` — успешно.
- Lazarus/FPC 3.2.2 скомпилировал `uzeacadtable_model.pas`, все изменённые
  зависимые модули и отдельный проект тестов AcadTable без ошибок типов.
- В тестах AcadTable выполнено 46 тестов: 40 успешно, включая все изменённые
  пути построения таблиц; 6 не связанных с этой задачей проверок ручного
  разбиения остаются падающими в текущем наборе.
- Из 21 корневого Python-теста 20 успешны. Существующий
  `test_issue1368_cell_style.py:115` ожидает строку, удалённую последующим
  изменением #1373, и остаётся падающим без связи с этим PR.
- Полная Linux-сборка прошла все исправленные ошибки геометрических типов и
  остановилась позднее на платформенном импорте `Windows` в
  `VElectrNav`.
- Для SHA `f9c2c5ae1` GitHub Actions и AppVeyor не создали запуск PR;
  `statusCheckRollup` пуст, поэтому удалённых проверок для ожидания нет.

Изменение не затрагивает внешний вид интерфейса, поэтому скриншоты не нужны.

Fixes #1387

*PR подготовлен AI-решателем задач.*
