### PR TITLE
SVG exporter: fix block compilation errors

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-23T12:21:35.860Z for PR creation at branch issue-1393-adf66f940a60 for issue https://github.com/veb86/zcadvelecAI/issues/1393

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-23T12:21:35.860Z for PR creation at branch issue-1393-adf66f940a60 for issue https://github.com/veb86/zcadvelecAI/issues/1393

--- a/cad_source/zcad/velec/exporttosvg/uexpsvgblock.pas
+++ b/cad_source/zcad/velec/exporttosvg/uexpsvgblock.pas
@@ -139,7 +139,7 @@ begin
   Center := FTransformer.Transform(Ellipse^.Local.P_insert);
   
   // Большая полуось (длина вектора MajorAxis)
-  MajorRadius := oneVertexlength(Ellipse^.MajorAxis.asVector3d);
+  MajorRadius := oneVertexlength(Ellipse^.MajorAxis);
   // Малая полуось (через Ratio)
   MinorRadius := MajorRadius * Ellipse^.Ratio;
   
@@ -297,7 +297,7 @@ begin
     end;
 
     // Сбрасываем трансформер в identity - экспортируем в локальных координатах блока
-    FTransformer.SetFromBlockInsert(OneMatrix);
+    FTransformer.SetFromBlockInsert(cOneMatrix);
 
     // Перебираем примитивы в определении блока (как в getPointConnector из uzvcom)
     // BlockDef.ObjArray содержит примитивы блока
@@ -374,7 +374,7 @@ begin
     end;
 
     // Сбрасываем трансформер в identity - экспортируем в локальных координатах устройства
-    FTransformer.SetFromBlockInsert(OneMatrix);
+    FTransformer.SetFromBlockInsert(cOneMatrix);
 
     // 1. Перебираем примитивы в определении блока устройства
     for i := 0 to BlockDef^.ObjArray.Count - 1 do

--- a/test_issue1387_acadtable_geometry_types.py
+++ b/test_issue1387_acadtable_geometry_types.py
@@ -125,8 +125,8 @@ def test_rotation_centers_use_point_zero_constant():
 def test_svg_ellipse_axis_is_converted_to_vector_for_length():
     source = compact(read_svg_block())
 
-    assert "onevertexlength(ellipse^.majoraxis.asvector3d)" in source
-    assert "onevertexlength(ellipse^.majoraxis)" not in source
+    assert "onevertexlength(ellipse^.majoraxis)" in source
+    assert "ellipse^.majoraxis.asvector3d" not in source
 
 
 def test_matrix_decomposition_keeps_basis_vectors_and_translation_point():

--- a/test_issue1393_svg_block_compile_contract.py
+++ b/test_issue1393_svg_block_compile_contract.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""
+Контракт компиляции SVG-экспортера после разделения GPoint/GVector.
+
+MajorAxis уже является вектором, а единичная матрица геометрического
+движка называется cOneMatrix.
+"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SVG_BLOCK = (
+    ROOT / "cad_source" / "zcad" / "velec" / "exporttosvg" / "uexpsvgblock.pas"
+)
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def test_ellipse_axis_length_uses_vector_directly():
+    source = compact(SVG_BLOCK.read_text(encoding="utf-8"))
+
+    assert "onevertexlength(ellipse^.majoraxis)" in source
+    assert "ellipse^.majoraxis.asvector3d" not in source
+
+
+def test_local_svg_exports_use_current_identity_matrix_constant():
+    source = compact(SVG_BLOCK.read_text(encoding="utf-8"))
+
+    assert source.count("ftransformer.setfromblockinsert(conematrix)") == 2
+    assert "ftransformer.setfromblockinsert(onematrix)" not in source
+
+
+if __name__ == "__main__":
+    test_ellipse_axis_length_uses_vector_directly()
+    test_local_svg_exports_use_current_identity_matrix_constant()
+    print("issue 1393 SVG block compile contract checks passed")


### PR DESCRIPTION
## Что исправлено

- Для длины большой полуоси SVG-эллипса `MajorAxis` передаётся в `oneVertexlength` напрямую: поле уже имеет векторный тип и больше не предоставляет `asVector3d`.
- Два сброса SVG-трансформера используют актуальную единичную матрицу `cOneMatrix` вместо удалённого `OneMatrix`.
- Добавлен минимальный контрактный тест для всех трёх мест из сообщения компилятора.
- Обновлена устаревшая SVG-проверка в тесте issue #1387, которая фиксировала старый API.

## Причина

После разделения типов точек и векторов `MajorAxis` стал самостоятельным вектором, поэтому прежнее преобразование через `asVector3d` больше не существует. Одновременно единичная матрица геометрического движка доступна как `cOneMatrix`; несуществующий идентификатор `OneMatrix` оставался в двух путях локального SVG-экспорта.

## Воспроизведение

До исправления компилятор сообщал:

```text
uexpsvgblock.pas(142,53) Error: Identifier idents no member "asVector3d"
uexpsvgblock.pas(300,37) Error: Identifier not found "OneMatrix"
uexpsvgblock.pas(377,37) Error: Identifier not found "OneMatrix"
```

Новый `test_issue1393_svg_block_compile_contract.py` до изменения падал на первом устаревшем выражении и проверяет отсутствие всех трёх ошибочных вызовов.

## Проверка

```text
python3 test_issue1393_svg_block_compile_contract.py
issue 1393 SVG block compile contract checks passed

python3 -c "import test_issue1387_acadtable_geometry_types as t; t.test_svg_ellipse_axis_is_converted_to_vector_for_length()"
python3 test_issue1389_acadtable_scale_type.py
python3 test_issue1391_rotate_translation_type.py
python3 -m py_compile test_issue1393_svg_block_compile_contract.py test_issue1387_acadtable_geometry_types.py
git diff --check upstream/master...HEAD
```

Полная Pascal-сборка локально не запускалась: в окружении отсутствуют `fpc` и `lazbuild`. Изменение не визуальное, поэтому скриншоты не требуются.

Fixes #1393
