### PR TITLE
Rotate control: fix translation vector compilation errors

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-23T11:41:54.618Z for PR creation at branch issue-1391-082188e20234 for issue https://github.com/veb86/zcadvelecAI/issues/1391

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-23T11:41:54.618Z for PR creation at branch issue-1391-082188e20234 for issue https://github.com/veb86/zcadvelecAI/issues/1391

--- a/cad_source/zcad/velec/rotatecontrol/uzvrotate_logic.pas
+++ b/cad_source/zcad/velec/rotatecontrol/uzvrotate_logic.pas
@@ -226,10 +226,8 @@ var
   combined: TzeTypedMatrix4d;
 begin
   // Порядок операций аналогичен uzccommand_rotate.pas
-  translateToOrigin := CreateTranslationMatrix(
-    CreateVertex(-ACenter.x, -ACenter.y, -ACenter.z)
-  );
-  translateBack := CreateTranslationMatrix(ACenter);
+  translateToOrigin := CreateTranslationMatrix(-ACenter.asVector);
+  translateBack := CreateTranslationMatrix(ACenter.asVector);
 
   // Матрицы вращения по осям
   rotX := CreateRotationMatrixX(AAngleX);

--- a/test_issue1391_rotate_translation_type.py
+++ b/test_issue1391_rotate_translation_type.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""
+Контракт компиляции матриц переноса после разделения GPoint/GVector.
+
+Центр вращения является точкой, но перенос к центру и обратно задаётся
+вектором. Поэтому CreateTranslationMatrix должен получать ACenter.asVector.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+ROTATE_LOGIC = (
+    ROOT / "cad_source" / "zcad" / "velec" / "rotatecontrol" / "uzvrotate_logic.pas"
+)
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def test_rotation_center_is_converted_to_translation_vectors():
+    logic = compact(ROTATE_LOGIC.read_text(encoding="utf-8"))
+
+    assert "createtranslationmatrix(-acenter.asvector)" in logic
+    assert "createtranslationmatrix(acenter.asvector)" in logic
+    assert "createtranslationmatrix(createvertex(-acenter.x,-acenter.y,-acenter.z))" not in logic
+    assert "createtranslationmatrix(acenter)" not in logic
+
+
+if __name__ == "__main__":
+    test_rotation_center_is_converted_to_translation_vectors()
+    print("issue 1391 rotate translation type contract checks passed")


### PR DESCRIPTION
## Что исправлено

- Центр вращения остаётся `TzePoint3d`, но перед передачей в `CreateTranslationMatrix` явно преобразуется в `TzeVector3d` через `asVector`.
- Перенос к началу координат использует `-ACenter.asVector`, обратный перенос — `ACenter.asVector`, как в `uzccommand_rotate.pas`.
- Добавлен минимальный контрактный тест для обоих аргументов матриц переноса.

## Причина

После разделения обобщённых типов `GPoint3` и `GVector3` функция `CreateTranslationMatrix` принимает вектор переноса. В `uzvrotate_logic.pas` ей передавались две точки: результат `CreateVertex(...)` и `ACenter`. Координаты были математически верными, но типы больше не совместимы.

## Воспроизведение

До исправления компилятор сообщал:

```text
uzvrotate_logic.pas(231,3) Error: Incompatible type for arg no. 1: Got GPoint3, expected GVector3
uzvrotate_logic.pas(232,51) Error: Incompatible type for arg no. 1: Got GPoint3, expected GVector3
```

Контрактный тест также падал, поскольку оба вызова использовали точки вместо векторов.

## Проверка

```text
python3 test_issue1391_rotate_translation_type.py
issue 1391 rotate translation type contract checks passed

python3 -m py_compile test_issue1391_rotate_translation_type.py
python3 test_issue1389_acadtable_scale_type.py
git diff --check upstream/master...HEAD
```

Полная Pascal-сборка локально не запускалась: в окружении отсутствуют `fpc` и `lazbuild`. Визуальных изменений нет, поэтому скриншоты не требуются.

Fixes #1391
