### PR TITLE
AcadTable: восстанавливать стиль каждой ячейки в редакторе

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-28T20:31:05.905Z for PR creation at branch issue-1409-cc54ab95ab10 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-28T20:31:05.905Z for PR creation at branch issue-1409-cc54ab95ab10 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdeditacadtable.pas
+++ b/cad_source/zcad/velec/uzvspreadsheet/uzvspreadsheet_cmdeditacadtable.pas
@@ -89,10 +89,9 @@ begin
   Result := PGDBObjAcadTable(Selected^.objaddr);
 end;
 
-procedure WriteRowType(AWorksheet: TsWorksheet; ARow, AColCount,
+procedure WriteCellType(AWorksheet: TsWorksheet; ARow, ACol,
   AStyleType: Integer);
 var
-  Col: Integer;
   StyleKind: TZVCellStyleKind;
 begin
   case AStyleType of
@@ -100,9 +99,8 @@ begin
     1: StyleKind := zvskHeader;
     else StyleKind := zvskData;
   end;
-  for Col := 0 to AColCount - 1 do
-    AWorksheet.WriteBackgroundColor(ARow, Col,
-      CellStyleKindColor(StyleKind));
+  AWorksheet.WriteBackgroundColor(ARow, ACol,
+    CellStyleKindColor(StyleKind));
 end;
 
 function LoadAcadTableToWorksheet(ATable: PGDBObjAcadTable;
@@ -124,11 +122,11 @@ begin
   begin
     SetWorksheetRowHeightMM(AWorksheet, Row,
       AcadToWorksheetSize(ATable^.RowHeightAt(Row)));
-    WriteRowType(AWorksheet, Row, ATable^.ColCount,
-      ATable^.RowStyleTypeAt(Row));
     for Col := 0 to ATable^.ColCount - 1 do
     begin
       AWorksheet.WriteText(Row, Col, ATable^.CellTextAt(Row, Col));
+      WriteCellType(AWorksheet, Row, Col,
+        ATable^.CellStyleTypeAt(Row, Col));
       Alignment := ATable^.CellAlignmentAt(Row, Col);
       AcadAlignmentToWorksheet(Alignment, Hor, Vert);
       AWorksheet.WriteHorAlignment(Row, Col, Hor);

--- a/test_issue1402_acadtable_edit_contract.py
+++ b/test_issue1402_acadtable_edit_contract.py
@@ -41,7 +41,7 @@ require(open_cmd, "SelObjArray.Count <> 1", "single-selection validation")
 require(open_cmd, "GDBAcadTableID", "AcadTable type validation")
 require(open_cmd, "CellTextAt(", "text import")
 require(open_cmd, "CellAlignmentAt(", "alignment import")
-require(open_cmd, "RowStyleTypeAt(", "cell type import")
+require(open_cmd, "CellStyleTypeAt(", "cell type import")
 require(
     model,
     "else if FForceDataStyleAllRows then",

--- a/test_issue1406_acadtable_legacy_row_styles.py
+++ b/test_issue1406_acadtable_legacy_row_styles.py
@@ -43,7 +43,9 @@ def test_accessor_returns_the_effective_legacy_row_style():
 def test_editor_and_fpunit_regression_use_effective_row_styles():
     edit = compact(EDIT.read_text(encoding="utf-8"))
     tests = TESTS.read_text(encoding="utf-8")
-    assert "atable^.rowstyletypeat(row)" in edit
+    # CellStyleTypeAt falls back to RowStyleTypeAt when a legacy table has no
+    # explicit per-cell style, preserving the old editor shading behavior.
+    assert "atable^.cellstyletypeat(row,col)" in edit
     assert "LoadsLegacyRowStylesForSpreadsheetEditing" in tests
     assert "zcadtablevyrav.txt" in tests
 

--- a/test_issue1409_acadtable_cell_styles.py
+++ b/test_issue1409_acadtable_cell_styles.py
@@ -30,6 +30,13 @@ def test_create_and_save_pass_cell_styles_to_model():
         assert "SetCellStyleTypes(" in source, name
 
 
+def test_edit_restores_every_cell_style_from_model():
+    source = read(SHEET / "uzvspreadsheet_cmdeditacadtable.pas")
+    assert "ATable^.CellStyleTypeAt(Row, Col)" in source
+    assert "CellStyleKindColor(" in source
+    assert "WriteRowType(" not in source
+
+
 def test_model_keeps_cell_styles_independent():
     source = read(ACADTABLE / "uzeacadtable_model.pas")
     assert "procedure SetCellStyleTypes(const ATypes: array of Integer);" in source
@@ -47,6 +54,7 @@ def test_dxf_writes_style_for_each_cell():
 if __name__ == "__main__":
     test_spreadsheet_collects_every_cell_style()
     test_create_and_save_pass_cell_styles_to_model()
+    test_edit_restores_every_cell_style_from_model()
     test_model_keeps_cell_styles_independent()
     test_dxf_writes_style_for_each_cell()
     print("ALL TESTS PASSED")


### PR DESCRIPTION
## Итог

Исправляет оставшуюся ошибку #1409: при повторном открытии ACAD_TABLE в `uzvspreadsheet` стиль Title/Header/Data теперь восстанавливается для каждой ячейки, поэтому таблица из приложенного примера отображается как Title / Header / Header / Data / Data.

## Причина

DXF уже содержал правильные group 172 для всех 15 ячеек (`0×3, 1×6, 2×6`), но команда `editacadtable` читала только `RowStyleTypeAt` и закрашивала всю строку одним стилем. Это теряло второй Header при загрузке таблицы в редактор.

## Исправление

- редактор читает `CellStyleTypeAt(Row, Col)` и применяет стиль отдельно к каждой ячейке;
- legacy-таблицы без per-cell данных продолжают работать через существующий fallback `CellStyleTypeAt -> RowStyleTypeAt`;
- контракты редактирования и legacy-совместимости обновлены под per-cell API;
- добавлен регрессионный контракт, запрещающий возврат к строковой закраске.

## Как воспроизвести

1. Открыть приложенный к issue DXF с 5 строками.
2. Загрузить ACAD_TABLE в `uzvspreadsheet`.
3. До исправления стили восстанавливались как Title / Header / Data / Data / Data.
4. После исправления: Title / Header / Header / Data / Data.

## Тесты

- `python3 test_issue1409_acadtable_cell_styles.py`
- `python3 test_issue1402_acadtable_edit_contract.py`
- `python3 test_issue1406_acadtable_legacy_row_styles.py`
- `python3 test_issue1368_cell_style.py`
- все 27 применимых корневых Python-контрактов проходят;
- `test_issue1387_acadtable_geometry_types.py` по-прежнему падает тем же exact-string assertion на чистом `upstream/master` и не связан с этой правкой;
- `git diff --check upstream/master..HEAD` проходит.

Нативный FPUnit локально не запускался: в окружении отсутствуют FPC/Lazarus.

Fixes #1409
