### PR TITLE
AcadTable: использовать текущий слой при создании

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-24T08:46:38.503Z for PR creation at branch issue-1404-4211519e0739 for issue https://github.com/veb86/zcadvelecAI/issues/1404

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-24T08:46:38.503Z for PR creation at branch issue-1404-4211519e0739 for issue https://github.com/veb86/zcadvelecAI/issues/1404

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
@@ -228,6 +228,7 @@ begin
   // Создаём сущность и помещаем её в конструктивный root чертежа
   pt := AllocAndInitAcadTable(
     PGDBObjGenericWithSubordinated(@drawings.CurrentDWG^.ConstructObjRoot));
+  zcSetEntPropFromCurrentDrawingProp(PGDBObjEntity(pt));
   drawings.CurrentDWG^.ConstructObjRoot.ObjArray.AddPEntity(pt^);
 
   // Строим таблицу из текстов ячеек с переносом размеров столбцов/строк

--- a/test_issue1404_acadtable_current_layer.py
+++ b/test_issue1404_acadtable_current_layer.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Regression contract for issue #1404: new AcadTable uses current layer."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+COMMAND = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "uzvspreadsheet"
+    / "uzvspreadsheet_cmdcreateacadtable.pas"
+)
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def test_created_acadtable_receives_current_drawing_properties():
+    source = compact(COMMAND.read_text(encoding="utf-8"))
+    allocation = source.index("pt:=allocandinitacadtable(")
+    insertion = source.index(
+        "drawings.currentdwg^.constructobjroot.objarray.addpentity(pt^);",
+        allocation,
+    )
+    setup = source[allocation:insertion]
+
+    assert "zcsetentpropfromcurrentdrawingprop(pgdbobjentity(pt));" in setup
+
+
+if __name__ == "__main__":
+    test_created_acadtable_receives_current_drawing_properties()
+    print("issue 1404 AcadTable current-layer checks passed")


### PR DESCRIPTION
## Что изменено

- при создании `AcadTable` из редактора таблиц к сущности применяются текущие свойства чертежа до добавления в конструктивную область;
- поэтому новая таблица получает выбранный пользователем слой вместо `DefaultErrorLayer`;
- добавлен регрессионный контракт, фиксирующий порядок инициализации.

## Как воспроизвести исходную проблему

1. Выбрать в ZCAD слой, отличный от системного.
2. Открыть редактор таблиц и создать `AcadTable`.
3. Вставить таблицу в чертёж.
4. До исправления у таблицы оставался `DefaultErrorLayer`; после исправления используется текущий выбранный слой.

## Проверка

- `python3 test_issue1404_acadtable_current_layer.py`
- `python3 test_issue1402_acadtable_edit_contract.py`
- `python3 -m py_compile test_issue1404_acadtable_current_layer.py`
- `git diff --check upstream/master...HEAD`

Полная Pascal-сборка локально не запускалась: в среде отсутствуют FPC/Lazarus.

Fixes veb86/zcadvelecAI#1404
