### PR TITLE
AcadTable: объявлять DXF-классы для стилей ячеек (#1409)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-29T10:42:11.560Z for PR creation at branch issue-1409-5503e98b4832 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-29T10:42:11.560Z for PR creation at branch issue-1409-5503e98b4832 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -114,7 +114,7 @@ procedure WriteAcadTableRoundTripObjectsToDXF(
 implementation
 
 uses
-  SysUtils, Classes, uzeffdxfout;
+  SysUtils, Classes, uzeffdxfout, uzeentity;
 
 const
   { Идентификаторы стилей ячеек AutoCAD (CELLSTYLEMAP / TABLECELL_BEGIN.90):
@@ -166,6 +166,64 @@ type
 var
   RoundTripRecords: array of TAcadTableRoundTripRecord;
   ContentRecords: array of TAcadTableContentRecord;
+
+procedure WriteAcadTableClassRecord(
+  var AOutStream: TZctnrVectorBytes;
+  const ADXFName, ACppName: String;
+  AProxyFlags, AInstanceCount, AIsEntity: Integer);
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 0, 'CLASS');
+  dxfStringWithoutEncodeOut(AOutStream, 1, ADXFName);
+  dxfStringWithoutEncodeOut(AOutStream, 2, ACppName);
+  dxfStringWithoutEncodeOut(AOutStream, 3, 'ObjectDBX Classes');
+  dxfIntegerout(AOutStream, 90, AProxyFlags);
+  dxfIntegerout(AOutStream, 91, AInstanceCount);
+  dxfIntegerout(AOutStream, 280, 0);
+  dxfIntegerout(AOutStream, 281, AIsEntity);
+end;
+
+{ Объявляет прикладные классы, экземпляры которых этот модуль пишет в
+  ENTITIES и OBJECTS. Без этих CLASS-записей AutoCAD не связывает
+  TABLECONTENT/CELLSTYLEMAP с реализацией ObjectDBX и восстанавливает стили
+  ячеек по встроенному правилу строк (issue #1409).
+
+  В эталоне AutoCAD TABLECONTENT имеет два экземпляра класса на одну таблицу:
+  данные самой таблицы и связанное содержимое сущности. }
+procedure WriteAcadTableClassesToDXF(
+  var AOutStream: TZctnrVectorBytes;
+  var ADrawing: TSimpleDrawing;
+  var AIODXFContext: TIODXFSaveContext);
+var
+  AcadTableCount, CellStyleMapCount: Integer;
+  Entity: PGDBObjEntity;
+  Iter: itrec;
+begin
+  AcadTableCount:=0;
+  if ADrawing.pObjRoot<>nil then
+  begin
+    Entity:=ADrawing.pObjRoot^.ObjArray.beginiterate(Iter);
+    while Entity<>nil do
+    begin
+      if Entity^.GetObjType=GDBAcadTableID then
+        Inc(AcadTableCount);
+      Entity:=ADrawing.pObjRoot^.ObjArray.iterate(Iter);
+    end;
+  end;
+  CellStyleMapCount:=ADrawing.DXFTableStyleTable.Count;
+
+  if AcadTableCount>0 then
+  begin
+    WriteAcadTableClassRecord(AOutStream,
+      'ACAD_TABLE', 'AcDbTable', 1025, AcadTableCount, 1);
+    WriteAcadTableClassRecord(AOutStream,
+      'TABLECONTENT', 'AcDbTableContent', 1152,
+      AcadTableCount*2, 0);
+  end;
+  if CellStyleMapCount>0 then
+    WriteAcadTableClassRecord(AOutStream,
+      'CELLSTYLEMAP', 'AcDbCellStyleMap', 1152,
+      CellStyleMapCount, 0);
+end;
 
 procedure ResetAcadTableDXFWriteState;
 var
@@ -1243,6 +1301,7 @@ end;
 
 initialization
   RegisterBeforeSaveDxfProc(@ResetAcadTableDXFWriteStateBeforeSave);
+  RegisterClassesSaveDxfProc(@WriteAcadTableClassesToDXF);
   RegisterObjectsSaveDxfProc(@WriteAcadTableRoundTripObjectsToDXF);
 
 finalization

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -42,11 +42,18 @@ type
   TObjectsSaveDxfProc=procedure(var outstream:TZctnrVectorBytes;
                                 var drawing:TSimpleDrawing;
                                 var IODXFContext:TIODXFSaveContext);
+  { Callback, вызываемый перед закрытием секции CLASSES. Классы
+    прикладных DXF-объектов должны быть объявлены до появления их
+    экземпляров в секциях ENTITIES/OBJECTS. }
+  TClassesSaveDxfProc=procedure(var outstream:TZctnrVectorBytes;
+                                var drawing:TSimpleDrawing;
+                                var IODXFContext:TIODXFSaveContext);
 
 { Регистрирует pre-save callback. Все зарегистрированные callback'и
   вызываются в порядке регистрации в начале savedxf20XX. }
 procedure RegisterBeforeSaveDxfProc(proc:TBeforeSaveDxfProc);
 procedure RegisterObjectsSaveDxfProc(proc:TObjectsSaveDxfProc);
+procedure RegisterClassesSaveDxfProc(proc:TClassesSaveDxfProc);
 
 function savedxf20XX(const SavedFileName:string;const TemplateFileName:string;var drawing:TSimpleDrawing;AVer:TZCDxfVersion):boolean;
 
@@ -55,6 +62,7 @@ implementation
 var
   BeforeSaveDxfProcs:array of TBeforeSaveDxfProc;
   ObjectsSaveDxfProcs:array of TObjectsSaveDxfProc;
+  ClassesSaveDxfProcs:array of TClassesSaveDxfProc;
 
 procedure RegisterBeforeSaveDxfProc(proc:TBeforeSaveDxfProc);
 var
@@ -72,6 +80,15 @@ begin
   i:=Length(ObjectsSaveDxfProcs);
   SetLength(ObjectsSaveDxfProcs,i+1);
   ObjectsSaveDxfProcs[i]:=proc;
+end;
+
+procedure RegisterClassesSaveDxfProc(proc:TClassesSaveDxfProc);
+var
+  i:Integer;
+begin
+  i:=Length(ClassesSaveDxfProcs);
+  SetLength(ClassesSaveDxfProcs,i+1);
+  ClassesSaveDxfProcs[i]:=proc;
 end;
 
 procedure RegisterAcadAppInDXF(const appname:string;outstream:PTZctnrVectorBytes;var handle:TDWGHandle);
@@ -527,7 +544,7 @@ var
   lph:TLPSHandle;
 
   { Переменные для сохранения стилей таблиц в секции OBJECTS }
-  inobjectssec: boolean;
+  inobjectssec,inclassessec: boolean;
   tablestyledicthandle: TDWGHandle;
   tablestyleiter: itrec;
   ptablestyle: PTGDBDXFTableStyle;
@@ -548,6 +565,16 @@ var
     for objectsProcIdx:=0 to High(ObjectsSaveDxfProcs) do
       if Assigned(ObjectsSaveDxfProcs[objectsProcIdx]) then
         ObjectsSaveDxfProcs[objectsProcIdx](
+          outstream,drawing,IODXFContext);
+  end;
+
+  procedure RunClassesSaveDxfProcs;
+  var
+    classesProcIdx: Integer;
+  begin
+    for classesProcIdx:=0 to High(ClassesSaveDxfProcs) do
+      if Assigned(ClassesSaveDxfProcs[classesProcIdx]) then
+        ClassesSaveDxfProcs[classesProcIdx](
           outstream,drawing,IODXFContext);
   end;
 
@@ -635,6 +662,7 @@ begin
     indimstyletable:=False;
     inappidtable:=False;
     inobjectssec:=False;
+    inclassessec:=False;
     intablestyledict:=False;
     tablestyledicthandle:=0;
     writtenstylecount:=0;
@@ -703,6 +731,18 @@ begin
                and (lasthandle=tablestyledicthandle) then
               intablestyledict:=True;
           end;
+        end else if (groupi=2) and (values='CLASSES') then begin
+          outstream.TXTAddStringEOL(groups);
+          outstream.TXTAddStringEOL(values);
+          inclassessec:=True;
+        end else if inclassessec and (groupi=0)
+                    and (values=dxfName_ENDSEC) then begin
+          { Прикладные модули объявляют здесь классы своих сущностей и
+            объектов до закрывающего ENDSEC (issue #1409). }
+          RunClassesSaveDxfProcs;
+          inclassessec:=False;
+          outstream.TXTAddStringEOL(groups);
+          outstream.TXTAddStringEOL(values);
         end else if (groupi=2) and (values='ENTITIES') then begin
           outstream.TXTAddStringEOL(groups);
           outstream.TXTAddStringEOL(values);

--- a/experiments/issue1409/compare_dxf_records.py
+++ b/experiments/issue1409/compare_dxf_records.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Compare selected DXF records without being distracted by line formatting.
+
+The files attached to issue #1409 use different whitespace conventions, so a
+plain text diff obscures the meaningful group-code differences.  This helper
+parses code/value pairs, groups them into records beginning with group code 0,
+and prints records selected by type or by a value they contain.
+
+Usage:
+    python3 compare_dxf_records.py FILE [FILE ...] \
+        --type TABLESTYLE --type CELLSTYLEMAP --contains TABLECONTENT
+"""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class Pair:
+    code: str
+    value: str
+    line: int
+
+
+def read_pairs(path: Path) -> list[Pair]:
+    lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    return [
+        Pair(lines[index].strip(), lines[index + 1].strip(), index + 1)
+        for index in range(0, len(lines) - 1, 2)
+    ]
+
+
+def records(pairs: list[Pair]) -> list[list[Pair]]:
+    result: list[list[Pair]] = []
+    current: list[Pair] = []
+    for pair in pairs:
+        if pair.code == "0":
+            if current:
+                result.append(current)
+            current = [pair]
+        elif current:
+            current.append(pair)
+    if current:
+        result.append(current)
+    return result
+
+
+def selected(
+    record: list[Pair], record_types: set[str], contained_values: set[str]
+) -> bool:
+    if record_types and record[0].value in record_types:
+        return True
+    values = {pair.value for pair in record}
+    return bool(values & contained_values)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("files", type=Path, nargs="+")
+    parser.add_argument("--type", dest="record_types", action="append", default=[])
+    parser.add_argument("--contains", action="append", default=[])
+    args = parser.parse_args()
+
+    record_types = set(args.record_types)
+    contained_values = set(args.contains)
+    if not record_types and not contained_values:
+        parser.error("select at least one record with --type or --contains")
+
+    for path in args.files:
+        print(f"=== {path}")
+        matches = [
+            record
+            for record in records(read_pairs(path))
+            if selected(record, record_types, contained_values)
+        ]
+        for number, record in enumerate(matches, start=1):
+            print(
+                f"--- match {number}: {record[0].value} "
+                f"(source line {record[0].line})"
+            )
+            for pair in record:
+                print(f"{pair.code:>3} | {pair.value}")
+        if not matches:
+            print("(no matching records)")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_issue1409_acadtable_classes_dxf.py
+++ b/test_issue1409_acadtable_classes_dxf.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Regression contract for ACAD_TABLE class declarations (issue #1409).
+
+The DXF produced by ZCAD in ``test4.txt`` already contains the per-cell style
+ids, a TABLECONTENT object, and a CELLSTYLEMAP object.  AutoCAD nevertheless
+falls back to its built-in row styles because those application-defined
+objects are absent from the file's CLASSES section.
+
+An AutoCAD-resaved reference declares all three classes used by this export
+path before their instances:
+
+* ACAD_TABLE / AcDbTable
+* TABLECONTENT / AcDbTableContent
+* CELLSTYLEMAP / AcDbCellStyleMap
+
+The generic DXF writer owns the CLASSES section, while the AcadTable module
+owns these application-specific definitions.  This test pins the callback
+boundary between them and the exact class records found in the reference.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+DXFOUT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfout.pas"
+WRITER = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_dxf_write.pas"
+)
+REFERENCE = ROOT / "cad_source" / "test" / "tablebugheader.dxf"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def dxf_records(path: Path, record_type: str):
+    lines = [line.strip() for line in read(path).splitlines()]
+    pairs = list(zip(lines[0::2], lines[1::2]))
+    records = []
+    current = None
+    for code, value in pairs:
+        if code == "0":
+            if current and current[0][1] == record_type:
+                records.append(current)
+            current = [(code, value)]
+        elif current is not None:
+            current.append((code, value))
+    if current and current[0][1] == record_type:
+        records.append(current)
+    return records
+
+
+def class_record_map(path: Path):
+    result = {}
+    for record in dxf_records(path, "CLASS"):
+        values = dict(record)
+        result[values["1"]] = values
+    return result
+
+
+def test_autocad_reference_declares_the_three_custom_classes():
+    classes = class_record_map(REFERENCE)
+    expected = {
+        "ACAD_TABLE": ("AcDbTable", "1025", "1"),
+        "TABLECONTENT": ("AcDbTableContent", "1152", "0"),
+        "CELLSTYLEMAP": ("AcDbCellStyleMap", "1152", "0"),
+    }
+    for name, (cpp_name, proxy_flags, entity_flag) in expected.items():
+        record = classes[name]
+        assert record["2"] == cpp_name
+        assert record["3"] == "ObjectDBX Classes"
+        assert record["90"] == proxy_flags
+        assert record["280"] == "0"
+        assert record["281"] == entity_flag
+
+
+def test_generic_writer_offers_and_runs_a_classes_callback():
+    source = read(DXFOUT)
+    assert "TClassesSaveDxfProc" in source
+    assert "RegisterClassesSaveDxfProc" in source
+    assert "procedure RunClassesSaveDxfProcs" in source
+    assert re.search(
+        r"inclassessec\s+and\s+\(groupi=0\)\s+and\s+"
+        r"\(values=dxfName_ENDSEC\).*?RunClassesSaveDxfProcs",
+        source,
+        re.S,
+    )
+
+
+def test_acadtable_writer_emits_and_registers_required_classes():
+    source = read(WRITER)
+    assert "procedure WriteAcadTableClassRecord" in source
+    assert "'ObjectDBX Classes'" in source
+    assert "procedure WriteAcadTableClassesToDXF" in source
+    body = source[source.index("procedure WriteAcadTableClassesToDXF") :]
+    body = body[: body.index("\nprocedure ", 20)]
+    for marker in (
+        "'ACAD_TABLE'",
+        "'AcDbTable'",
+        "'TABLECONTENT'",
+        "'AcDbTableContent'",
+        "'CELLSTYLEMAP'",
+        "'AcDbCellStyleMap'",
+    ):
+        assert marker in body
+    assert "RegisterClassesSaveDxfProc(@WriteAcadTableClassesToDXF)" in source
+
+
+def main():
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+            except (AssertionError, KeyError) as exc:
+                failures += 1
+                print(f"FAILED {name}: {exc}")
+            else:
+                print(f"ok {name}")
+    if failures:
+        raise SystemExit(f"{failures} test(s) failed")
+    print("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()

--- a/test_issue1409_acadtable_classes_dxf.py
+++ b/test_issue1409_acadtable_classes_dxf.py
@@ -108,6 +108,20 @@ def test_acadtable_writer_emits_and_registers_required_classes():
         "'AcDbCellStyleMap'",
     ):
         assert marker in body
+    assert re.search(
+        r"'ACAD_TABLE',\s*'AcDbTable',\s*1025,\s*AcadTableCount,\s*1",
+        body,
+    )
+    assert re.search(
+        r"'TABLECONTENT',\s*'AcDbTableContent',\s*1152,\s*"
+        r"AcadTableCount\*2,\s*0",
+        body,
+    )
+    assert re.search(
+        r"'CELLSTYLEMAP',\s*'AcDbCellStyleMap',\s*1152,\s*"
+        r"CellStyleMapCount,\s*0",
+        body,
+    )
     assert "RegisterClassesSaveDxfProc(@WriteAcadTableClassesToDXF)" in source
 
 


### PR DESCRIPTION
Fixes #1409

## Проблема

После предыдущего исправления приложенный к issue `test4.txt` уже содержит:

- правильные идентификаторы стилей каждой ячейки в `TABLECONTENT`;
- `CELLSTYLEMAP` с `_TITLE`, `_HEADER` и `_DATA`;
- ссылки `330`, `342` и `340` между сущностью, стилем и содержимым.

Но AutoCAD по-прежнему открывает таблицу как Title / Header / Data / Data /
Data вместо ожидаемых Title / Header / Header / Data / Data.

## Причина

Сравнение `test4.txt` с тем же файлом, пересохранённым AutoCAD
(`test3acad.txt`), выявило структурную ошибку уровнем выше объектов:
ZCAD пишет экземпляры `ACAD_TABLE`, `TABLECONTENT` и `CELLSTYLEMAP`, но не
объявляет их прикладные классы в секции DXF `CLASSES`.

В файле ZCAD секция содержит только пять классов шаблона. В исправном файле
AutoCAD дополнительно присутствуют:

```text
ACAD_TABLE   / AcDbTable          / proxy flags 1025 / entity
TABLECONTENT / AcDbTableContent   / proxy flags 1152 / object
CELLSTYLEMAP / AcDbCellStyleMap   / proxy flags 1152 / object
```

По [спецификации Autodesk](https://help.autodesk.com/cloudhelp/2024/ENU/AutoCAD-DXF/files/GUID-DBD5351C-E408-4CED-9336-3BD489179EF5.htm)
имя C++-класса из этой секции связывает DXF-запись с реализацией поведения
объекта. Без объявлений AutoCAD не материализует round-trip объекты как
`AcDbTableContent`/`AcDbCellStyleMap`, игнорирует индивидуальные стили и
возвращается к встроенной раскладке строк.

## Решение

- В общий DXF writer добавлен регистрируемый callback, который вызывается
  перед закрытием секции `CLASSES`. Предметные модули могут объявлять свои
  классы без зависимости общего writer от конкретных сущностей.
- AcadTable writer регистрирует callback и записывает три `CLASS`-записи с
  именами, proxy flags и признаком entity/object из файла AutoCAD.
- Количество экземпляров вычисляется по таблицам и стилям текущего чертежа,
  а не зашито под единственный тестовый пример.
- Добавлен инструмент `experiments/issue1409/compare_dxf_records.py`, который
  сравнивает записи DXF по code/value без шума от различного форматирования.

## Как воспроизвести

```bash
python3 experiments/issue1409/compare_dxf_records.py \
  --type CLASS test4.txt test3acad.txt
```

До исправления в `test4.txt` отсутствуют все три класса выше, хотя их
экземпляры уже записаны в `ENTITIES` и `OBJECTS`. После исправления writer
добавляет объявления перед `ENDSEC`.

## Тесты

- `python3 test_issue1409_acadtable_classes_dxf.py`
- `python3 test_issue1409_acadtable_cell_styles.py`
- `python3 test_issue1409_cellstylemap_dxf.py`
- `python3 test_issue1409_tablecontent_dxf.py`
- `python3 -m py_compile experiments/issue1409/compare_dxf_records.py test_issue1409_acadtable_classes_dxf.py`
- `git diff --check upstream/master...HEAD`

Новый контракт сначала воспроизводил дефект отсутствием callback и
CLASS-записей, а теперь проверяет:

- точные определения классов в эталонном DXF AutoCAD;
- вызов предметных обработчиков внутри секции `CLASSES`;
- точные имена, proxy flags и признаки entity/object в AcadTable writer.

Остальные корневые Python-контракты проходят, кроме существующего
`test_issue1387_acadtable_geometry_types.py`: он падает тем же exact-string
assertion в не изменённом этой веткой `uzeacadtable_model.pas`.

Нативный FPUnit локально не запускался: в окружении отсутствуют FPC/Lazarus.
