### PR TITLE
AcadTable: сохранять CELLSTYLEMAP и ссылки на стиль таблицы, чтобы AutoCAD читал стили ячеек (#1409)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-29T07:50:10.517Z for PR creation at branch issue-1409-61ddc90c2ece for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-29T07:50:10.517Z for PR creation at branch issue-1409-61ddc90c2ece for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -56,6 +56,11 @@ type
     Cells: TTableCellArray;
     Merges: TMergeRangeArray;
     TableStyleHandle: String;
+    // Имя стиля таблицы. Хэндл TABLESTYLE перенумеровывается при сохранении,
+    // поэтому TableStyleHandle (хэндл из загруженного файла) для ссылки 342
+    // непригоден — хэндл резолвится по имени через
+    // AIODXFContext.TableStyleNameHandleMap (issue #1409).
+    TableStyleName: String;
     // Имя анонимного блока таблицы (group code 2 / связанный BLOCK_RECORD
     // через group code 343). Для модельного пути записи (issue #1381) сюда
     // подставляется имя сгенерированного перед сохранением блока с геометрией
@@ -135,6 +140,7 @@ type
     XRecordHandle: TDWGHandle;
     ContentHandle: TDWGHandle;
     TableStyleHandle: String;
+    TableStyleName: String;
     RowCount: Integer;
     ColCount: Integer;
     RowHeights: TAcadTableDoubleArray;
@@ -373,6 +379,7 @@ begin
     XRecordHandle := NextAnonymousHandle(AIODXFContext);
     ContentHandle := NextAnonymousHandle(AIODXFContext);
     TableStyleHandle := APart.TableStyleHandle;
+    TableStyleName := APart.TableStyleName;
     RowCount := APart.RowCount;
     ColCount := APart.ColCount;
 
@@ -406,6 +413,27 @@ begin
   Result := True;
 end;
 
+// Возвращает актуальный хэндл объекта TABLESTYLE для ссылок 342/340.
+// Приоритет — карта «имя стиля -> новый хэндл», заполняемая при записи
+// секции OBJECTS: хэндлы стилей перенумеровываются при сохранении, поэтому
+// сохранённый в модели TableStyleHandle почти всегда устарел (issue #1409).
+function ResolveTableStyleHandle(
+  var AIODXFContext: TIODXFSaveContext;
+  const ATableStyleName, AFallbackHandle: String): String;
+var
+  MappedValue: String;
+begin
+  if ATableStyleName <> '' then
+    if AIODXFContext.TableStyleNameHandleMap.MyGetValue(
+         ATableStyleName, MappedValue) then
+      if MappedValue <> '' then
+      begin
+        Result := MappedValue;
+        Exit;
+      end;
+  Result := AFallbackHandle;
+end;
+
 procedure WriteEntityPrefix(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
@@ -429,6 +457,11 @@ begin
       IntToHex(DictionaryHandle, 0));
     dxfStringWithoutEncodeOut(AOutStream, 102, '}');
   end;
+  // Владелец сущности — BLOCK_RECORD пространства модели. Без группы 330
+  // AutoCAD не принимает round-trip таблицу (issue #1409).
+  if AIODXFContext.AcadTableOwnerHandle > 0 then
+    dxfStringWithoutEncodeOut(AOutStream, 330,
+      IntToHex(AIODXFContext.AcadTableOwnerHandle, 0));
   dxfStringWithoutEncodeOut(AOutStream, 100, dxfName_AcDbEntity);
   if APart.LayerName <> '' then
     dxfStringout(AOutStream, 8, APart.LayerName,
@@ -471,11 +504,13 @@ procedure WriteTableHeader(
   var AIODXFContext: TIODXFSaveContext;
   const APart: TAcadTableDXFWritePart);
 var
-  BlockRecordHandle: String;
+  BlockRecordHandle, TableStyleHandle: String;
 begin
   dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbTable');
-  if APart.TableStyleHandle <> '' then
-    dxfStringWithoutEncodeOut(AOutStream, 342, APart.TableStyleHandle);
+  TableStyleHandle := ResolveTableStyleHandle(AIODXFContext,
+    APart.TableStyleName, APart.TableStyleHandle);
+  if TableStyleHandle <> '' then
+    dxfStringWithoutEncodeOut(AOutStream, 342, TableStyleHandle);
   // Ссылка на BLOCK_RECORD анонимного блока таблицы (group code 343). AutoCAD
   // отрисовывает proxy/roundtrip AcDbTable по связанному блоку, поэтому без
   // 343 части разорванной таблицы открываются пустыми/битыми (issue #1381).
@@ -955,6 +990,42 @@ begin
   dxfStringWithoutEncodeOut(AOutStream, 309, 'DATAMAP_END');
 end;
 
+// Контрольная сумма содержимого ячейки, которую AutoCAD хранит в
+// ACAD_ROUNDTRIP_2008_CELL_CHECKSUM: сумма кодов символов текста ячейки.
+// Проверено на файле, пересохранённом AutoCAD: для односимвольных ячеек
+// значение равно коду символа Unicode ('1'=49, 'ф'=1092 и т.д.).
+function CellTextChecksum(const AText: String): Int64;
+var
+  U: UnicodeString;
+  I: Integer;
+begin
+  Result := 0;
+  U := UTF8Decode(AText);
+  for I := 1 to Length(U) do
+    Result := Result + Ord(U[I]);
+end;
+
+// DATAMAP ячейки с контрольной суммой её содержимого. AutoCAD сверяет эту
+// величину при открытии round-trip таблицы (issue #1409).
+procedure WriteCellChecksumDataMap(
+  var AOutStream: TZctnrVectorBytes; const AText: String);
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 301, 'CUSTOMDATA');
+  dxfStringWithoutEncodeOut(AOutStream, 1, 'DATAMAP_BEGIN');
+  dxfIntegerout(AOutStream, 90, 1);
+  dxfStringWithoutEncodeOut(AOutStream, 300,
+    'ACAD_ROUNDTRIP_2008_CELL_CHECKSUM');
+  dxfStringWithoutEncodeOut(AOutStream, 301, 'DATAMAP_VALUE');
+  dxfIntegerout(AOutStream, 93, 2);
+  dxfIntegerout(AOutStream, 90, 2);
+  dxfDoubleout(AOutStream, 140, CellTextChecksum(AText));
+  dxfIntegerout(AOutStream, 94, 0);
+  dxfStringWithoutEncodeOut(AOutStream, 300, '');
+  dxfStringWithoutEncodeOut(AOutStream, 302, '');
+  dxfStringWithoutEncodeOut(AOutStream, 304, 'ACVALUE_END');
+  dxfStringWithoutEncodeOut(AOutStream, 309, 'DATAMAP_END');
+end;
+
 // Нейтральный TABLEFORMAT (170 = 0: переопределений свойств нет).
 // AType: 1 — ячейка, 2 — строка, 3 — столбец, 4 — таблица.
 procedure WriteEmptyTableFormat(
@@ -977,7 +1048,7 @@ begin
   dxfIntegerout(AOutStream, 90, 0);
   dxfStringWithoutEncodeOut(AOutStream, 300, '');
   dxfIntegerout(AOutStream, 91, 0);
-  WriteEmptyDataMap(AOutStream);
+  WriteCellChecksumDataMap(AOutStream, AText);
   dxfIntegerout(AOutStream, 92, 0);
   if AText <> '' then
   begin
@@ -1026,6 +1097,7 @@ procedure WriteTableContentObject(
   const ARecord: TAcadTableContentRecord);
 var
   RowIdx, ColIdx: Integer;
+  TableStyleHandle: String;
 begin
   dxfStringWithoutEncodeOut(AOutStream, 0, 'TABLECONTENT');
   dxfStringWithoutEncodeOut(AOutStream, 5,
@@ -1091,15 +1163,17 @@ begin
   dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbFormattedTableData');
   dxfStringWithoutEncodeOut(AOutStream, 300, 'TABLEFORMAT');
   WriteEmptyTableFormat(AOutStream, 4);
-  dxfIntegerout(AOutStream, 90, 1);
-  dxfIntegerout(AOutStream, 91, 0);
-  dxfIntegerout(AOutStream, 92, 0);
-  dxfIntegerout(AOutStream, 93, 0);
-  dxfIntegerout(AOutStream, 94, 2);
+  // Переопределений форматирования на уровне таблицы нет (AutoCAD пишет
+  // здесь одиночное 90|0; наш прежний набор 90..94 ломал разбор).
+  dxfIntegerout(AOutStream, 90, 0);
 
   dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbTableContent');
-  if ARecord.TableStyleHandle <> '' then
-    dxfStringWithoutEncodeOut(AOutStream, 340, ARecord.TableStyleHandle)
+  // Ссылка на TABLESTYLE, в расширенном словаре которого лежит CELLSTYLEMAP
+  // с определениями _TITLE/_HEADER/_DATA (issue #1409).
+  TableStyleHandle := ResolveTableStyleHandle(AIODXFContext,
+    ARecord.TableStyleName, ARecord.TableStyleHandle);
+  if TableStyleHandle <> '' then
+    dxfStringWithoutEncodeOut(AOutStream, 340, TableStyleHandle)
   else
     dxfStringWithoutEncodeOut(AOutStream, 340, '0');
 end;

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_model.pas
@@ -3777,6 +3777,9 @@ begin
   CopyCellArray(FCells, APart.Cells);
   CopyMergeArray(FMerges, APart.Merges);
   APart.TableStyleHandle := FTableStyleHandle;
+  // Имя стиля нужно писателю DXF, чтобы получить актуальный (перенумерованный)
+  // хэндл TABLESTYLE для ссылок 342/340 (issue #1409).
+  APart.TableStyleName := FTableStyle.Name;
   APart.BlockName := FMainPartBlockName;
   APart.TableFlags := FTableFlags;
   APart.BreakEnabled := GetBreakEnabled;
@@ -3803,6 +3806,8 @@ begin
   CopyCellArray(ASource.Cells, APart.Cells);
   CopyMergeArray(ASource.Merges, APart.Merges);
   APart.TableStyleHandle := ASource.TableStyleHandle;
+  if ASource.TableStyle.Name <> '' then
+    APart.TableStyleName := ASource.TableStyle.Name;
   APart.BlockName := ASource.BlockName;
   APart.TableFlags := ASource.TableFlags;
   APart.BreakEnabled := ASource.BreakEnabled;

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -171,14 +171,170 @@ begin
   WriteCellBordersToStream(outstream);
 end;
 
+{ Пара «код/значение» в поток (сокращение для читаемости кода ниже) }
+procedure dxfPairOut(var outstream: TZctnrVectorBytes;
+                     const Code: Integer; const Value: string); inline;
+begin
+  outstream.TXTAddStringEOL(dxfGroupCode(Code));
+  outstream.TXTAddStringEOL(Value);
+end;
+
+{ Записывает один блок CELLSTYLE карты стилей ячеек (AcDbCellStyleMap).
+
+  Именно этот объект даёт смысл идентификаторам стиля ячейки (90) внутри
+  TABLECELL_BEGIN объекта TABLECONTENT: без CELLSTYLEMAP AutoCAD отбрасывает
+  индивидуальные стили ячеек и применяет встроенное правило «строка 1 — Title,
+  строка 2 — Header, остальные — Data» (issue #1409).
+
+  AStyleId  — 1=_TITLE, 2=_HEADER, 3=_DATA
+  AStyleName— '_TITLE' / '_HEADER' / '_DATA'
+  AStyleType— 1 для заголовочных строк (title/header), 2 для данных
+  AFlags92  — 32768 для _TITLE (признак строки заголовка таблицы), иначе 0 }
+procedure WriteCellStyleMapEntryToStream(
+  var outstream: TZctnrVectorBytes;
+  const CS: TGDBDXFTableCellStyle;
+  const AStyleId, AStyleType, AFlags92: Integer;
+  const AStyleName: string);
+var
+  GridBit: Integer;
+begin
+  dxfPairOut(outstream, 300, 'CELLSTYLE');
+  dxfPairOut(outstream, 1, 'TABLEFORMAT_BEGIN');
+  dxfPairOut(outstream, 90, '5');
+  dxfPairOut(outstream, 170, '1');
+  dxfPairOut(outstream, 91, '0');
+  dxfPairOut(outstream, 92, IntToStr(AFlags92));
+  dxfPairOut(outstream, 62, '257');
+  dxfPairOut(outstream, 93, '1');
+
+  { Формат содержимого ячейки: выравнивание (94) и высота текста (144) }
+  dxfPairOut(outstream, 300, 'CONTENTFORMAT');
+  dxfPairOut(outstream, 1, 'CONTENTFORMAT_BEGIN');
+  dxfPairOut(outstream, 90, '0');
+  dxfPairOut(outstream, 91, '0');
+  dxfPairOut(outstream, 92, '512');
+  dxfPairOut(outstream, 93, '0');
+  dxfPairOut(outstream, 300, '');
+  dxfPairOut(outstream, 40, '0.0');
+  dxfPairOut(outstream, 140, '1.0');
+  dxfPairOut(outstream, 94, IntToStr(CS.Alignment));
+  dxfPairOut(outstream, 62, IntToStr(CS.TextColor));
+  { 340 = хэндл текстового стиля. 0 означает «стиль по умолчанию таблицы»;
+    имя текстового стиля уже записано в самом TABLESTYLE (группа 7). }
+  dxfPairOut(outstream, 340, '0');
+  dxfPairOut(outstream, 144, DXFFloatStr(CS.TextHeight));
+  dxfPairOut(outstream, 309, 'CONTENTFORMAT_END');
+
+  dxfPairOut(outstream, 171, '1');
+  dxfPairOut(outstream, 301, 'MARGIN');
+  dxfPairOut(outstream, 1, 'CELLMARGIN_BEGIN');
+  dxfPairOut(outstream, 40, '1.5');
+  dxfPairOut(outstream, 40, '1.5');
+  dxfPairOut(outstream, 40, '1.5');
+  dxfPairOut(outstream, 40, '1.5');
+  dxfPairOut(outstream, 40, '0.18');
+  dxfPairOut(outstream, 40, '0.18');
+  dxfPairOut(outstream, 309, 'CELLMARGIN_END');
+
+  { Шесть описаний линий сетки ячейки (горизонтальные/вертикальные/рамка) }
+  dxfPairOut(outstream, 94, '6');
+  GridBit := 1;
+  while GridBit <= 32 do
+  begin
+    dxfPairOut(outstream, 95, IntToStr(GridBit));
+    dxfPairOut(outstream, 302, 'GRIDFORMAT');
+    dxfPairOut(outstream, 1, 'GRIDFORMAT_BEGIN');
+    dxfPairOut(outstream, 90, '0');
+    dxfPairOut(outstream, 91, '1');
+    dxfPairOut(outstream, 62, '0');
+    dxfPairOut(outstream, 92, '-2');
+    dxfPairOut(outstream, 340, '0');
+    dxfPairOut(outstream, 93, '0');
+    dxfPairOut(outstream, 40, '0.045');
+    dxfPairOut(outstream, 309, 'GRIDFORMAT_END');
+    GridBit := GridBit * 2;
+  end;
+  dxfPairOut(outstream, 309, 'TABLEFORMAT_END');
+
+  dxfPairOut(outstream, 1, 'CELLSTYLE_BEGIN');
+  dxfPairOut(outstream, 90, IntToStr(AStyleId));
+  dxfPairOut(outstream, 91, IntToStr(AStyleType));
+  dxfPairOut(outstream, 300, AStyleName);
+  dxfPairOut(outstream, 309, 'CELLSTYLE_END');
+end;
+
+{ Записывает расширенный словарь стиля таблицы и объект CELLSTYLEMAP.
+
+  Цепочка ссылок, которую ожидает AutoCAD (issue #1409):
+    TABLESTYLE --102{ACAD_XDICTIONARY/360}--> DICTIONARY
+      --(ключ ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP)--> CELLSTYLEMAP
+
+  DictHandle/MapHandle — заранее выделенные хэндлы этих двух объектов. }
+procedure WriteCellStyleMapObjectsToStream(
+  var outstream: TZctnrVectorBytes;
+  Style: PTGDBDXFTableStyle;
+  const StyleHandle, DictHandle, MapHandle: TDWGHandle);
+var
+  CS: array[0..2] of TGDBDXFTableCellStyle;
+  PCellStyle: PTGDBDXFTableCellStyle;
+  CellIdx: Integer;
+  Iter: itrec;
+  DefaultAlignments: array[0..2] of Integer;
+begin
+  { Порядок блоков ячеек в TABLESTYLE: 0=data, 1=title, 2=header }
+  DefaultAlignments[0] := 2;
+  DefaultAlignments[1] := 5;
+  DefaultAlignments[2] := 5;
+  for CellIdx := 0 to 2 do
+  begin
+    FillChar(CS[CellIdx], SizeOf(CS[CellIdx]), 0);
+    CS[CellIdx].TextHeight := 2.5;
+    CS[CellIdx].Alignment := DefaultAlignments[CellIdx];
+  end;
+  CellIdx := 0;
+  PCellStyle := Style^.CellFormats.beginiterate(Iter);
+  while (PCellStyle <> nil) and (CellIdx < 3) do
+  begin
+    CS[CellIdx] := PCellStyle^;
+    Inc(CellIdx);
+    PCellStyle := Style^.CellFormats.iterate(Iter);
+  end;
+
+  { Словарь-расширение стиля таблицы }
+  dxfPairOut(outstream, 0, 'DICTIONARY');
+  dxfPairOut(outstream, 5, inttohex(DictHandle, 0));
+  dxfPairOut(outstream, 330, inttohex(StyleHandle, 0));
+  dxfPairOut(outstream, 100, 'AcDbDictionary');
+  dxfPairOut(outstream, 281, '1');
+  dxfPairOut(outstream, 3, 'ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP');
+  dxfPairOut(outstream, 360, inttohex(MapHandle, 0));
+
+  { Сама карта стилей ячеек: _TITLE=1, _HEADER=2, _DATA=3 }
+  dxfPairOut(outstream, 0, 'CELLSTYLEMAP');
+  dxfPairOut(outstream, 5, inttohex(MapHandle, 0));
+  dxfPairOut(outstream, 102, '{ACAD_REACTORS');
+  dxfPairOut(outstream, 330, inttohex(DictHandle, 0));
+  dxfPairOut(outstream, 102, '}');
+  dxfPairOut(outstream, 330, inttohex(DictHandle, 0));
+  dxfPairOut(outstream, 100, 'AcDbCellStyleMap');
+  dxfPairOut(outstream, 90, '3');
+  WriteCellStyleMapEntryToStream(outstream, CS[1], 1, 1, 32768, '_TITLE');
+  WriteCellStyleMapEntryToStream(outstream, CS[2], 2, 1, 0, '_HEADER');
+  WriteCellStyleMapEntryToStream(outstream, CS[0], 3, 2, 0, '_DATA');
+end;
+
 { Записывает один объект TABLESTYLE в выходной поток DXF.
   StyleHandle — заранее назначенный хэндл объекта.
-  OwnerHandle — хэндл словаря ACAD_TABLESTYLE (владелец). }
+  OwnerHandle — хэндл словаря ACAD_TABLESTYLE (владелец).
+  DictHandle/MapHandle — хэндлы расширенного словаря и CELLSTYLEMAP;
+  если оба равны 0, карта стилей ячеек не записывается. }
 procedure WriteTableStyleObjectToStream(
   var outstream: TZctnrVectorBytes;
   Style: PTGDBDXFTableStyle;
   const StyleHandle: TDWGHandle;
-  const OwnerHandle: TDWGHandle);
+  const OwnerHandle: TDWGHandle;
+  const DictHandle: TDWGHandle = 0;
+  const MapHandle: TDWGHandle = 0);
 var
   PCellStyle: PTGDBDXFTableCellStyle;
   DefaultCS: TGDBDXFTableCellStyle;
@@ -195,11 +351,19 @@ begin
   outstream.TXTAddStringEOL(dxfGroupCode(5));
   outstream.TXTAddStringEOL(inttohex(StyleHandle, 0));
 
-  { Блок ACAD_XDICTIONARY намеренно НЕ пишем (issue #1339): сам объект
-    расширенного словаря в выходной файл не сохраняется, поэтому ссылка 360
-    на Style^.XDictHandle (старый хэндл из загруженного файла) указывала бы
-    на несуществующий объект — висячая ссылка, из-за которой AutoCAD
-    открывает пустой чертёж. }
+  { Блок ACAD_XDICTIONARY со старым хэндлом Style^.XDictHandle не пишем
+    (issue #1339): такая ссылка указывала бы на несуществующий объект.
+    Но если для стиля выделены хэндлы под словарь и CELLSTYLEMAP, эти
+    объекты записываются нами ниже, и ссылка 360 корректна (issue #1409). }
+  if (DictHandle > 0) and (MapHandle > 0) then
+  begin
+    outstream.TXTAddStringEOL(dxfGroupCode(102));
+    outstream.TXTAddStringEOL('{ACAD_XDICTIONARY');
+    outstream.TXTAddStringEOL(dxfGroupCode(360));
+    outstream.TXTAddStringEOL(inttohex(DictHandle, 0));
+    outstream.TXTAddStringEOL(dxfGroupCode(102));
+    outstream.TXTAddStringEOL('}');
+  end;
 
   { Блок ACAD_REACTORS — принадлежность словарю }
   outstream.TXTAddStringEOL(dxfGroupCode(102));
@@ -255,6 +419,12 @@ begin
     WriteCellStyleToStream(outstream, DefaultCS, 'Standard');
     Inc(CellIdx);
   end;
+
+  { Карта стилей ячеек — без неё AutoCAD игнорирует индивидуальные стили
+    ячеек в TABLECONTENT (issue #1409). }
+  if (DictHandle > 0) and (MapHandle > 0) then
+    WriteCellStyleMapObjectsToStream(outstream, Style,
+      StyleHandle, DictHandle, MapHandle);
 
   programlog.LogOutFormatStr(
     'uzeffdxfout: записан TABLESTYLE "%s" handle=%s',
@@ -365,6 +535,8 @@ var
   intablestyledict: boolean;
   { Массивы предварительно выделенных хэндлов для стилей таблиц }
   tsHandles: array of TDWGHandle;
+  tsDictHandles: array of TDWGHandle;
+  tsMapHandles: array of TDWGHandle;
   tsCount: integer;
   tsHandlesAllocated: boolean;
   beforeProcIdx: integer;
@@ -405,10 +577,18 @@ var
     tsCount:=drawing.DXFTableStyleTable.count;
     if tsCount>0 then begin
       SetLength(tsHandles, tsCount);
+      SetLength(tsDictHandles, tsCount);
+      SetLength(tsMapHandles, tsCount);
       psIdx:=0;
       psStyle:=drawing.DXFTableStyleTable.beginiterate(psIter);
       while (psStyle<>nil) and (psIdx<tsCount) do begin
         tsHandles[psIdx]:=IODXFContext.handle;
+        Inc(IODXFContext.handle);
+        { Хэндлы расширенного словаря стиля и карты стилей ячеек
+          (CELLSTYLEMAP), см. issue #1409 }
+        tsDictHandles[psIdx]:=IODXFContext.handle;
+        Inc(IODXFContext.handle);
+        tsMapHandles[psIdx]:=IODXFContext.handle;
         Inc(IODXFContext.handle);
         if not IODXFContext.TableStyleNameHandleMap.MyContans(psStyle^.Name) then
           IODXFContext.TableStyleNameHandleMap.Add(
@@ -461,6 +641,8 @@ begin
     tsCount:=0;
     tsHandlesAllocated:=False;
     SetLength(tsHandles, 0);
+    SetLength(tsDictHandles, 0);
+    SetLength(tsMapHandles, 0);
     MakeVariablesDict(IODXFContext.VarsDict,drawing);
     processedvarscount:=IODXFContext.VarsDict.Count;
     while templatefile.notEOF do begin
@@ -1380,7 +1562,8 @@ begin
               ptablestyle:=drawing.DXFTableStyleTable.beginiterate(tablestyleiter);
               while (ptablestyle<>nil) and (i<tsCount) do begin
                 WriteTableStyleObjectToStream(
-                  outstream,ptablestyle,tsHandles[i],tablestyledicthandle);
+                  outstream,ptablestyle,tsHandles[i],tablestyledicthandle,
+                  tsDictHandles[i],tsMapHandles[i]);
                 Inc(writtenstylecount);
                 Inc(i);
                 ptablestyle:=drawing.DXFTableStyleTable.iterate(tablestyleiter);
@@ -1430,7 +1613,8 @@ begin
             ptablestyle:=drawing.DXFTableStyleTable.beginiterate(tablestyleiter);
             while (ptablestyle<>nil) and (i<tsCount) do begin
               WriteTableStyleObjectToStream(
-                outstream,ptablestyle,tsHandles[i],tablestyledicthandle);
+                outstream,ptablestyle,tsHandles[i],tablestyledicthandle,
+                  tsDictHandles[i],tsMapHandles[i]);
               Inc(writtenstylecount);
               Inc(i);
               ptablestyle:=drawing.DXFTableStyleTable.iterate(tablestyleiter);
@@ -1452,7 +1636,8 @@ begin
             ptablestyle:=drawing.DXFTableStyleTable.beginiterate(tablestyleiter);
             while (ptablestyle<>nil) and (i<tsCount) do begin
               WriteTableStyleObjectToStream(
-                outstream,ptablestyle,tsHandles[i],tablestyledicthandle);
+                outstream,ptablestyle,tsHandles[i],tablestyledicthandle,
+                  tsDictHandles[i],tsMapHandles[i]);
               Inc(writtenstylecount);
               Inc(i);
               ptablestyle:=drawing.DXFTableStyleTable.iterate(tablestyleiter);

--- a/cad_source/zengine/tests/uzctacadtable.pas
+++ b/cad_source/zengine/tests/uzctacadtable.pas
@@ -89,6 +89,12 @@ type
     // ссылку 342 на актуальный хэндл TABLESTYLE, а не оставляет старый хэндл,
     // который после перенумерации указывал на чужой объект ("aits"/блок).
     procedure ResolvesRawTableStyleNameAndRemaps342OnDXFOut;
+    // issue #1409: при сохранении по МОДЕЛЬНОМУ пути (raw-DXF инвалидирован
+    // редактированием) сущность ACAD_TABLE тоже должна получать владельца
+    // (330) и актуальный хэндл стиля таблицы (342), а объект TABLECONTENT —
+    // ссылку 340 на тот же стиль. Без них AutoCAD игнорирует
+    // индивидуальные стили ячеек и раскрашивает таблицу по своему правилу.
+    procedure WritesOwnerAndTableStyleRefsOnModelPathDXFOut;
     // issue #1305, часть 1: трансформация (перенос) должна перестраивать
     // визуальное представление таблицы.
     procedure TransformationMovesRenderedTable;
@@ -1403,6 +1409,67 @@ begin
     // Старый хэндл стиля 87 (после перенумерации — чужой объект) не должен течь.
     CheckEquals(0, CountDxfPairs(DXFText, '342', '87'),
       'Старый хэндл стиля 87 не должен оставаться в сохранённой таблице');
+  finally
+    Drawing.done;
+  end;
+end;
+
+procedure TAcadTableStyleTest.WritesOwnerAndTableStyleRefsOnModelPathDXFOut;
+const
+  StandardHandle = 'B8';
+  OwnerHandle = '1F';
+var
+  Drawing: TSimpleDrawing;
+  AcadTable: PGDBObjAcadTable;
+  OutStream: TZctnrVectorBytes;
+  SaveContext: TIODXFSaveContext;
+  DXFText: String;
+  OrigDir, OtherDir: TAcadTableBreakDirection;
+begin
+  LoadDrawingFromDXF(
+    ExpandFileName('../../../cad_source/test/tablerazdel.dxf'), Drawing);
+  try
+    AcadTable := FindFirstAcadTable(Drawing.pObjRoot);
+    AssertNotNull('Ожидалась сущность AcadTable', AcadTable);
+
+    // Инвалидируем raw-DXF, чтобы сохранение пошло по модельному пути.
+    OrigDir := AcadTable^.BreakDirection;
+    if OrigDir = atbdRight then
+      OtherDir := atbdLeft
+    else
+      OtherDir := atbdRight;
+    AcadTable^.BreakDirection := OtherDir;
+    AcadTable^.BreakDirection := OrigDir;
+
+    OutStream.init(64 * 1024);
+    SaveContext.InitRec;
+    SaveContext.Header.Version := AC1021;
+    SaveContext.Header.iVersion := 1021;
+    try
+      SaveContext.AcadTableOwnerHandle := $1F;
+      SaveContext.TableStyleNameHandleMap.Add(
+        AcadTable^.TableStyleName, StandardHandle);
+
+      ResetAcadTableDXFWriteState;
+      AcadTable^.DXFOut(OutStream, Drawing, SaveContext);
+      WriteAcadTableRoundTripObjectsToDXF(OutStream, Drawing, SaveContext);
+      DXFText := DxfStreamToText(OutStream);
+    finally
+      ResetAcadTableDXFWriteState;
+      SaveContext.Done;
+      OutStream.done;
+    end;
+
+    CheckTrue(HasDxfSequence(DXFText, ['330', OwnerHandle]),
+      'Сущность ACAD_TABLE должна ссылаться на владельца (330) — иначе ' +
+      'AutoCAD не принимает round-trip таблицу (issue #1409)');
+    CheckTrue(HasDxfSequence(DXFText, ['342', StandardHandle]),
+      'Модельный путь должен писать актуальный хэндл стиля таблицы (342)');
+    CheckTrue(HasDxfSequence(DXFText, ['340', StandardHandle]),
+      'TABLECONTENT должен ссылаться (340) на стиль таблицы, в расширенном ' +
+      'словаре которого лежит CELLSTYLEMAP (issue #1409)');
+    CheckTrue(CountDxfPairs(DXFText, '90', '1') > 0,
+      'В TABLECONTENT должны присутствовать идентификаторы стилей ячеек');
   finally
     Drawing.done;
   end;

--- a/experiments/issue1409/compare_roundtrip.py
+++ b/experiments/issue1409/compare_roundtrip.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Compare a ZCAD-saved DXF against the same file re-saved by AutoCAD.
+
+Usage: python3 compare_roundtrip.py <ours.dxf> <autocad.dxf>
+
+This is the tool used to find the root cause of issue #1409.  It reports, for
+both files:
+
+  * whether a CELLSTYLEMAP object exists (the object that *defines* what cell
+    style ids 1/2/3 mean — without it AutoCAD throws the per-cell styles away
+    and falls back to "row 1 Title, row 2 Header, rest Data");
+  * the reference groups of every ACAD_TABLE entity (330 owner, 342 table
+    style, 343 anonymous block);
+  * the row and cell style ids stored in each TABLECONTENT.
+"""
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+NAMES = {1: "Title", 2: "Header", 3: "Data"}
+
+
+def pairs(path):
+    lines = [l.strip() for l in Path(path).read_text(
+        encoding="utf-8", errors="replace").splitlines()]
+    return [(lines[i], lines[i + 1]) for i in range(0, len(lines) - 1, 2)]
+
+
+def report(path):
+    p = pairs(path)
+    print(f"=== {path}")
+    kinds = Counter(v for c, v in p if c == "0")
+    for name in ("ACAD_TABLE", "TABLESTYLE", "CELLSTYLEMAP", "TABLECONTENT"):
+        print(f"  {name:<14} {kinds.get(name, 0)}")
+
+    for i, (code, value) in enumerate(p):
+        if code == "0" and value == "ACAD_TABLE":
+            refs = {}
+            for c, v in p[i + 1:i + 60]:
+                if c == "0":
+                    break
+                if c in ("330", "342", "343"):
+                    refs.setdefault(c, v)
+            print(f"  ACAD_TABLE handle={p[i + 1][1]} refs={refs}")
+
+    content = 0
+    rows, cells = [], []
+    for i, (code, value) in enumerate(p):
+        if code == "0" and value == "TABLECONTENT":
+            if content:
+                print(f"    rows={rows} cells={cells}")
+            content += 1
+            rows, cells = [], []
+            print(f"  TABLECONTENT #{content} handle={p[i + 1][1]}")
+        elif value == "TABLEROW_BEGIN" and p[i + 1][0] == "90":
+            rows.append(int(p[i + 1][1]))
+        elif value == "TABLECELL_BEGIN" and p[i + 1][0] == "90":
+            cells.append(int(p[i + 1][1]))
+    if content:
+        print(f"    rows={rows} cells={cells}")
+        print("    legend: " + ", ".join(f"{k}={v}" for k, v in NAMES.items()))
+
+
+def main(argv):
+    if not argv:
+        sys.exit(__doc__)
+    for path in argv:
+        report(path)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])

--- a/test_issue1409_cellstylemap_dxf.py
+++ b/test_issue1409_cellstylemap_dxf.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Contract for the CELLSTYLEMAP chain of a saved TABLESTYLE (issue #1409).
+
+Writing the individual style id of every cell into TABLECONTENT
+(``TABLECELL_BEGIN / 90`` = 1/2/3) is not enough on its own: those ids are
+meaningless unless the drawing also contains the object that *defines* them.
+AutoCAD stores those definitions in an ``AcDbCellStyleMap`` reached from the
+table style's extension dictionary::
+
+    TABLESTYLE -> {ACAD_XDICTIONARY -> DICTIONARY
+                -> (ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP)
+                -> CELLSTYLEMAP  (90 = 3 entries: _TITLE, _HEADER, _DATA)
+
+Without that object AutoCAD discards the per-cell ids and re-applies its
+built-in rule "row 1 = Title, row 2 = Header, the rest = Data" — exactly the
+symptom reported in the issue.  The reference layout was extracted from a
+file re-saved by AutoCAD, see ``experiments/issue1409/cellstylemap.txt``.
+
+This test also pins the entity-side references that the round-trip needs:
+group 342 (table style) and group 330 (owner) on the ACAD_TABLE entity, and
+group 340 (table style) in the TABLECONTENT object.  All three used to be
+written as an empty/zero handle because the handle stored in the model is the
+*pre-renumbering* one; they must be resolved by style name through
+``TableStyleNameHandleMap``.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+DXFOUT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfout.pas"
+WRITER = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_dxf_write.pas"
+)
+MODEL = (
+    ROOT / "cad_source" / "zcad" / "velec" / "acadtable" / "uzeacadtable_model.pas"
+)
+REFERENCE = ROOT / "experiments" / "issue1409" / "cellstylemap.txt"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def emitted_pairs(source: str, stream: str = "outstream"):
+    """Group code / literal value pairs emitted into ``stream``, in order."""
+    pattern = re.compile(
+        re.escape(stream) + r"\.TXTAddStringEOL\(\s*(?:dxfGroupCode\((\d+)\)"
+        r"|(.+?))\s*\)\s*;",
+        re.S,
+    )
+    return pattern.findall(source)
+
+
+def test_tablestyle_gets_extension_dictionary_and_cellstylemap():
+    source = read(DXFOUT)
+    assert "WriteCellStyleMapObjectsToStream" in source
+    assert "'{ACAD_XDICTIONARY'" in source
+    assert "'ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP'" in source
+    assert "'CELLSTYLEMAP'" in source
+    assert "'AcDbCellStyleMap'" in source
+    # The map declares exactly three cell styles.
+    assert "WriteCellStyleMapEntryToStream(outstream, CS[1], 1, 1, 32768, '_TITLE')" in source
+    assert "WriteCellStyleMapEntryToStream(outstream, CS[2], 2, 1, 0, '_HEADER')" in source
+    assert "WriteCellStyleMapEntryToStream(outstream, CS[0], 3, 2, 0, '_DATA')" in source
+
+
+def test_dictionary_and_map_handles_are_preallocated():
+    source = read(DXFOUT)
+    # Both extra objects need their own handles, allocated together with the
+    # table style handle so that nothing else claims them.
+    assert "tsDictHandles" in source
+    assert "tsMapHandles" in source
+    body = source[source.index("procedure PreallocateTableStyleHandles"):]
+    body = body[: body.index("\n  begin\n") + 4000]
+    assert body.count("Inc(IODXFContext.handle);") >= 3
+
+
+def test_cellstyle_entry_matches_autocad_reference_structure():
+    """Every marker of one reference CELLSTYLE block must be emitted."""
+    source = read(DXFOUT)
+    entry = source[source.index("procedure WriteCellStyleMapEntryToStream"):]
+    entry = entry[: entry.index("\nprocedure WriteCellStyleMapObjectsToStream")]
+    for marker in (
+        "TABLEFORMAT_BEGIN",
+        "CONTENTFORMAT",
+        "CONTENTFORMAT_BEGIN",
+        "CONTENTFORMAT_END",
+        "MARGIN",
+        "CELLMARGIN_BEGIN",
+        "CELLMARGIN_END",
+        "GRIDFORMAT",
+        "GRIDFORMAT_BEGIN",
+        "GRIDFORMAT_END",
+        "TABLEFORMAT_END",
+        "CELLSTYLE_BEGIN",
+        "CELLSTYLE_END",
+    ):
+        assert f"'{marker}'" in entry, marker
+    # Six grid formats (bits 1,2,4,8,16,32) as in the AutoCAD reference.
+    assert "dxfPairOut(outstream, 94, '6');" in entry
+    assert "GridBit <= 32" in entry
+
+
+def test_reference_file_documents_three_cell_styles():
+    if not REFERENCE.exists():  # reference kept for documentation only
+        return
+    text = read(REFERENCE)
+    assert text.count("CELLSTYLE_BEGIN") == 3
+    for name in ("_TITLE", "_HEADER", "_DATA"):
+        assert name in text
+    assert re.search(r"^90 3$", text, re.M)
+
+
+def test_entity_writes_owner_and_table_style_references():
+    source = read(WRITER)
+    assert "ResolveTableStyleHandle" in source
+    # 342 on the ACAD_TABLE entity, resolved by style name.
+    assert re.search(
+        r"dxfStringWithoutEncodeOut\(AOutStream, 342, TableStyleHandle\)",
+        source,
+    )
+    # 330 owner (*Model_Space) on the entity.
+    assert "AcadTableOwnerHandle > 0" in source
+    assert re.search(
+        r"dxfStringWithoutEncodeOut\(AOutStream, 330,\s*"
+        r"IntToHex\(AIODXFContext\.AcadTableOwnerHandle, 0\)\)",
+        source,
+    )
+    # 340 in TABLECONTENT, resolved the same way instead of the hard '0'.
+    assert re.search(
+        r"dxfStringWithoutEncodeOut\(AOutStream, 340, TableStyleHandle\)",
+        source,
+    )
+
+
+def test_write_part_carries_the_table_style_name():
+    assert "TableStyleName: String;" in read(WRITER)
+    model = read(MODEL)
+    assert "APart.TableStyleName := FTableStyle.Name;" in model
+    assert "APart.TableStyleName := ASource.TableStyle.Name;" in model
+
+
+def test_cells_carry_the_roundtrip_checksum():
+    source = read(WRITER)
+    assert "'ACAD_ROUNDTRIP_2008_CELL_CHECKSUM'" in source
+    assert "function CellTextChecksum" in source
+    assert "WriteCellChecksumDataMap(AOutStream, AText);" in source
+
+
+def test_formatted_table_data_trailer_is_a_single_zero():
+    """AutoCAD writes 90|0 there; the old 90..94 block broke parsing."""
+    source = read(WRITER)
+    tail = source[source.index("'AcDbFormattedTableData'"):]
+    tail = tail[: tail.index("'AcDbTableContent'")]
+    ints = re.findall(r"dxfIntegerout\(AOutStream, (\d+), (\d+)\)", tail)
+    # only the TABLEFORMAT block (90/170) plus the single trailing 90|0
+    assert ints[-1] == ("90", "0"), ints
+
+
+def main():
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+            except AssertionError as exc:
+                failures += 1
+                print(f"FAILED {name}: {exc}")
+            else:
+                print(f"ok {name}")
+    if failures:
+        raise SystemExit(f"{failures} test(s) failed")
+    print("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes #1409

## Проблема

Индивидуальный стиль каждой ячейки уже записывался в `TABLECONTENT`
(`TABLECELL_BEGIN / 90` = 1/2/3), но AutoCAD его игнорировал: тестовая таблица
(строка 1 — Title, строки 2–3 — Header, строки 4–5 — Data) открывалась как
строка 1 Title, строка 2 Header, остальные Data.

## Причина

Сравнение нашего файла (`test3.txt`) с ним же, пересохранённым AutoCAD
(`test3acad.txt`), показало: идентификаторы стилей ячеек **нигде не
определялись**. AutoCAD хранит их определения в объекте `CELLSTYLEMAP`
(`AcDbCellStyleMap`), доступном из расширенного словаря стиля таблицы:

```
TABLESTYLE --102{ACAD_XDICTIONARY/360}--> DICTIONARY
           --(ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP)--> CELLSTYLEMAP
                                          (_TITLE=1, _HEADER=2, _DATA=3)
```

`grep -c CELLSTYLEMAP` — 0 в нашем файле против 3 в файле AutoCAD. Без этого
объекта идентификаторы 1/2/3 бессмысленны, AutoCAD их отбрасывает и применяет
встроенное правило «строка 1 — Title, строка 2 — Header, остальные — Data» —
ровно тот симптом, о котором сообщено в issue.

Сопутствующие расхождения, найденные тем же сравнением:

| Группа | Было у нас | У AutoCAD |
|---|---|---|
| `330` (владелец) на ACAD_TABLE | не писалась | `24` (*Model_Space) |
| `342` (стиль таблицы) на ACAD_TABLE | не писалась (хэндл в модели устарел после перенумерации) | `5C` |
| `340` в TABLECONTENT | `0` | `5C` |
| `ACAD_ROUNDTRIP_2008_CELL_CHECKSUM` | отсутствовала | есть у каждой ячейки |
| хвост `AcDbFormattedTableData` | `90|1 91|0 92|0 93|0 94|2` | `90|0` |

## Решение

* **`uzeffdxfout.pas`** — для каждого стиля таблицы выделяются два
  дополнительных хэндла и записываются расширенный словарь и объект
  `CELLSTYLEMAP` с тремя блоками `CELLSTYLE` (`_TITLE`/`_HEADER`/`_DATA`);
  выравнивание и высота текста берутся из соответствующего блока стиля.
* **`uzeacadtable_dxf_write.pas`** — сущность `ACAD_TABLE` модельного пути
  получает владельца (`330`) и актуальный хэндл стиля таблицы (`342`),
  `TABLECONTENT` — ссылку `340` на тот же стиль. Хэндл резолвится **по имени
  стиля** через `TableStyleNameHandleMap`, так как хэндлы перенумеровываются
  при сохранении (сырой путь записи так уже делал).
* **`uzeacadtable_dxf_write.pas`** — в `DATAMAP` каждой ячейки пишется
  `ACAD_ROUNDTRIP_2008_CELL_CHECKSUM` (сумма кодов символов текста ячейки;
  значение проверено на всех 15 односимвольных ячейках файла AutoCAD), хвост
  `AcDbFormattedTableData` приведён к одиночному `90|0`.
* **`uzeacadtable_model.pas`** — имя стиля таблицы передаётся писателю DXF.

## Как воспроизвести

```
python3 experiments/issue1409/compare_roundtrip.py <файл.dxf>
```

До исправления (файл, сохранённый ZCAD):

```
=== experiments/issue1409/test1.dxf
  ACAD_TABLE     1
  TABLESTYLE     1
  CELLSTYLEMAP   0
  TABLECONTENT   0
  ACAD_TABLE handle=5D refs={'343': '2A'}
```

Ни `CELLSTYLEMAP`, ни `TABLECONTENT`, ни ссылок `330`/`342` — AutoCAD нечего
читать, поэтому раскладка строк восстанавливается по встроенному правилу.

## Тесты

* `test_issue1409_cellstylemap_dxf.py` — контракт на цепочку `CELLSTYLEMAP`,
  ссылки `330`/`342`/`340`, контрольную сумму ячейки и хвост
  `AcDbFormattedTableData`.
* `cad_source/zengine/tests/uzctacadtable.pas` —
  `WritesOwnerAndTableStyleRefsOnModelPathDXFOut`: сохранение по модельному
  пути должно писать `330`, `342` и `340` на актуальный хэндл стиля.
* Существующие `test_issue1409_tablecontent_dxf.py` и
  `test_issue1409_acadtable_cell_styles.py` продолжают проходить.

Все контрактные тесты каталога проходят, кроме
`test_issue1387_acadtable_geometry_types.py`, который падал и до этих
изменений (проверено на чистом дереве).
