### PR TITLE
AcadTable: сохранять стандартное выравнивание ячеек

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-23T21:43:33.878Z for PR creation at branch issue-1399-5e354d01f1c2 for issue https://github.com/veb86/zcadvelecAI/issues/1399

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-23T21:43:33.878Z for PR creation at branch issue-1399-5e354d01f1c2 for issue https://github.com/veb86/zcadvelecAI/issues/1399

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_dimensions.pas
@@ -107,8 +107,8 @@ function WorksheetAlignmentToAcad(AHor: TsHorAlignment;
 
 { Собирает выравнивания ячеек листа в кодировке AutoCAD для передачи в
   GDBObjAcadTable.BuildFromCellTextsWithSizesAndAlignments (issue #1363).
-  Ячейкам без явно заданного выравнивания (оба значения "по умолчанию")
-  присваивается 0 — наследование выравнивания от стиля таблицы. }
+  Значения "по умолчанию" преобразуются в фактическое выравнивание листа
+  слева/сверху, а не в наследование от стиля таблицы (issue #1399). }
 function CollectCellAlignments(AWorksheet: TsWorksheet;
   ARowCount, AColCount: Integer): TTableAlignmentArray;
 
@@ -264,20 +264,19 @@ begin
   for RowIdx := 0 to ARowCount - 1 do
     for ColIdx := 0 to AColCount - 1 do
     begin
-      // По умолчанию выравнивание не задано — ячейка наследует его от стиля
-      // таблицы. Это сохраняет прежнее поведение для ячеек, которым в
-      // редакторе явно не назначали выравнивание.
-      Result[RowIdx * AColCount + ColIdx] := 0;
+      // Пустая ячейка не имеет записи fpspreadsheet и получает фактическое
+      // выравнивание листа по умолчанию: слева/сверху (код AutoCAD 1).
+      Result[RowIdx * AColCount + ColIdx] :=
+        WorksheetAlignmentToAcad(fpsTypes.haDefault, fpsTypes.vaDefault);
       Cell := AWorksheet.FindCell(Cardinal(RowIdx), Cardinal(ColIdx));
       if Cell = nil then
         Continue;
       Hor := AWorksheet.ReadHorAlignment(Cell);
       Vert := AWorksheet.ReadVertAlignment(Cell);
-      // Переносим выравнивание только если оно задано в ячейке листа явно;
-      // иначе оставляем 0 (наследование от стиля таблицы).
-      if (Hor <> fpsTypes.haDefault) or (Vert <> fpsTypes.vaDefault) then
-        Result[RowIdx * AColCount + ColIdx] :=
-          WorksheetAlignmentToAcad(Hor, Vert);
+      // Даже полностью стандартное выравнивание надо записывать явно.
+      // Иначе ACAD_TABLE применяет MiddleCenter из стиля таблицы.
+      Result[RowIdx * AColCount + ColIdx] :=
+        WorksheetAlignmentToAcad(Hor, Vert);
     end;
 end;
 

--- a/experiments/test_cell_alignment_transfer.pas
+++ b/experiments/test_cell_alignment_transfer.pas
@@ -18,7 +18,8 @@
     * the AutoCAD code decodes back to the same hor/vert groups (round-trip),
     * "default" alignments are treated as left/top, matching the editor
       combobox convention (issue #1352),
-    * cells without an explicit alignment collect to 0 (inherit from style).
+    * cells without an explicit alignment collect to 1 (TopLeft), rather than
+      inheriting MiddleCenter from the AutoCAD table style (issue #1399).
 
   Build & run:
     fpc -Mobjfpc experiments/test_cell_alignment_transfer.pas \
@@ -32,14 +33,14 @@ uses
   SysUtils;
 
 type
-  // Mirror of fpsTypes enums (same declaration order!)
+  // Копия порядка перечислений fpsTypes.
   TsHorAlignment = (haDefault, haLeft, haCenter, haRight);
   TsVertAlignment = (vaDefault, vaTop, vaCenter, vaBottom);
-  // Mirror of uzeacadtable_types
+  // Копия перечислений uzeacadtable_types.
   THorzAlign = (zhaLeft, zhaCenter, zhaRight);
   TVertAlign = (zvaTop, zvaMiddle, zvaBottom);
 
-{ ---- logic copied verbatim from uzvspreadsheet_dimensions.pas ---- }
+{ Логика из uzvspreadsheet_dimensions.pas. }
 
 function HorAlignToGroup(AHor: TsHorAlignment): Integer;
 begin
@@ -65,17 +66,14 @@ begin
   Result := VertAlignToGroup(AVert) * 3 + HorAlignToGroup(AHor) + 1;
 end;
 
-{ Collects the AutoCAD code for one cell the way CollectCellAlignments does:
-  0 (inherit) when both alignments are default, otherwise the encoded code. }
+{ Собирает код одной ячейки так же, как CollectCellAlignments. Значения
+  по умолчанию должны стать явным TopLeft, иначе стиль таблицы изменит их. }
 function CollectOne(AHor: TsHorAlignment; AVert: TsVertAlignment): Integer;
 begin
-  if (AHor <> haDefault) or (AVert <> vaDefault) then
-    Result := WorksheetAlignmentToAcad(AHor, AVert)
-  else
-    Result := 0;
+  Result := WorksheetAlignmentToAcad(AHor, AVert);
 end;
 
-{ ---- logic copied verbatim from uzeacadtable_styles.pas ---- }
+{ Логика из uzeacadtable_styles.pas. }
 
 function DXFAlignToHorz(Alignment: Integer): THorzAlign;
 var
@@ -103,7 +101,7 @@ begin
   end;
 end;
 
-{ ---- test harness ---- }
+{ Тестовый запуск. }
 
 var
   Failures: Integer = 0;
@@ -131,7 +129,7 @@ end;
 begin
   WriteLn('Testing cell alignment transfer (issue #1363)');
 
-  // The 9 combinations, AutoCAD codes 1..9 (1=TopLeft .. 9=BottomRight)
+  // Девять комбинаций AutoCAD: 1=TopLeft .. 9=BottomRight.
   ExpectCode(haLeft,   vaTop,    1, zhaLeft,   zvaTop,    'left-top');
   ExpectCode(haCenter, vaTop,    2, zhaCenter, zvaTop,    'center-top');
   ExpectCode(haRight,  vaTop,    3, zhaRight,  zvaTop,    'right-top');
@@ -142,7 +140,7 @@ begin
   ExpectCode(haCenter, vaBottom, 8, zhaCenter, zvaBottom, 'center-bottom');
   ExpectCode(haRight,  vaBottom, 9, zhaRight,  zvaBottom, 'right-bottom');
 
-  // Defaults are treated as left/top (matching editor combobox, issue #1352)
+  // Значения по умолчанию соответствуют left/top (issue #1352).
   Check(WorksheetAlignmentToAcad(haDefault, vaDefault) = 1,
     'haDefault/vaDefault -> AutoCAD code 1 (TopLeft)');
   Check(WorksheetAlignmentToAcad(haDefault, vaCenter) = 4,
@@ -150,9 +148,9 @@ begin
   Check(WorksheetAlignmentToAcad(haRight, vaDefault) = 3,
     'haRight/vaDefault -> AutoCAD code 3 (TopRight)');
 
-  // Collection emits 0 (inherit) only when BOTH alignments are default
-  Check(CollectOne(haDefault, vaDefault) = 0,
-    'fully default cell -> 0 (inherit from style)');
+  // Сбор сохраняет умолчание листа, а не наследует стиль таблицы (issue #1399).
+  Check(CollectOne(haDefault, vaDefault) = 1,
+    'fully default cell -> code 1 (TopLeft)');
   Check(CollectOne(haCenter, vaDefault) = 2,
     'explicit horizontal only -> code 2 (TopCenter)');
   Check(CollectOne(haDefault, vaBottom) = 7,

--- a/test_issue1399_acadtable_default_alignment.py
+++ b/test_issue1399_acadtable_default_alignment.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Контракт сохранения стандартного выравнивания AcadTable для issue 1399."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+DIMENSIONS = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvspreadsheet"
+    / "uzvspreadsheet_dimensions.pas"
+)
+WRITER = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_dxf_write.pas"
+)
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def extract(source: str, start_marker: str, end_marker: str) -> str:
+    start = source.index(start_marker)
+    end = source.index(end_marker, start + len(start_marker))
+    return source[start:end]
+
+
+def test_default_alignment_is_serialized_as_top_left():
+    source = DIMENSIONS.read_text(encoding="utf-8")
+    body = compact(
+        extract(
+            source,
+            "function CollectCellAlignments",
+            "\nend;\n\nend.",
+        )
+    )
+    default_call = (
+        "worksheetalignmenttoacad("
+        "fpstypes.hadefault,fpstypes.vadefault)"
+    )
+    assert default_call in body
+    assert "result[rowidx*acolcount+colidx]:=0;" not in body
+
+
+def test_writer_emits_every_nonzero_alignment():
+    source = WRITER.read_text(encoding="utf-8")
+    body = compact(
+        extract(source, "procedure WriteCell", "procedure WriteTableCells")
+    )
+    assert "ifalignment<>0then" in body
+    assert "dxfintegerout(aoutstream,170,alignment);" in body
+
+
+if __name__ == "__main__":
+    test_default_alignment_is_serialized_as_top_left()
+    test_writer_emits_every_nonzero_alignment()
+    print("issue 1399 AcadTable default alignment checks passed")


### PR DESCRIPTION
## Итог

Исправляет veb86/zcadvelecAI#1399: таблица ACAD_TABLE, созданная из `uzvspreadsheet`, после сохранения и повторного открытия сохраняет видимое в редакторе стандартное выравнивание ячеек — по левому краю вверху.

## Причина

`fpspreadsheet` возвращает для стандартного выравнивания значения `haDefault` / `vaDefault`. При создании ACAD_TABLE `CollectCellAlignments` преобразовывал такую пару в `0`. Однако в данных ячейки ACAD_TABLE код `0` означает не «слева вверху», а наследование от TABLESTYLE. В приложенном к issue DXF поэтому group `170` отсутствует у всех ячеек, и AutoCAD применяет стиль таблицы `MiddleCenter` (`5`).

## Решение

- Стандартное выравнивание листа теперь преобразуется в явный код AutoCAD `1` (`TopLeft`).
- Пустые ячейки без записи `fpspreadsheet` также получают явный `TopLeft`, а не наследование от TABLESTYLE.
- Явно выбранные остальные восемь вариантов продолжают преобразовываться в коды AutoCAD `2..9`.

## Как воспроизвести

1. В редакторе таблиц оставить ячейки со стандартным видимым выравниванием по левому краю вверху.
2. Создать ACAD_TABLE и сохранить чертёж в DXF 2007.
3. Повторно открыть файл.
4. До исправления ячейки наследуют `MiddleCenter` из TABLESTYLE; после исправления сохраняется `TopLeft`.

## Проверка

```text
python3 test_issue1399_acadtable_default_alignment.py
# issue 1399 AcadTable default alignment checks passed

python3 test_issue1396_acadtable_save_contract.py
# issue 1396 AcadTable save contract checks passed

python3 test_issue1375_acadtable_repeat_top_labels.py
# issue 1375 AcadTable repeat-top label checks passed

git diff --check
# без ошибок
```

Обновлён существующий Pascal-эксперимент `experiments/test_cell_alignment_transfer.pas`: стандартная пара теперь обязана собираться в `1` (`TopLeft`), а не `0` (наследование). Полный Pascal suite локально не запускался: в среде решателя отсутствуют `fpc` и `lazbuild`.

Fixes veb86/zcadvelecAI#1399
