### PR TITLE
AcadTable: fix scale vector compilation errors

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-23T11:01:51.175Z for PR creation at branch issue-1389-2eb1f1b1e52c for issue https://github.com/veb86/zcadvelecAI/issues/1389

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-23T11:01:51.175Z for PR creation at branch issue-1389-2eb1f1b1e52c for issue https://github.com/veb86/zcadvelecAI/issues/1389

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -167,7 +167,7 @@ type
     // из OZ и теряет поворот в плоскости и масштаб. Благодаря этим полям
     // перенос, поворот и масштабирование таблицы отображаются корректно
     // (issue #1305).
-    FScale: TzePoint3d;
+    FScale: TzeVector3d;
     FRotate: Double;
     // Стиль таблицы
     FTableStyle: TTableStyle;

--- a/test_issue1389_acadtable_scale_type.py
+++ b/test_issue1389_acadtable_scale_type.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+"""
+Контракт компиляции масштаба AcadTable после разделения GPoint/GVector.
+
+Масштаб задаёт компоненты преобразования и поэтому должен храниться как
+вектор. Это позволяет без преобразований передавать его в геометрические
+функции, принимающие выходной вектор масштаба и строящие матрицу масштаба.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+ACADTABLE_MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
+)
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def test_acadtable_scale_uses_vector_type():
+    model = compact(ACADTABLE_MODEL.read_text(encoding="utf-8"))
+
+    assert "fscale:tzevector3d;" in model
+    assert "fscale:tzepoint3d;" not in model
+    assert "fscale:=cv3d__1__1__1;" in model
+    assert "getpointinocsbybasis(bx,by,bz,t,fscale)" in model
+    assert "createscalematrix(fscale)" in model
+
+
+if __name__ == "__main__":
+    test_acadtable_scale_uses_vector_type()
+    print("issue 1389 AcadTable scale type contract checks passed")


### PR DESCRIPTION
## Что исправлено

- `GDBObjAcadTable.FScale` теперь хранится как `TzeVector3d`, как и масштаб
  вставки блока.
- Это устраняет три ошибки компиляции после разделения `GPoint3` и `GVector3`:
  присваивание единичного вектора, параметр `var` в `GetPointInOCSByBasis`
  и аргумент `CreateScaleMatrix`.
- Добавлен минимальный контрактный тест, фиксирующий векторный тип и все три
  места использования.

## Воспроизведение

До исправления:

```text
uzeacadtable_model.pas(828,13) Error: Incompatible types: got GVector3 expected GPoint3
uzeacadtable_model.pas(3215,54) Error: Call by var ... got GPoint3 expected GVector3
uzeacadtable_model.pas(3253,33) Error: Incompatible type for arg no. 1
```

Контрактный тест также падал на объявлении `FScale: TzePoint3d`.

## Проверка

```text
python3 test_issue1389_acadtable_scale_type.py
issue 1389 AcadTable scale type contract checks passed

python3 -m py_compile test_issue1389_acadtable_scale_type.py
git diff --check upstream/master...HEAD
```

Полная Pascal-сборка локально не запускалась: в окружении отсутствуют `fpc`
и `lazbuild`. Существующий `test_issue1387_acadtable_geometry_types.py` уже
не соответствует текущему upstream после замены `NulPoint` на
`cP3d__0__0__0`; это не связано с данным изменением.

Fixes #1389
