### PR TITLE
Корректная обработка видимости DXF-примитивов по коду 60

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-23T13:50:54.823Z for PR creation at branch issue-788-a7d589cb32e2 for issue https://github.com/veb86/zcadvelecAI/issues/788

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-23T13:50:54.823Z for PR creation at branch issue-788-a7d589cb32e2 for issue https://github.com/veb86/zcadvelecAI/issues/788

--- a/cad_source/zengine/containers/UGDBOpenArrayOfPV.pas
+++ b/cad_source/zengine/containers/UGDBOpenArrayOfPV.pas
@@ -69,7 +69,7 @@ begin
      pobj:=beginiterate(ir);
      if pobj<>nil then
      repeat
-           if pobj^.onpoint(Objects,point) then
+           if pobj^.IsActualy and pobj^.onpoint(Objects,point) then
            begin
                 result:=true;
                 //Objects.Add(@pobj);
@@ -85,22 +85,21 @@ function GDBObjOpenArrayOfPV.calcbb:TBoundingBox;
 var pobj:pGDBObjEntity;
     ir:itrec;
 begin
+  result.LBN:=cP3d__0__0__0;
+  result.RTF:=cP3d_m1_m1_m1;
   pobj:=beginiterate(ir);
-  if pobj=nil then
-                  begin
-                       result.LBN:=cP3d__0__0__0;
-                       result.RTF:=cP3d__0__0__0;
-                  end
-              else
-                  begin
+  while (pobj<>nil) and (not pobj^.IsActualy) do
+    pobj:=iterate(ir);
+  if pobj<>nil then begin
                        result:=pobj^.vp.BoundingBox;
                        pobj:=iterate(ir);
                        if pobj<>nil then
                        repeat
-                             concatbb(result,pobj^.vp.BoundingBox);
+                             if pobj^.IsActualy then
+                               concatbb(result,pobj^.vp.BoundingBox);
                              pobj:=iterate(ir);
                        until pobj=nil;
-                  end;
+  end;
 end;
 function GDBObjOpenArrayOfPV.calcvisbb(infrustumactualy:TActuality):TBoundingBox;
 var pobj:pGDBObjEntity;
@@ -202,7 +201,7 @@ begin
                        //pobj:=iterate(ir);
                        if pobj<>nil then
                        repeat
-                         if (pobj.vp.Layer<>nil)and(pobj.vp.Layer^._on) then begin
+                         if pobj^.IsActualy then begin
                            bb:=pobj^.getonlyvisibleoutbound(dc);
                            if bb.RTF.x>=bb.LBN.x then begin
                              if result.RTF.x>=result.LBN.x then
@@ -364,7 +363,7 @@ begin
   begin
   repeat
         //if p^.Visible=visibleactualy then
-    if p^.vp.Layer^._on then
+    if p^.IsActualy then
         begin
              inc(objcount);
              q:=p^.CalcTrueInFrustum(frustum);

--- a/cad_source/zengine/core/entities/uzeentgenericsubentry.pas
+++ b/cad_source/zengine/core/entities/uzeentgenericsubentry.pas
@@ -258,7 +258,7 @@ begin
   pobj:=objarray.beginiterate(ir);
   if pobj<>nil then
     repeat
-      if pobj^.onpoint(Objects,point) then begin
+      if pobj^.IsActualy and pobj^.onpoint(Objects,point) then begin
         Result:=True;
       end;
 
@@ -290,7 +290,7 @@ begin
   pobj:=Node.nulbeginiterate(ir);
   if pobj<>nil then
     repeat
-      if pobj^.onpoint(Objects,point) then begin
+      if pobj^.IsActualy and pobj^.onpoint(Objects,point) then begin
         Result:=True;
       end;
 
@@ -632,7 +632,7 @@ begin
   for i:=0 to ObjArray.Count-1 do begin
     p:=Pointer(ObjArray.getDataMutable(i));
     if p<>nil then begin
-      ot:=p^.onpoint(objects,point);
+      ot:=p^.IsActualy and p^.onpoint(objects,point);
       if ot then begin
         Result:=True;
       end;
@@ -650,7 +650,7 @@ begin
   for i:=0 to ObjArray.Count-1 do begin
     p:=Pointer(ObjArray.getDataMutable(i));
     if p<>nil then begin
-      ot:=p^.onmouse(popa,mf,InSubEntry);
+      ot:=p^.isonmouse(popa,mf,InSubEntry);
       if ot then begin
         lstonmouse:=p;
         popa.PushBackData(p);

--- a/cad_source/zengine/core/entities/uzeentity.pas
+++ b/cad_source/zengine/core/entities/uzeentity.pas
@@ -39,7 +39,7 @@ type
   TSelect2Stage=procedure(PEntity,PGripsCreator:PGDBObjEntity;
     var SelectedObjCount:integer) of object;
   TDeSelect2Stage=procedure(PV:PGDBObjEntity;var SelectedObjCount:integer) of object;
-  TEntityState=(ESCalcWithoutOwner,ESTemp,ESConstructProxy);
+  TEntityState=(ESCalcWithoutOwner,ESTemp,ESConstructProxy,ESInvisible);
   TEntityStates=set of TEntityState;
   PTExtAttrib=^TExtAttrib;
 
@@ -351,6 +351,7 @@ begin
   toObj.vp.color:=vp.color;
   toObj.vp.Layer:=vp.Layer;
   toObj.vp.LineWeight:=vp.LineWeight;
+  toObj.State:=State;
 end;
 
 procedure GDBObjEntity.correctsublayers(var la:GDBLayerArray);
@@ -403,7 +404,7 @@ var
   oldValue:TActuality;
 begin
   oldValue:=Visible;
-  if (self.vp.Layer._on) then
+  if self.IsActualy then
     Visible:=Actuality.visibleactualy
   else
     Visible:=0;
@@ -865,7 +866,7 @@ begin
     Result:=False;
   end;
   if self.vp.Layer<>nil then
-    if not(self.vp.Layer._on) then begin
+    if not IsActualy then begin
       Visible:=0;
       Result:=False;
     end;
@@ -927,16 +928,19 @@ end;
 
 function GDBObjEntity.getonlyvisibleoutbound(var DC:TDrawContext):TBoundingBox;
 begin
-  getonlyoutbound(dc);
-  Result:=vp.BoundingBox;
+  if IsActualy then begin
+    getonlyoutbound(dc);
+    Result:=vp.BoundingBox;
+  end else begin
+    Result.LBN:=cP3d__0__0__0;
+    Result.RTF:=cP3d_m1_m1_m1;
+  end;
 end;
 
 function GDBObjEntity.IsActualy:boolean;
 begin
-  if vp.Layer^._on then
-    Result:=True
-  else
-    Result:=False;
+  Result:=(vp.Layer<>nil) and vp.Layer^._on and
+    not (ESInvisible in State);
 end;
 
 function GDBObjEntity.isonmouse;
@@ -1004,7 +1008,7 @@ end;
 
 function GDBObjEntity.SelectQuik;
 begin
-  if (vp.Layer._lock)or(not vp.Layer._on) then begin
+  if (vp.Layer._lock)or(not IsActualy) then begin
     Result:=False;
   end else begin
     Result:=True;
@@ -1146,6 +1150,13 @@ begin
     end;
     62:begin
       vp.color:=rdr.ParseInteger;
+      Result:=True;
+    end;
+    60:begin
+      if rdr.ParseInteger=1 then
+        Include(State,ESInvisible)
+      else
+        Exclude(State,ESInvisible);
       Result:=True;
     end;
     370:begin

--- a/cad_source/zengine/core/objects/uzeentitiestree.pas
+++ b/cad_source/zengine/core/objects/uzeentitiestree.pas
@@ -283,7 +283,8 @@ begin
 end;
 class procedure TZEntsManipulator.CorrectNodeBoundingBox(var NodeBB:TBoundingBox;var Entity:GDBObjEntity);
 begin
-     ConcatBB(NodeBB,GetEntityBoundingBox(Entity));
+     if Entity.IsActualy then
+       ConcatBB(NodeBB,GetEntityBoundingBox(Entity));
 end;
 class function TZEntsManipulator.GetEntityBoundingBox(var Entity:GDBObjEntity):TBoundingBox;
 begin

--- a/cad_source/zengine/tests/testzengine.lpr
+++ b/cad_source/zengine/tests/testzengine.lpr
@@ -10,7 +10,8 @@ uses
   uzctentpolyfacemesh, uzctentleader, uzctdwgblockreserve, uzctdwgentleader,
   uzctenttextnilstyle,
   uzctmtextcontentsave,
-  uzctenttransformscalars;
+  uzctenttransformscalars,
+  uzctentityvisibility;
 
 var
   Application: TTestRunner;

--- a/cad_source/zengine/tests/uzctentityvisibility.pas
+++ b/cad_source/zengine/tests/uzctentityvisibility.pas
@@ -1,0 +1,155 @@
+unit uzctentityvisibility;
+
+{$mode objfpc}{$H+}
+
+interface
+
+uses
+  SysUtils,
+  Interfaces,
+  fpcunit,
+  testregistry,
+  uzeentity,
+  uzeffdxf,
+  uzegeometrytypes,
+  uzedrawingsimple,
+  uzgldrawcontext,
+  uzeblockdef,
+  uzeTypes;
+
+type
+  TEntityVisibilityTest = class(TTestCase)
+  published
+    procedure DXFCode60PersistsOnEntityAndControlsCommonBehavior;
+    procedure DXFCode60ZeroAndMissingRemainVisible;
+  end;
+
+implementation
+
+function WriteTempDXF(const Content:string):string;
+var
+  F:TextFile;
+begin
+  Result:=GetTempDir+'test_entity_visibility_'+
+    IntToStr(Random(MaxInt))+'.dxf';
+  AssignFile(F,Result);
+  Rewrite(F);
+  Write(F,Content);
+  CloseFile(F);
+end;
+
+function LineEntity(const X:integer;const VisibilityPair:string):string;
+begin
+  Result:=
+    '  0'+#13#10+'LINE'+#13#10+
+    '100'+#13#10+'AcDbEntity'+#13#10+
+    '  8'+#13#10+'0'+#13#10+
+    VisibilityPair+
+    '100'+#13#10+'AcDbLine'+#13#10+
+    ' 10'+#13#10+IntToStr(X)+#13#10+
+    ' 20'+#13#10+'0'+#13#10+
+    ' 30'+#13#10+'0'+#13#10+
+    ' 11'+#13#10+IntToStr(X+1)+#13#10+
+    ' 21'+#13#10+'1'+#13#10+
+    ' 31'+#13#10+'0'+#13#10;
+end;
+
+function VisibilityDXF:string;
+begin
+  Result:=
+    '  0'+#13#10+'SECTION'+#13#10+
+    '  2'+#13#10+'HEADER'+#13#10+
+    '  0'+#13#10+'ENDSEC'+#13#10+
+    '  0'+#13#10+'SECTION'+#13#10+
+    '  2'+#13#10+'TABLES'+#13#10+
+    '  0'+#13#10+'ENDSEC'+#13#10+
+    '  0'+#13#10+'SECTION'+#13#10+
+    '  2'+#13#10+'BLOCKS'+#13#10+
+    '  0'+#13#10+'BLOCK'+#13#10+
+    '  2'+#13#10+'*U1'+#13#10+
+    ' 70'+#13#10+'1'+#13#10+
+    ' 10'+#13#10+'0'+#13#10+
+    ' 20'+#13#10+'0'+#13#10+
+    ' 30'+#13#10+'0'+#13#10+
+    LineEntity(100,' 60'+#13#10+'1'+#13#10)+
+    LineEntity(10,' 60'+#13#10+'0'+#13#10)+
+    LineEntity(20,'')+
+    '  0'+#13#10+'ENDBLK'+#13#10+
+    '  0'+#13#10+'ENDSEC'+#13#10+
+    '  0'+#13#10+'EOF'+#13#10;
+end;
+
+procedure LoadVisibilityDXF(var Drawing:TSimpleDrawing);
+var
+  DC:TDrawContext;
+  TempFile:string;
+  ZDC:TZDrawingContext;
+begin
+  TempFile:=WriteTempDXF(VisibilityDXF);
+  try
+    Drawing.init(nil);
+    DC:=Drawing.CreateDrawingRC;
+    ZDC.CreateRec(Drawing,Drawing.pObjRoot^,TLOLoad,DC);
+    AddFromDXF(TempFile,ZDC);
+  finally
+    SysUtils.DeleteFile(TempFile);
+  end;
+end;
+
+procedure TEntityVisibilityTest.DXFCode60PersistsOnEntityAndControlsCommonBehavior;
+var
+  Drawing:TSimpleDrawing;
+  BlockDef:PGDBObjBlockdef;
+  Entity:PGDBObjEntity;
+  SelectedCount:integer;
+  DC:TDrawContext;
+  Bounds:TBoundingBox;
+begin
+  LoadVisibilityDXF(Drawing);
+  try
+    BlockDef:=Drawing.BlockDefArray.getblockdef('*U1');
+    CheckTrue(BlockDef<>nil,'anonymous block must load');
+    CheckEquals(3,BlockDef^.ObjArray.Count,
+      'invisible entity must be retained with its persistent state');
+    Entity:=PGDBObjEntity(BlockDef^.ObjArray.GetData(0));
+    CheckTrue(ESInvisible in Entity^.State,
+      'group code 60=1 must set the base entity state');
+    CheckTrue(Entity^.PExtAttrib=nil,
+      'visibility must not allocate temporary DXF extension attributes');
+    CheckFalse(Entity^.IsActualy,'invisible entity must not be drawable');
+    SelectedCount:=0;
+    CheckFalse(Entity^.select(SelectedCount,nil),
+      'invisible entity must not be selectable');
+    DC:=Drawing.CreateDrawingRC;
+    Bounds:=BlockDef^.ObjArray.getonlyvisibleoutbound(DC);
+    CheckTrue(Bounds.RTF.x<100,
+      'invisible geometry must not affect visible bounds');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TEntityVisibilityTest.DXFCode60ZeroAndMissingRemainVisible;
+var
+  Drawing:TSimpleDrawing;
+  BlockDef:PGDBObjBlockdef;
+  Entity:PGDBObjEntity;
+begin
+  LoadVisibilityDXF(Drawing);
+  try
+    BlockDef:=Drawing.BlockDefArray.getblockdef('*U1');
+    Entity:=PGDBObjEntity(BlockDef^.ObjArray.GetData(1));
+    CheckFalse(ESInvisible in Entity^.State);
+    CheckTrue(Entity^.IsActualy,'group code 60=0 must remain visible');
+    Entity:=PGDBObjEntity(BlockDef^.ObjArray.GetData(2));
+    CheckFalse(ESInvisible in Entity^.State);
+    CheckTrue(Entity^.IsActualy,'missing group code 60 must remain visible');
+  finally
+    Drawing.done;
+  end;
+end;
+
+initialization
+  RegisterTest(TEntityVisibilityTest);
+
+end.


### PR DESCRIPTION
## Описание

Исправляет обработку группового кода DXF 60 для примитивов динамических блоков. Признак невидимости теперь хранится в постоянном состоянии базовой сущности `GDBObjEntity`, а не во временной структуре `TExtAttrib`.

## Что изменено

- добавлено состояние `ESInvisible` в `GDBObjEntity`;
- общий DXF-загрузчик устанавливает его для кода 60 со значением 1 и снимает для значения 0;
- общие пути отображения, выбора, поиска по точке и построения bounding box исключают невидимые сущности;
- состояние копируется вместе с общими визуальными свойствами сущности;
- невидимая сущность сохраняется в модели блока вместе с метаданными, но не отображается и не выбирается.

## Воспроизведение и проверка

Добавлен тест `uzctentityvisibility.pas` с анонимным блоком `*U1` и тремя LINE-примитивами:

1. код 60 = 1 — состояние `ESInvisible`, без `TExtAttrib`, не выбирается и не влияет на видимые границы;
2. код 60 = 0 — остаётся видимым;
3. код 60 отсутствует — остаётся видимым.

Локальный запуск тестового проекта невозможен в подготовленном окружении: отсутствуют Lazarus/FPC (`/home/box/lazarus/lazbuild: not found`). Компиляция и тесты проверяются GitHub Actions.

Fixes #788
