### PR TITLE
Исправить типы строк AcadTable при редактировании

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-24T10:37:50.371Z for PR creation at branch issue-1406-9c68f70256d7 for issue https://github.com/veb86/zcadvelecAI/issues/1406

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-24T10:37:50.371Z for PR creation at branch issue-1406-9c68f70256d7 for issue https://github.com/veb86/zcadvelecAI/issues/1406

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -439,9 +439,10 @@ type
     // редактора электронных таблиц после построения геометрии, чтобы строки,
     // целиком состоящие из ячеек Title/Header, получили соответствующий стиль.
     procedure SetRowStyleTypes(const ATypes: array of Integer); virtual;
-    // Возвращает явно заданный индекс базового стиля для строки ARow
-    // (0=Title, 1=Header, 2=Data) либо -1, если тип строки не задан или
-    // строка вне диапазона (issue #1368).
+    // Возвращает эффективный индекс базового стиля для строки ARow
+    // (0=Title, 1=Header, 2=Data). При отсутствии явных типов использует
+    // ту же принудительную/позиционную логику, что и рендеринг таблицы;
+    // для строки вне диапазона возвращает -1 (issue #1368/#1406).
     function RowStyleTypeAt(ARow: Integer): Integer;
     // Возвращает текст ячейки главной части таблицы. Для некорректных
     // индексов возвращает пустую строку (issue #1402).
@@ -850,10 +851,14 @@ end;
 
 function GDBObjAcadTable.RowStyleTypeAt(ARow: Integer): Integer;
 begin
-  if (ARow >= 0) and (ARow <= High(FRowStyleTypes)) then
+  if (ARow < 0) or (ARow >= FRowCount) then
+    Result := -1
+  else if ARow <= High(FRowStyleTypes) then
     Result := FRowStyleTypes[ARow]
+  else if FForceDataStyleAllRows then
+    Result := 2
   else
-    Result := -1;
+    Result := Min(ARow, 2);
 end;
 
 function GDBObjAcadTable.CellTextAt(ARow, ACol: Integer): String;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -187,10 +187,13 @@ type
     procedure SavesTransformedInsertPointAndCellAlignmentToDXF;
     // issue #1368: явные типы строк (SetRowStyleTypes) задают индекс базового
     // стиля строки (0=Title, 1=Header, 2=Data); RowStyleTypeAt возвращает
-    // заданное значение либо -1 вне диапазона, а перестроение таблицы
-    // сбрасывает ранее заданные типы строк.
+    // эффективный тип с учётом fallback рендера либо -1 вне диапазона, а
+    // перестроение таблицы сбрасывает ранее заданные типы строк.
     procedure SetRowStyleTypesAssignsRowStyles;
     procedure RebuildResetsRowStyleTypes;
+    // issue #1406: ZCAD model-path DXF не содержит AcDbTableContent, поэтому
+    // редактор должен получать Title/Header/Data из legacy-позиционной логики.
+    procedure LoadsLegacyRowStylesForSpreadsheetEditing;
     // issue #1373: таблица с несколькими строками-заголовками (tablebugheader.dxf:
     // строка 0 = Title, строки 1 и 2 = Header, остальные = Data) должна
     // загружаться с правильными типами строк, прочитанными из современного
@@ -2831,9 +2834,9 @@ begin
       ColWidths, RowHeights, Alignments, InsertPt),
       'BuildFromCellTextsWithSizesAndAlignments должен построить таблицу');
 
-    // До назначения типов строк все строки не имеют явного типа (-1).
-    CheckEquals(-1, Table^.RowStyleTypeAt(0),
-      'До SetRowStyleTypes строка 0 не должна иметь явного типа');
+    // Программно созданная таблица до назначения типов состоит из Data.
+    CheckEquals(2, Table^.RowStyleTypeAt(0),
+      'До SetRowStyleTypes программная строка должна иметь тип Data');
 
     // Назначаем: строка 0 = Title (0), строка 1 = Header (1), строка 2 = Data (2).
     Table^.SetRowStyleTypes([0, 1, 2]);
@@ -2890,10 +2893,36 @@ begin
       ColWidths, RowHeights, Alignments, InsertPt),
       'Повторное построение таблицы должно завершиться успешно');
 
-    CheckEquals(-1, Table^.RowStyleTypeAt(0),
-      'После перестроения строка 0 не должна иметь явного типа');
-    CheckEquals(-1, Table^.RowStyleTypeAt(1),
-      'После перестроения строка 1 не должна иметь явного типа');
+    CheckEquals(2, Table^.RowStyleTypeAt(0),
+      'После перестроения строка 0 должна вернуться к типу Data');
+    CheckEquals(2, Table^.RowStyleTypeAt(1),
+      'После перестроения строка 1 должна вернуться к типу Data');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.LoadsLegacyRowStylesForSpreadsheetEditing;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../experiments/issue1399/zcadtablevyrav.txt'),
+    Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(4, AcadTable^.RowCount, 'Ожидались четыре строки');
+
+    CheckEquals(0, AcadTable^.RowStyleTypeAt(0),
+      'Первая legacy-строка должна открываться как Title');
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(1),
+      'Вторая legacy-строка должна открываться как Header');
+    CheckEquals(2, AcadTable^.RowStyleTypeAt(2),
+      'Третья legacy-строка должна открываться как Data');
+    CheckEquals(2, AcadTable^.RowStyleTypeAt(3),
+      'Четвёртая legacy-строка должна открываться как Data');
   finally
     Drawing.done;
   end;

--- a/test_issue1406_acadtable_legacy_row_styles.py
+++ b/test_issue1406_acadtable_legacy_row_styles.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Regression contract for legacy AcadTable row styles in issue 1406."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MODEL = ROOT / "cad_source/zcad/velec/acadtable/uzeacadtable_model.pas"
+EDIT = (
+    ROOT
+    / "cad_source/zcad/velec/uzvspreadsheet/"
+    "uzvspreadsheet_cmdeditacadtable.pas"
+)
+TESTS = ROOT / "cad_source/zengine/tests/uzctacadtable.pas"
+FIXTURE = ROOT / "experiments/issue1399/zcadtablevyrav.txt"
+
+
+def compact(text: str) -> str:
+    return "".join(text.split()).lower()
+
+
+def pairs(path: Path) -> list[tuple[str, str]]:
+    lines = path.read_text(encoding="utf-8").splitlines()
+    return [
+        (lines[index].strip(), lines[index + 1].strip())
+        for index in range(0, len(lines) - 1, 2)
+    ]
+
+
+def test_zcad_fixture_has_no_modern_row_style_object():
+    values = pairs(FIXTURE)
+    assert ("0", "ACAD_TABLE") in values
+    assert ("100", "AcDbTableContent") not in values
+    assert ("1", "TABLEROW_BEGIN") not in values
+
+
+def test_accessor_returns_the_effective_legacy_row_style():
+    model = compact(MODEL.read_text(encoding="utf-8"))
+    assert "elseiffforcedatastyleallrowsthenresult:=2" in model
+    assert "elseresult:=min(arow,2)" in model
+
+
+def test_editor_and_fpunit_regression_use_effective_row_styles():
+    edit = compact(EDIT.read_text(encoding="utf-8"))
+    tests = TESTS.read_text(encoding="utf-8")
+    assert "atable^.rowstyletypeat(row)" in edit
+    assert "LoadsLegacyRowStylesForSpreadsheetEditing" in tests
+    assert "zcadtablevyrav.txt" in tests
+
+
+if __name__ == "__main__":
+    test_zcad_fixture_has_no_modern_row_style_object()
+    test_accessor_returns_the_effective_legacy_row_style()
+    test_editor_and_fpunit_regression_use_effective_row_styles()
+    print("issue 1406 legacy AcadTable row-style checks passed")


### PR DESCRIPTION
## Что исправлено

При открытии созданной ZCAD таблицы через `editacadtable` строки больше не теряют типы Title/Header/Data.

Причина была в различии DXF: AutoCAD сохраняет явные типы строк в объекте `AcDbTableContent`, а модельный путь ZCAD его не создаёт. Рендеринг ZCAD уже использовал совместимую позиционную схему (первая строка Title, вторая Header, остальные Data), но `RowStyleTypeAt` возвращал `-1`, поэтому редактор не получал ни одного типа строки.

`RowStyleTypeAt` теперь возвращает эффективный тип строки: явный тип, принудительный Data для программно созданных таблиц либо legacy-позиционный тип. Это синхронизирует импорт в редактор с тем, как таблица отображается.

## Воспроизведение

1. Открыть `experiments/issue1399/zcadtablevyrav.txt`.
2. Выделить ACAD_TABLE и выполнить `editacadtable`.
3. До исправления цвета типов Title/Header/Data отсутствовали; после исправления строки распознаются как Title, Header, Data, Data.

## Проверки

- Новый FPUnit-тест `LoadsLegacyRowStylesForSpreadsheetEditing` загружает исходный ZCAD fixture и проверяет типы всех четырёх строк.
- Новый source-level контракт `test_issue1406_acadtable_legacy_row_styles.py` подтверждает отсутствие `AcDbTableContent` в fixture и наличие fallback-пути.
- Пройдены контракты issue 1406, 1402 и оба контракта многострочных заголовков issue 1373.
- `git diff --check` пройден.

Полный FPUnit запуск локально недоступен: в окружении нет Lazarus/FPC. `pytest` также не установлен; скрипты контрактов запускались напрямую через Python.

Fixes veb86/zcadvelecAI#1406
