### PR TITLE
AcadTable: восстановить заливку типов строк в редакторе (#1402)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-27T06:13:32.144Z for PR creation at branch issue-1402-3e57f3f42cd8 for issue https://github.com/veb86/zcadvelecAI/issues/1402

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-27T06:13:32.144Z for PR creation at branch issue-1402-3e57f3f42cd8 for issue https://github.com/veb86/zcadvelecAI/issues/1402

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -439,9 +439,10 @@ type
     // редактора электронных таблиц после построения геометрии, чтобы строки,
     // целиком состоящие из ячеек Title/Header, получили соответствующий стиль.
     procedure SetRowStyleTypes(const ATypes: array of Integer); virtual;
-    // Возвращает явно заданный индекс базового стиля для строки ARow
-    // (0=Title, 1=Header, 2=Data) либо -1, если тип строки не задан или
-    // строка вне диапазона (issue #1368).
+    // Возвращает эффективный индекс базового стиля для строки ARow
+    // (0=Title, 1=Header, 2=Data). При отсутствии явных типов использует
+    // ту же принудительную/позиционную логику, что и рендеринг таблицы;
+    // для строки вне диапазона возвращает -1 (issue #1368/#1402).
     function RowStyleTypeAt(ARow: Integer): Integer;
     // Возвращает текст ячейки главной части таблицы. Для некорректных
     // индексов возвращает пустую строку (issue #1402).
@@ -850,10 +851,14 @@ end;
 
 function GDBObjAcadTable.RowStyleTypeAt(ARow: Integer): Integer;
 begin
-  if (ARow >= 0) and (ARow <= High(FRowStyleTypes)) then
+  if (ARow < 0) or (ARow >= FRowCount) then
+    Result := -1
+  else if ARow <= High(FRowStyleTypes) then
     Result := FRowStyleTypes[ARow]
+  else if FForceDataStyleAllRows then
+    Result := 2
   else
-    Result := -1;
+    Result := Min(ARow, 2);
 end;
 
 function GDBObjAcadTable.CellTextAt(ARow, ACol: Integer): String;

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -187,10 +187,13 @@ type
     procedure SavesTransformedInsertPointAndCellAlignmentToDXF;
     // issue #1368: явные типы строк (SetRowStyleTypes) задают индекс базового
     // стиля строки (0=Title, 1=Header, 2=Data); RowStyleTypeAt возвращает
-    // заданное значение либо -1 вне диапазона, а перестроение таблицы
-    // сбрасывает ранее заданные типы строк.
+    // эффективный тип с учётом fallback рендера либо -1 вне диапазона, а
+    // перестроение таблицы сбрасывает ранее заданные типы строк.
     procedure SetRowStyleTypesAssignsRowStyles;
     procedure RebuildResetsRowStyleTypes;
+    // issue #1402: ZCAD model-path DXF не содержит AcDbTableContent, поэтому
+    // редактор должен получать Title/Header/Data из legacy-позиционной логики.
+    procedure LoadsLegacyRowStylesForSpreadsheetEditing;
     // issue #1373: таблица с несколькими строками-заголовками (tablebugheader.dxf:
     // строка 0 = Title, строки 1 и 2 = Header, остальные = Data) должна
     // загружаться с правильными типами строк, прочитанными из современного
@@ -2831,9 +2834,9 @@ begin
       ColWidths, RowHeights, Alignments, InsertPt),
       'BuildFromCellTextsWithSizesAndAlignments должен построить таблицу');
 
-    // До назначения типов строк все строки не имеют явного типа (-1).
-    CheckEquals(-1, Table^.RowStyleTypeAt(0),
-      'До SetRowStyleTypes строка 0 не должна иметь явного типа');
+    // Программно созданная таблица до назначения типов состоит из Data.
+    CheckEquals(2, Table^.RowStyleTypeAt(0),
+      'До SetRowStyleTypes программная строка должна иметь тип Data');
 
     // Назначаем: строка 0 = Title (0), строка 1 = Header (1), строка 2 = Data (2).
     Table^.SetRowStyleTypes([0, 1, 2]);
@@ -2890,10 +2893,36 @@ begin
       ColWidths, RowHeights, Alignments, InsertPt),
       'Повторное построение таблицы должно завершиться успешно');
 
-    CheckEquals(-1, Table^.RowStyleTypeAt(0),
-      'После перестроения строка 0 не должна иметь явного типа');
-    CheckEquals(-1, Table^.RowStyleTypeAt(1),
-      'После перестроения строка 1 не должна иметь явного типа');
+    CheckEquals(2, Table^.RowStyleTypeAt(0),
+      'После перестроения строка 0 должна вернуться к типу Data');
+    CheckEquals(2, Table^.RowStyleTypeAt(1),
+      'После перестроения строка 1 должна вернуться к типу Data');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.LoadsLegacyRowStylesForSpreadsheetEditing;
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../experiments/issue1399/zcadtablevyrav.txt'),
+    Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+    CheckEquals(4, AcadTable^.RowCount, 'Ожидались четыре строки');
+
+    CheckEquals(0, AcadTable^.RowStyleTypeAt(0),
+      'Первая legacy-строка должна открываться как Title');
+    CheckEquals(1, AcadTable^.RowStyleTypeAt(1),
+      'Вторая legacy-строка должна открываться как Header');
+    CheckEquals(2, AcadTable^.RowStyleTypeAt(2),
+      'Третья legacy-строка должна открываться как Data');
+    CheckEquals(2, AcadTable^.RowStyleTypeAt(3),
+      'Четвёртая legacy-строка должна открываться как Data');
   finally
     Drawing.done;
   end;

--- a/test_issue1402_acadtable_edit_contract.py
+++ b/test_issue1402_acadtable_edit_contract.py
@@ -42,6 +42,16 @@ require(open_cmd, "GDBAcadTableID", "AcadTable type validation")
 require(open_cmd, "CellTextAt(", "text import")
 require(open_cmd, "CellAlignmentAt(", "alignment import")
 require(open_cmd, "RowStyleTypeAt(", "cell type import")
+require(
+    model,
+    "else if FForceDataStyleAllRows then",
+    "effective legacy row type for editor shading",
+)
+require(
+    model,
+    "Result := Min(ARow, 2);",
+    "Title/Header/Data positional fallback for editor shading",
+)
 require(open_cmd, "RowHeightAt(", "row height import")
 require(open_cmd, "ColWidthAt(", "column width import")
 require(open_cmd, "Entity = PGDBObjEntity(FEditingAcadTable)", "live target check")


### PR DESCRIPTION
## Итог

Исправляет veb86/zcadvelecAI#1402: при открытии legacy/model-path `ACAD_TABLE` в `uzvspreadsheet` снова отображается цветовая заливка ролей строк Title, Header и Data.

## Причина

Команда `editacadtable` задаёт заливку по результату `RowStyleTypeAt`. После последнего отката этот метод возвращал только явно сохранённые типы из `AcDbTableContent`. У legacy-таблиц такого массива нет, поэтому каждая строка возвращала `-1` и импортировалась как Data.

## Исправление

- `RowStyleTypeAt` снова возвращает эффективный тип строки, совпадающий с логикой рендера:
  - явный тип, если он прочитан из DXF;
  - Data для программно созданных таблиц;
  - позиционный fallback Title/Header/Data для legacy-таблиц.
- Восстановлен FPUnit-тест на реальном legacy DXF, проверяющий роли всех четырёх строк.
- Статический контракт issue #1402 теперь проверяет наличие fallback, от которого зависит заливка редактора.
- Явные типы современных таблиц, включая несколько Header-строк, сохраняют приоритет.

## Как воспроизвести

1. Открыть `experiments/issue1399/zcadtablevyrav.txt`.
2. Выделить единственную `ACAD_TABLE`.
3. Выполнить `editacadtable`.
4. До исправления все строки выглядели как Data; после исправления первая строка имеет заливку Title, вторая — Header, остальные — Data.

## Проверки

Проходят:

- `python3 test_issue1402_acadtable_edit_contract.py`
- `python3 test_issue1406_acadtable_legacy_row_styles.py`
- `python3 test_issue1373_acadtable_multiheader_contract.py`
- `python3 test_issue1373_acadtable_split_multiheader_contract.py`
- `python3 test_issue1399_acadtable_default_alignment.py`
- `python3 test_issue1342_acadtable_compile_contract.py`
- `python3 test_issue1396_acadtable_save_contract.py`
- `git diff --check upstream/master...HEAD`

Полный набор корневых Python-контрактов также проверен. Два старых exact-string теста (`test_issue1368_cell_style.py`, `test_issue1387_acadtable_geometry_types.py`) уже не проходят на `upstream/master` и не связаны с этой правкой.

Нативный FPUnit и скриншот Lazarus UI локально недоступны: в среде нет FPC/Lazarus и готового GUI-исполняемого файла. Регрессионный FPUnit-тест добавлен в существующий suite для выполнения в среде сборки.

Fixes veb86/zcadvelecAI#1402
