### PR TITLE
AcadTable: сохранять координаты и выравнивание после вставки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-23T20:21:54.651Z for PR creation at branch issue-1396-a96774c5ea59 for issue https://github.com/veb86/zcadvelecAI/issues/1396

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-23T20:21:54.651Z for PR creation at branch issue-1396-a96774c5ea59 for issue https://github.com/veb86/zcadvelecAI/issues/1396

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -405,14 +405,17 @@ begin
   dxfIntegerout(AOutStream, 171, 1);
   dxfIntegerout(AOutStream, 172, 0);
   dxfIntegerout(AOutStream, 173, BoolToDXF(IsVirtual));
-  if Alignment <> 0 then
-    dxfIntegerout(AOutStream, 170, Alignment);
   dxfIntegerout(AOutStream, 174, 0);
   dxfIntegerout(AOutStream, 175, ColSpan);
   dxfIntegerout(AOutStream, 176, RowSpan);
   dxfIntegerout(AOutStream, 91, 262144);
   dxfIntegerout(AOutStream, 178, 0);
   dxfDoubleout(AOutStream, 145, 0);
+  // AutoCAD хранит выравнивание после служебных данных ячейки и перед
+  // group 92. Ранняя запись group 170 игнорировалась при открытии файла,
+  // поэтому ячейка возвращалась к выравниванию стиля таблицы (issue #1396).
+  if Alignment <> 0 then
+    dxfIntegerout(AOutStream, 170, Alignment);
   dxfIntegerout(AOutStream, 92, 0);
   dxfStringWithoutEncodeOut(AOutStream, 301, 'CELL_VALUE');
   if CellText <> '' then

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -3616,7 +3616,10 @@ begin
     APart.LineTypeName := '';
   APart.LineTypeScale := vp.LineTypeScale;
 
-  APart.InsertPoint := FInsertPoint;
+  // FInsertPoint содержит исходную точку DXF/программного построения, а
+  // интерактивный перенос обновляет Local.P_insert через objmatrix.
+  // Сохраняем фактическое положение объекта после трансформаций (issue #1396).
+  APart.InsertPoint := Local.P_insert;
   APart.Direction.x := Cos(FRotate);
   APart.Direction.y := Sin(FRotate);
   APart.Direction.z := 0;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -179,6 +179,10 @@ type
     // issue #1363: выравнивание ячеек (код AutoCAD 1..9) переносится в
     // таблицу ACAD_TABLE; отсутствующие коды дают 0 (наследование от стиля).
     procedure BuildFromCellTextsAppliesCellAlignments;
+    // issue #1396: после интерактивного переноса программно созданной таблицы
+    // DXF должен содержать фактическую точку вставки и явное выравнивание
+    // ячеек в позиции group 170, совместимой с форматом AutoCAD.
+    procedure SavesTransformedInsertPointAndCellAlignmentToDXF;
     // issue #1368: явные типы строк (SetRowStyleTypes) задают индекс базового
     // стиля строки (0=Title, 1=Header, 2=Data); RowStyleTypeAt возвращает
     // заданное значение либо -1 вне диапазона, а перестроение таблицы
@@ -2640,6 +2644,71 @@ begin
       'Ячейка [1,1] с явным 0 должна наследовать выравнивание (0)');
     CheckEquals(0, Table^.CellAlignmentAt(1, 2),
       'Ячейка [1,2] вне массива должна наследовать выравнивание (0)');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.SavesTransformedInsertPointAndCellAlignmentToDXF;
+const
+  InsertX = 125.5;
+  InsertY = -42.25;
+  InsertZ = 7.0;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  ColWidths, RowHeights: TTableSizeArray;
+  Alignments: TTableAlignmentArray;
+  InsertPt: TzePoint3d;
+  MoveMatrix: TzeTypedMatrix4d;
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  DXFText: String;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 1);
+    Texts[0] := 'Aligned';
+    System.SetLength(ColWidths, 0);
+    System.SetLength(RowHeights, 0);
+    System.SetLength(Alignments, 1);
+    Alignments[0] := 9;
+    InsertPt := NulPoint;
+    CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(
+      1, 1, Texts, ColWidths, RowHeights, Alignments, InsertPt),
+      'Таблица для проверки round-trip должна быть построена');
+
+    // Повторяем финальный перенос из ConstructObjRoot при выборе точки.
+    MoveMatrix := CreateTranslationMatrix(InsertX, InsertY, InsertZ);
+    Table^.transform(MoveMatrix);
+
+    OutStream.init(8 * 1024);
+    SaveContext.InitRec;
+    SaveContext.Header.Version := AC1021;
+    SaveContext.Header.iVersion := 1021;
+    try
+      Table^.DXFOut(OutStream, Drawing, SaveContext);
+      DXFText := DxfStreamToText(OutStream);
+    finally
+      SaveContext.Done;
+      OutStream.done;
+    end;
+
+    CheckTrue(HasDxfSequence(DXFText, [
+      '100', 'AcDbBlockReference', '2', '*T1',
+      '10', '125.5', '20', '-42.25', '30', '7.0']),
+      'DXF должен сохранять фактическую точку вставки после переноса');
+    CheckTrue(HasDxfSequence(DXFText, [
+      '171', '1', '172', '0', '173', '0', '174', '0',
+      '175', '1', '176', '1', '91', '262144', '178', '0',
+      '145', '0', '170', '9', '92', '0']),
+      'Group 170 должен сохранять выравнивание в AutoCAD-совместимой позиции');
   finally
     Drawing.done;
   end;

--- a/test_issue1396_acadtable_save_contract.py
+++ b/test_issue1396_acadtable_save_contract.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Контракт сохранения координат и выравнивания AcadTable для issue 1396."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable"
+    / "uzeacadtable_model.pas"
+)
+WRITER = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable"
+    / "uzeacadtable_dxf_write.pas"
+)
+FPUNIT = ROOT / "cad_source" / "zengine" / "tests" / "uzctacadtable.pas"
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def extract_procedure(source: str, marker: str, next_marker: str) -> str:
+    start = source.index(marker)
+    end = source.index(next_marker, start + len(marker))
+    return source[start:end]
+
+
+def test_writer_uses_current_local_insert_point():
+    source = MODEL.read_text(encoding="utf-8")
+    body = compact(
+        extract_procedure(
+            source,
+            "procedure GDBObjAcadTable.FillDXFWritePartFromSelf",
+            "procedure GDBObjAcadTable.FillDXFWritePartFromContinuation",
+        )
+    )
+    assert "apart.insertpoint:=local.p_insert;" in body
+    assert "apart.insertpoint:=finsertpoint;" not in body
+
+
+def test_alignment_uses_autocad_cell_group_order():
+    source = WRITER.read_text(encoding="utf-8")
+    body = compact(
+        extract_procedure(source, "procedure WriteCell", "procedure WriteTableCells")
+    )
+    groups = [
+        "dxfintegerout(aoutstream,176,rowspan);",
+        "dxfintegerout(aoutstream,91,262144);",
+        "dxfintegerout(aoutstream,178,0);",
+        "dxfdoubleout(aoutstream,145,0);",
+        "dxfintegerout(aoutstream,170,alignment);",
+        "dxfintegerout(aoutstream,92,0);",
+    ]
+    positions = [body.index(group) for group in groups]
+    assert positions == sorted(positions)
+
+
+def test_fpunit_reproduces_save_round_trip():
+    source = FPUNIT.read_text(encoding="utf-8")
+    assert "procedure SavesTransformedInsertPointAndCellAlignmentToDXF;" in source
+    assert "Table^.transform(MoveMatrix);" in source
+    assert "'145', '0', '170', '9', '92', '0'" in source
+
+
+if __name__ == "__main__":
+    test_writer_uses_current_local_insert_point()
+    test_alignment_uses_autocad_cell_group_order()
+    test_fpunit_reproduces_save_round_trip()
+    print("issue 1396 AcadTable save contract checks passed")


### PR DESCRIPTION
## Итог

Исправляет veb86/zcadvelecAI#1396: таблица ACAD_TABLE, созданная из `uzvspreadsheet`, после сохранения и повторного открытия теперь сохраняет выбранную точку вставки и явное выравнивание текста в ячейках.

## Причина

- Команда сначала строит таблицу в `(0,0,0)`, затем интерактивно переносит её через матрицу объекта. Перенос обновлял `Local.P_insert`, но DXF writer сохранял исходное поле `FInsertPoint`, которое оставалось нулевым.
- Явное выравнивание ячейки записывалось в group `170` слишком рано — перед служебными группами `174..145`. Реальные ACAD_TABLE-файлы AutoCAD размещают `170` после `145` и перед `92`; при прежнем порядке AutoCAD игнорировал значение и после открытия применял выравнивание стиля таблицы.

## Решение

- Модельный DXF-путь сохраняет фактическую `Local.P_insert`, уже содержащую результат интерактивного переноса.
- Group `170` записывается в AutoCAD-совместимой позиции после `145` и перед `92`.
- Добавлен сквозной fpcunit-тест: программно создаёт таблицу с выравниванием BottomRight (`9`), переносит её в `(125.5, -42.25, 7)`, сохраняет и проверяет обе DXF-последовательности.
- Добавлен запускаемый контракт `test_issue1396_acadtable_save_contract.py`, фиксирующий обе части сериализации в окружениях без Lazarus/FPC.

## Как воспроизвести

1. Открыть редактор таблиц `uzvspreadsheet`.
2. Создать ячейку с явным выравниванием и вставить таблицу на чертёж в ненулевой точке.
3. Сохранить и повторно открыть чертёж.
4. До исправления таблица оказывалась в `(0,0,0)`, а текст наследовал выравнивание стиля; после исправления сохраняются выбранная точка и выравнивание ячейки.

## Проверка

```text
$ python3 test_issue1396_acadtable_save_contract.py
issue 1396 AcadTable save contract checks passed
$ python3 test_issue1375_acadtable_repeat_top_labels.py
issue 1375 AcadTable repeat-top label checks passed
$ git diff --check
# без ошибок
```

Полный Pascal test suite локально не запускался: в среде решателя отсутствуют `lazbuild` и `fpc`. Fpcunit-регрессия добавлена в существующий `uzctacadtable.pas` для выполнения в полном окружении разработчика.

Fixes veb86/zcadvelecAI#1396
