### PR TITLE
AcadTable: сохранять стиль отдельно для каждой ячейки

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-27T12:20:55.982Z for PR creation at branch issue-1409-96cc9afa5361 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-27T12:20:55.982Z for PR creation at branch issue-1409-96cc9afa5361 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -229,6 +229,21 @@ begin
     Result := APart.Cells[ARow][ACol].CellAlignment;
 end;
 
+function CellStyleTypeAt(
+  const APart: TAcadTableDXFWritePart;
+  ARow, ACol: Integer): Integer;
+begin
+  Result := -1;
+  if (ARow >= 0) and (ARow <= High(APart.Cells)) and
+     (ACol >= 0) and (ACol <= High(APart.Cells[ARow])) then
+    Result := APart.Cells[ARow][ACol].StyleType;
+  if (Result < 0) or (Result > 2) then
+    if ARow < 2 then
+      Result := ARow
+    else
+      Result := 2;
+end;
+
 function FindMergeForCell(
   const APart: TAcadTableDXFWritePart;
   ARow, ACol: Integer;
@@ -395,15 +410,16 @@ var
   CellText: String;
   ColSpan, RowSpan: Integer;
   IsVirtual: Boolean;
-  Alignment: Integer;
+  Alignment, StyleType: Integer;
 begin
   CellText := CellTextAt(APart, ARow, ACol);
   GetCellSpanAndVirtualFlag(APart, ARow, ACol,
     ColSpan, RowSpan, IsVirtual);
   Alignment := CellAlignmentAt(APart, ARow, ACol);
+  StyleType := CellStyleTypeAt(APart, ARow, ACol);
 
   dxfIntegerout(AOutStream, 171, 1);
-  dxfIntegerout(AOutStream, 172, 0);
+  dxfIntegerout(AOutStream, 172, StyleType);
   dxfIntegerout(AOutStream, 173, BoolToDXF(IsVirtual));
   dxfIntegerout(AOutStream, 174, 0);
   dxfIntegerout(AOutStream, 175, ColSpan);

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_edit.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_edit.pas
@@ -64,6 +64,7 @@ begin
   ACell.ColSpan := 1;
   ACell.RowSpan := 1;
   InitCellStyle(ACell.Style);
+  ACell.StyleType := -1;
 end;
 
 procedure SetCellText(

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -439,11 +439,13 @@ type
     // редактора электронных таблиц после построения геометрии, чтобы строки,
     // целиком состоящие из ячеек Title/Header, получили соответствующий стиль.
     procedure SetRowStyleTypes(const ATypes: array of Integer); virtual;
+    procedure SetCellStyleTypes(const ATypes: array of Integer); virtual;
     // Возвращает эффективный индекс базового стиля для строки ARow
     // (0=Title, 1=Header, 2=Data). При отсутствии явных типов использует
     // ту же принудительную/позиционную логику, что и рендеринг таблицы;
     // для строки вне диапазона возвращает -1 (issue #1368/#1402).
     function RowStyleTypeAt(ARow: Integer): Integer;
+    function CellStyleTypeAt(ARow, ACol: Integer): Integer;
     // Возвращает текст ячейки главной части таблицы. Для некорректных
     // индексов возвращает пустую строку (issue #1402).
     function CellTextAt(ARow, ACol: Integer): String;
@@ -765,6 +767,7 @@ begin
       FCells[RowIdx][ColIdx].ColSpan := 1;
       FCells[RowIdx][ColIdx].RowSpan := 1;
       InitCellStyle(FCells[RowIdx][ColIdx].Style);
+      FCells[RowIdx][ColIdx].StyleType := -1;
     end;
 
   // Программно созданная таблица не содержит объединений ячеек
@@ -849,6 +852,24 @@ begin
   FRowStyleTypesExplicit := True;
 end;
 
+procedure GDBObjAcadTable.SetCellStyleTypes(const ATypes: array of Integer);
+var
+  RowIdx, ColIdx, CellIdx, StyleType: Integer;
+begin
+  for RowIdx := 0 to FRowCount - 1 do
+    for ColIdx := 0 to FColCount - 1 do
+    begin
+      CellIdx := RowIdx * FColCount + ColIdx;
+      StyleType := -1;
+      if CellIdx <= High(ATypes) then
+        if (ATypes[CellIdx] >= 0) and (ATypes[CellIdx] <= 2) then
+          StyleType := ATypes[CellIdx];
+      FCells[RowIdx][ColIdx].StyleType := StyleType;
+    end;
+  InvalidateRawDXFEntity;
+  FGeometryBuilt := False;
+end;
+
 function GDBObjAcadTable.RowStyleTypeAt(ARow: Integer): Integer;
 begin
   if (ARow < 0) or (ARow >= FRowCount) then
@@ -859,6 +880,19 @@ begin
     Result := 2
   else
     Result := Min(ARow, 2);
+end;
+
+function GDBObjAcadTable.CellStyleTypeAt(ARow, ACol: Integer): Integer;
+begin
+  if (ARow < 0) or (ARow >= FRowCount) or
+     (ACol < 0) or (ACol >= FColCount) then
+    Result := -1
+  else if (ARow <= High(FCells)) and
+          (ACol <= High(FCells[ARow])) and
+          (FCells[ARow][ACol].StyleType >= 0) then
+    Result := FCells[ARow][ACol].StyleType
+  else
+    Result := RowStyleTypeAt(ARow);
 end;
 
 function GDBObjAcadTable.CellTextAt(ARow, ACol: Integer): String;
@@ -1126,6 +1160,7 @@ begin
         FCells[RowIdx][ColIdx].ColSpan := 1;
         FCells[RowIdx][ColIdx].RowSpan := 1;
         InitCellStyle(FCells[RowIdx][ColIdx].Style);
+        FCells[RowIdx][ColIdx].StyleType := -1;
         CellIndex := RowIdx * FColCount + ColIdx;
         if CellIndex < Length(DXFData.CellAlignments) then
           FCells[RowIdx][ColIdx].CellAlignment :=
@@ -1424,7 +1459,10 @@ begin
           //    используется позиционный стиль от логической базы (issue #1311);
           // 2) FForceDataStyleAllRows (issue #1357) — все строки как данные;
           // 3) позиционный выбор стиля по номеру строки.
-          if (ARowBaseIndex = 0) and (RowStyleTypeAt(RowIdx) >= 0) then
+          if (ARowBaseIndex = 0) and
+             (FCells[RowIdx][ColIdx].StyleType >= 0) then
+            StyleRowIndex := FCells[RowIdx][ColIdx].StyleType
+          else if RowStyleTypeAt(RowIdx) >= 0 then
             StyleRowIndex := RowStyleTypeAt(RowIdx)
           else if FForceDataStyleAllRows then
             StyleRowIndex := 2
@@ -1910,7 +1948,10 @@ begin
       Exit;
   end;
 
-  if RowStyleTypeAt(ARow) >= 0 then
+  if (ARow <= High(FCells)) and (ACol <= High(FCells[ARow])) and
+     (FCells[ARow][ACol].StyleType >= 0) then
+    StyleRowIndex := FCells[ARow][ACol].StyleType
+  else if RowStyleTypeAt(ARow) >= 0 then
     StyleRowIndex := RowStyleTypeAt(ARow)
   else if FForceDataStyleAllRows then
     StyleRowIndex := 2

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_types.pas
@@ -129,6 +129,9 @@ type
     BlockName: String;
     // Переопределение стиля
     Style: TCellStyle;
+    // Индекс базового стиля этой ячейки: 0=Title, 1=Header, 2=Data.
+    // -1 означает наследование типа от строки.
+    StyleType: Integer;
     // Выравнивание ячейки из DXF (group 170 в данных ячейки AcDbTable).
     // Значения AutoCAD:
     //   1=TopLeft, 2=TopCenter, 3=TopRight,

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcellstyle.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcellstyle.pas
@@ -28,12 +28,11 @@
       Header — #E7E6E6 (серый);
       Data   — #FFFFFF (белый).
 
-    При экспорте в GDBObjAcadTable тип строки определяется по цвету её ячеек:
-    строка становится Title/Header только тогда, когда ВСЕ её ячейки окрашены
-    в соответствующий цвет (правило единогласия). Логика классификации цвета
-    и определения типа строки вынесена в отдельные функции, чтобы её можно
-    было покрыть автоматическими тестами. Менять высоту текста и прочее
-    форматирование команды не должны — изменяется только цвет заливки. }
+    При экспорте в GDBObjAcadTable цвет классифицируется отдельно для каждой
+    ячейки и сохраняется как её собственный тип Title/Header/Data (issue
+    #1409). Совместимая классификация строк сохранена для старых потребителей.
+    Менять высоту текста и прочее форматирование команды не должны —
+    изменяется только цвет заливки. }
 unit uzvspreadsheet_cmdcellstyle;
 
 {$INCLUDE zengineconfig.inc}
@@ -90,6 +89,11 @@ function DetectRowStyleKind(aWorksheet: TsWorksheet;
   строк 0..ARowCount-1 по цвету заливки ячеек. Результат предназначен для
   передачи в GDBObjAcadTable.SetRowStyleTypes при экспорте. }
 function CollectRowStyleTypes(aWorksheet: TsWorksheet;
+  ARowCount, AColCount: Integer): TIntegerDynArray;
+
+{ Собирает тип каждой ячейки в порядке row-major. В отличие от
+  CollectRowStyleTypes смешанные стили одной строки не схлопываются в Data. }
+function CollectCellStyleTypes(aWorksheet: TsWorksheet;
   ARowCount, AColCount: Integer): TIntegerDynArray;
 
 { Применяет тип ячейки (цвет заливки) ко всем ячейкам выделенного диапазона }
@@ -174,6 +178,26 @@ begin
   for row := 0 to ARowCount - 1 do
     Result[row] := CellStyleKindToRowStyleIndex(
       DetectRowStyleKind(aWorksheet, row, AColCount));
+end;
+
+function CollectCellStyleTypes(aWorksheet: TsWorksheet;
+  ARowCount, AColCount: Integer): TIntegerDynArray;
+var
+  row, col: Integer;
+  cell: PCell;
+begin
+  SetLength(Result, 0);
+  if (aWorksheet = nil) or (ARowCount <= 0) or (AColCount <= 0) then
+    Exit;
+
+  SetLength(Result, ARowCount * AColCount);
+  for row := 0 to ARowCount - 1 do
+    for col := 0 to AColCount - 1 do
+    begin
+      cell := aWorksheet.FindCell(Cardinal(row), Cardinal(col));
+      Result[row * AColCount + col] := CellStyleKindToRowStyleIndex(
+        ClassifyCellBackgroundColor(aWorksheet.ReadBackgroundColor(cell)));
+    end;
 end;
 
 { Возвращает выделенный диапазон в координатах листа (без фиксированных

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdcreateacadtable.pas
@@ -22,10 +22,9 @@
 
     Команда анализирует заполненную часть активного листа книги, строит по её
     содержимому AutoCAD-совместимую таблицу ACAD_TABLE со стилем "Standard" и
-    помещает её на чертёж. Тип строки (Title/Header/Data) определяется по цвету
-    заливки ячеек редактора: строка получает тип Title/Header только если ВСЕ
-    её ячейки окрашены соответствующим цветом, иначе остаётся строкой данных
-    (issue #1368, цвета задаются командами модуля uzvspreadsheet_cmdcellstyle). }
+    помещает её на чертёж. Тип Title/Header/Data определяется по цвету заливки
+    отдельно для каждой ячейки (issue #1409; цвета задаются командами модуля
+    uzvspreadsheet_cmdcellstyle). }
 unit uzvspreadsheet_cmdcreateacadtable;
 
 {$INCLUDE zengineconfig.inc}
@@ -175,7 +174,7 @@ var
   texts: TTableTextArray;
   colWidths, rowHeights: TTableSizeArray;
   cellAlignments: TTableAlignmentArray;
-  rowStyleTypes: TIntegerDynArray;
+  rowStyleTypes, cellStyleTypes: TIntegerDynArray;
   rowCount, colCount: Integer;
   insPt: TzePoint3d;
   dc: TDrawContext;
@@ -244,13 +243,13 @@ begin
     Exit;
   end;
 
-  // Определяем тип каждой строки по цвету заливки ячеек редактора и переносим
-  // его в таблицу: строка становится Title/Header только если ВСЕ её ячейки
-  // окрашены соответствующим цветом (issue #1368). Строки без единогласия
-  // остаются строками данных. SetRowStyleTypes имеет приоритет над общим
-  // режимом «все строки — данные».
+  // Строковый тип сохраняется для совместимости с логикой повторяемых меток,
+  // а тип каждой ячейки переносится отдельно и имеет приоритет при рендере и
+  // DXF-записи (issue #1409).
   rowStyleTypes := CollectRowStyleTypes(worksheet, rowCount, colCount);
   pt^.SetRowStyleTypes(rowStyleTypes);
+  cellStyleTypes := CollectCellStyleTypes(worksheet, rowCount, colCount);
+  pt^.SetCellStyleTypes(cellStyleTypes);
 
   // Гарантируем наличие и применяем стиль "Standard" (issue #1357).
   // Если применение не удалось, остаётся стиль по умолчанию из

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdsaveacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdsaveacadtable.pas
@@ -68,7 +68,7 @@ var
   Texts: TTableTextArray;
   ColWidths, RowHeights: TTableSizeArray;
   Alignments: TTableAlignmentArray;
-  RowTypes: TIntegerDynArray;
+  RowTypes, CellTypes: TIntegerDynArray;
   DC: TDrawContext;
 begin
   Result := False;
@@ -88,11 +88,13 @@ begin
   RowHeights := CollectRowHeights(AWorksheet, RowCount);
   Alignments := CollectCellAlignments(AWorksheet, RowCount, ColCount);
   RowTypes := CollectRowStyleTypes(AWorksheet, RowCount, ColCount);
+  CellTypes := CollectCellStyleTypes(AWorksheet, RowCount, ColCount);
 
   if not ATable^.UpdateFromCellTextsWithSizesAndAlignments(
     RowCount, ColCount, Texts, ColWidths, RowHeights, Alignments) then
     Exit;
   ATable^.SetRowStyleTypes(RowTypes);
+  ATable^.SetCellStyleTypes(CellTypes);
   DC := drawings.GetCurrentDWG^.CreateDrawingRC;
   ATable^.FormatEntity(drawings.GetCurrentDWG^, DC);
   drawings.GetCurrentROOT^.ObjArray.ObjTree.CorrectNodeBoundingBox(ATable^);

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -190,6 +190,9 @@ type
     // эффективный тип с учётом fallback рендера либо -1 вне диапазона, а
     // перестроение таблицы сбрасывает ранее заданные типы строк.
     procedure SetRowStyleTypesAssignsRowStyles;
+    // issue #1409: mixed Title/Header/Data styles in one row must remain
+    // independent instead of being collapsed to one row style.
+    procedure SetCellStyleTypesKeepsMixedRowStyles;
     procedure RebuildResetsRowStyleTypes;
     // issue #1402: ZCAD model-path DXF не содержит AcDbTableContent, поэтому
     // редактор должен получать Title/Header/Data из legacy-позиционной логики.
@@ -2851,6 +2854,48 @@ begin
       'Строка вне диапазона должна вернуть -1');
     CheckEquals(-1, Table^.RowStyleTypeAt(-1),
       'Отрицательный индекс строки должен вернуть -1');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.SetCellStyleTypesKeepsMixedRowStyles;
+var
+  Drawing: TSimpleDrawing;
+  Table: PGDBObjAcadTable;
+  Texts: TTableTextArray;
+  ColWidths, RowHeights: TTableSizeArray;
+  Alignments: TTableAlignmentArray;
+  InsertPt: TzePoint3d;
+begin
+  Drawing.init(nil);
+  try
+    Table := AllocAndInitAcadTable(
+      PGDBObjGenericWithSubordinated(Drawing.pObjRoot));
+    Table^.bp.ListPos.Owner := Drawing.pObjRoot;
+    Drawing.pObjRoot^.ObjArray.AddPEntity(Table^);
+
+    System.SetLength(Texts, 3);
+    Texts[0] := 'Title';
+    Texts[1] := 'Header';
+    Texts[2] := 'Data';
+    System.SetLength(ColWidths, 0);
+    System.SetLength(RowHeights, 0);
+    System.SetLength(Alignments, 0);
+    InsertPt := NulPoint;
+    CheckTrue(Table^.BuildFromCellTextsWithSizesAndAlignments(
+      1, 3, Texts, ColWidths, RowHeights, Alignments, InsertPt),
+      'Таблица со смешанными стилями должна быть построена');
+
+    Table^.SetCellStyleTypes([0, 1, 2]);
+    CheckEquals(0, Table^.CellStyleTypeAt(0, 0),
+      'Первая ячейка должна сохранить Title');
+    CheckEquals(1, Table^.CellStyleTypeAt(0, 1),
+      'Вторая ячейка той же строки должна сохранить Header');
+    CheckEquals(2, Table^.CellStyleTypeAt(0, 2),
+      'Третья ячейка той же строки должна сохранить Data');
+    CheckEquals(-1, Table^.CellStyleTypeAt(0, 3),
+      'Ячейка вне диапазона должна вернуть -1');
   finally
     Drawing.done;
   end;

--- a/test_issue1409_acadtable_cell_styles.py
+++ b/test_issue1409_acadtable_cell_styles.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Regression contract for per-cell AcadTable styles (issue #1409)."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+SHEET = ROOT / "cad_source" / "zcad" / "velec" / "uzvspreadsheet"
+ACADTABLE = ROOT / "cad_source" / "zcad" / "velec" / "acadtable"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_spreadsheet_collects_every_cell_style():
+    source = read(SHEET / "uzvspreadsheet_cmdcellstyle.pas")
+    assert "function CollectCellStyleTypes(" in source
+    assert "Result[row * AColCount + col]" in source
+    assert "ClassifyCellBackgroundColor" in source
+
+
+def test_create_and_save_pass_cell_styles_to_model():
+    for name in (
+        "uzvspreadsheet_cmdcreateacadtable.pas",
+        "uzvspreadsheet_cmdsaveacadtable.pas",
+    ):
+        source = read(SHEET / name)
+        assert "CollectCellStyleTypes(" in source, name
+        assert "SetCellStyleTypes(" in source, name
+
+
+def test_model_keeps_cell_styles_independent():
+    source = read(ACADTABLE / "uzeacadtable_model.pas")
+    assert "procedure SetCellStyleTypes(const ATypes: array of Integer);" in source
+    assert "function CellStyleTypeAt(ARow, ACol: Integer): Integer;" in source
+    assert "FCells[RowIdx][ColIdx].StyleType" in source
+
+
+def test_dxf_writes_style_for_each_cell():
+    source = read(ACADTABLE / "uzeacadtable_dxf_write.pas")
+    assert "function CellStyleTypeAt(" in source
+    assert "StyleType := CellStyleTypeAt(APart, ARow, ACol);" in source
+    assert "dxfIntegerout(AOutStream, 172, StyleType);" in source
+
+
+if __name__ == "__main__":
+    test_spreadsheet_collects_every_cell_style()
+    test_create_and_save_pass_cell_styles_to_model()
+    test_model_keeps_cell_styles_independent()
+    test_dxf_writes_style_for_each_cell()
+    print("ALL TESTS PASSED")


### PR DESCRIPTION
## Итог

Исправляет #1409: стили Title/Header/Data из редактора электронных таблиц теперь сохраняются отдельно для каждой ячейки ACAD_TABLE, включая смешанные стили в одной строке.

## Причина

Реализация issue #1368 собирала цвета ячеек через `CollectRowStyleTypes`: Title/Header назначался строке только при одинаковом цвете всех её ячеек, а смешанная строка целиком превращалась в Data. Поэтому индивидуальный тип терялся ещё до DXF-записи.

## Исправление

- добавлен сбор типов в плоский массив `row * colCount + col` без схлопывания строки;
- пути создания и сохранения таблицы передают типы через `SetCellStyleTypes`;
- модель хранит тип Title/Header/Data в каждой `TTableCell` и использует его при рендере;
- DXF writer записывает group 172 для каждой ячейки из её собственного типа;
- строковые типы и legacy-позиционная логика сохранены как fallback для существующих DXF и повторяемых верхних меток.

## Как воспроизвести

1. В одной строке редактора назначить соседним ячейкам стили Title, Header и Data.
2. Создать или сохранить ACAD_TABLE в DXF.
3. До исправления смешанная строка классифицировалась целиком как Data; после исправления ячейки сохраняют значения 0/1/2 независимо.

## Тесты

- новый FPUnit-тест `SetCellStyleTypesKeepsMixedRowStyles` проверяет Title/Header/Data в одной строке;
- новый контракт `python3 test_issue1409_acadtable_cell_styles.py` проверяет сбор, передачу, хранение и DXF-запись типов;
- проходят контракты issues #1368, #1396, #1402 и #1342;
- проходят все корневые Python-контракты, кроме старого exact-string `test_issue1387_acadtable_geometry_types.py`, который также не проходит на `upstream/master` и не связан с этой правкой;
- `git diff --check upstream/master...HEAD` проходит.

Нативный FPUnit локально не запускался: в окружении отсутствует FPC/Lazarus. Тест добавлен в существующий suite для выполнения в среде сборки.

Fixes #1409
