### PR TITLE
AcadTable: стиль каждой ячейки сохраняется в DXF (завершение round-trip записи ссылкой на TABLEGEOMETRY)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-29T14:21:37.852Z for PR creation at branch issue-1409-82e896607199 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-29T14:21:37.852Z for PR creation at branch issue-1409-82e896607199 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_read.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_read.pas
@@ -392,12 +392,15 @@ begin
         if not RowHeightsRead then
         begin
           AData.TableFlags := ARdr.ParseInteger;
+          // Биты 0x02/0x04 — «таблица связана с блоком», а не подавление
+          // заголовков; подавление лежит в битах 0x20/0x40 (issue #1409).
           programlog.LogOutFormatStr(
             'AcadTable: dxf_read: TableFlags=0x%x ' +
-            '(titleSup=%d headerSup=%d)',
+            '(hasBlock=%d titleSup=%d headerSup=%d)',
             [AData.TableFlags,
-             Ord((AData.TableFlags and 2) <> 0),
-             Ord((AData.TableFlags and 4) <> 0)],
+             Ord((AData.TableFlags and $06) <> 0),
+             Ord((AData.TableFlags and $20) <> 0),
+             Ord((AData.TableFlags and $40) <> 0)],
             LM_Info);
         end
         else

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -122,6 +122,34 @@ const
     нумеруются с нуля (0 = Title, 1 = Header, 2 = Data). }
   CAcadCellStyleIdTitle = 1;
 
+  { Группа 172 ячейки AcDbTable — это «cell flag value», а не стиль ячейки.
+    AutoCAD всегда пишет здесь 0, а стиль берёт из TABLECONTENT (issue #1409). }
+  CAcadCellFlagValue = 0;
+
+  { Значение группы 90 подраздела AcDbTable (flag_for_table_value):
+      0x02 + 0x04 — таблица связана с блоком (AutoCAD всегда взводит эти биты),
+      0x10        — направление таблицы вниз.
+    ZCAD исторически писал 0, из-за чего AutoCAD считал таблицу «без блока» и
+    направленной вверх. }
+  CAcadTableHasBlockFlags = $02 or $04;
+  CAcadTableDirectionDownFlag = $10;
+  CAcadTableDefaultFlags =
+    CAcadTableHasBlockFlags or CAcadTableDirectionDownFlag;
+
+  { Хвост round-trip XRECORD ACAD_ROUNDTRIP_2008_TABLE_ENTITY. Во всех
+    эталонах AutoCAD (cad_source/test/tablebugheader.dxf, tablerazdel.dxf,
+    acadtablerazdel2007_*.dxf, bugbreaktable.dxf) запись всегда завершается
+    жёсткой ссылкой 361 на объект TABLEGEOMETRY. Без неё разбор round-trip
+    записи обрывается, AutoCAD отбрасывает TABLECONTENT целиком и
+    восстанавливает стили ячеек по встроенному правилу строк (issue #1409). }
+  CAcadTableRoundTripTailValue = 5;
+
+  { Кэш геометрии ячейки в TABLEGEOMETRY: geom_data_flag (93) AutoCAD всегда
+    пишет равным 7, а num_geometry (94) = 0 означает «геометрия не
+    закэширована» (так AutoCAD пишет пустые ячейки, см. tablerazdel.dxf). }
+  CAcadTableGeometryDataFlag = 7;
+  CAcadTableGeometryNoCache = 0;
+
 type
   TAcadTableIntegerArray = array of Integer;
   TAcadTableStringArray = array of String;
@@ -139,6 +167,7 @@ type
     DictionaryHandle: TDWGHandle;
     XRecordHandle: TDWGHandle;
     ContentHandle: TDWGHandle;
+    GeometryHandle: TDWGHandle;
     TableStyleHandle: String;
     TableStyleName: String;
     RowCount: Integer;
@@ -218,6 +247,11 @@ begin
     WriteAcadTableClassRecord(AOutStream,
       'TABLECONTENT', 'AcDbTableContent', 1152,
       AcadTableCount*2, 0);
+    // Кэш геометрии ячеек. Объект TABLEGEOMETRY завершает round-trip XRECORD
+    // (ссылка 361), без него AutoCAD не принимает TABLECONTENT (issue #1409).
+    WriteAcadTableClassRecord(AOutStream,
+      'TABLEGEOMETRY', 'AcDbTableGeometry', 1152,
+      AcadTableCount, 0);
   end;
   if CellStyleMapCount>0 then
     WriteAcadTableClassRecord(AOutStream,
@@ -403,6 +437,17 @@ begin
   end;
 end;
 
+// Значение группы 90 подраздела AcDbTable. Таблицы, созданные в ZCAD, имеют
+// TableFlags=0: это означает «нет связанного блока, направление вверх», и
+// AutoCAD такую таблицу разбирает по упрощённому пути. Подставляем набор
+// битов, который пишет сам AutoCAD (issue #1409).
+function TableFlagsForDXF(const APart: TAcadTableDXFWritePart): Integer;
+begin
+  Result := APart.TableFlags;
+  if Result = 0 then
+    Result := CAcadTableDefaultFlags;
+end;
+
 // Преобразует внутренний StyleType ячейки (0=Title, 1=Header, 2=Data)
 // в идентификатор стиля ячейки AutoCAD (1=_TITLE, 2=_HEADER, 3=_DATA).
 function AcadCellStyleId(AStyleType: Integer): Integer;
@@ -436,6 +481,7 @@ begin
     DictionaryHandle := NextAnonymousHandle(AIODXFContext);
     XRecordHandle := NextAnonymousHandle(AIODXFContext);
     ContentHandle := NextAnonymousHandle(AIODXFContext);
+    GeometryHandle := NextAnonymousHandle(AIODXFContext);
     TableStyleHandle := APart.TableStyleHandle;
     TableStyleName := APart.TableStyleName;
     RowCount := APart.RowCount;
@@ -579,7 +625,7 @@ begin
          APart.BlockName, BlockRecordHandle) then
       dxfStringWithoutEncodeOut(AOutStream, 343, BlockRecordHandle);
   dxfvertexout(AOutStream, 11, APart.Direction);
-  dxfIntegerout(AOutStream, 90, APart.TableFlags);
+  dxfIntegerout(AOutStream, 90, TableFlagsForDXF(APart));
   dxfIntegerout(AOutStream, 91, APart.RowCount);
   dxfIntegerout(AOutStream, 92, APart.ColCount);
   dxfIntegerout(AOutStream, 93, 0);
@@ -625,16 +671,19 @@ var
   CellText: String;
   ColSpan, RowSpan: Integer;
   IsVirtual: Boolean;
-  Alignment, StyleType: Integer;
+  Alignment: Integer;
 begin
   CellText := CellTextAt(APart, ARow, ACol);
   GetCellSpanAndVirtualFlag(APart, ARow, ACol,
     ColSpan, RowSpan, IsVirtual);
   Alignment := CellAlignmentAt(APart, ARow, ACol);
-  StyleType := CellStyleTypeAt(APart, ARow, ACol);
 
   dxfIntegerout(AOutStream, 171, 1);
-  dxfIntegerout(AOutStream, 172, StyleType);
+  // Группа 172 — cell flag value, а не стиль ячейки. Раньше сюда писался
+  // StyleType (0/1/2); AutoCAD это значение не интерпретирует как стиль, зато
+  // ненулевой флаг искажает разбор ячейки. Стиль каждой ячейки пишется
+  // отдельно, в TABLECELL_BEGIN|90 объекта TABLECONTENT (issue #1409).
+  dxfIntegerout(AOutStream, 172, CAcadCellFlagValue);
   dxfIntegerout(AOutStream, 173, BoolToDXF(IsVirtual));
   dxfIntegerout(AOutStream, 174, 0);
   dxfIntegerout(AOutStream, 175, ColSpan);
@@ -1236,8 +1285,44 @@ begin
     dxfStringWithoutEncodeOut(AOutStream, 340, '0');
 end;
 
-// Пишет тройку объектов round-trip AutoCAD 2008 для одной таблицы:
-// расширенный словарь сущности -> XRECORD -> TABLECONTENT (issue #1409).
+{ Кэш геометрии ячеек таблицы (AcDbTableGeometry). На него ссылается
+  завершающая группа 361 round-trip XRECORD, и без этого объекта AutoCAD
+  считает round-trip запись неполной и игнорирует TABLECONTENT вместе со
+  всеми индивидуальными стилями ячеек (issue #1409).
+
+  Содержимое кэша пишем пустым: num_geometry (94) = 0 — «геометрия ячейки не
+  закэширована». Именно так AutoCAD записывает пустые ячейки (см. эталон
+  cad_source/test/tablerazdel.dxf). Реальные значения зависят от метрик
+  шрифта AutoCAD, посчитать их в ZCAD нельзя, а кэш AutoCAD всё равно
+  перестраивает при регенерации таблицы. }
+procedure WriteTableGeometryObject(
+  var AOutStream: TZctnrVectorBytes;
+  const ARecord: TAcadTableContentRecord);
+var
+  CellIdx: Integer;
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 0, 'TABLEGEOMETRY');
+  dxfStringWithoutEncodeOut(AOutStream, 5,
+    IntToHex(ARecord.GeometryHandle, 0));
+  dxfStringWithoutEncodeOut(AOutStream, 330,
+    IntToHex(ARecord.XRecordHandle, 0));
+  dxfStringWithoutEncodeOut(AOutStream, 100, 'AcDbTableGeometry');
+  dxfIntegerout(AOutStream, 90, ARecord.RowCount);
+  dxfIntegerout(AOutStream, 91, ARecord.ColCount);
+  dxfIntegerout(AOutStream, 92, ARecord.RowCount * ARecord.ColCount);
+  for CellIdx := 0 to ARecord.RowCount * ARecord.ColCount - 1 do
+  begin
+    dxfIntegerout(AOutStream, 93, CAcadTableGeometryDataFlag);
+    dxfDoubleout(AOutStream, 40, 0);
+    dxfDoubleout(AOutStream, 41, 0);
+    dxfStringWithoutEncodeOut(AOutStream, 330, '0');
+    dxfIntegerout(AOutStream, 94, CAcadTableGeometryNoCache);
+  end;
+end;
+
+// Пишет четвёрку объектов round-trip AutoCAD 2008 для одной таблицы:
+// расширенный словарь сущности -> XRECORD -> TABLECONTENT + TABLEGEOMETRY
+// (issue #1409).
 procedure WriteAcadTableContentToDXF(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
@@ -1272,9 +1357,17 @@ begin
   dxfDoubleout(AOutStream, 20, 0);
   dxfDoubleout(AOutStream, 30, 0);
   dxfIntegerout(AOutStream, 90, 0);
-  dxfIntegerout(AOutStream, 90, 5);
+  // Хвост записи завершается обязательной ссылкой 361 на TABLEGEOMETRY —
+  // ровно так её пишет AutoCAD. Прежний вариант (последняя группа 90 без 361)
+  // обрывал round-trip запись, и AutoCAD отбрасывал TABLECONTENT с
+  // индивидуальными стилями ячеек, раскрашивая таблицу по правилу строк
+  // (issue #1409).
+  dxfIntegerout(AOutStream, 90, CAcadTableRoundTripTailValue);
+  dxfStringWithoutEncodeOut(AOutStream, 361,
+    IntToHex(ARecord.GeometryHandle, 0));
 
   WriteTableContentObject(AOutStream, AIODXFContext, ARecord);
+  WriteTableGeometryObject(AOutStream, ARecord);
 end;
 
 procedure WriteAcadTableRoundTripObjectsToDXF(

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_layout.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_layout.pas
@@ -72,6 +72,19 @@ procedure BuildRenderSegments(
 
 implementation
 
+const
+  { Биты подавления заголовков в группе 90 сущности AcDbTable
+    (flag_for_table_value): 0x20 — подавлена строка Title, 0x40 — строка
+    Header. Прежде здесь проверялись биты 0x02 и 0x04, но это биты «таблица
+    связана с блоком»: реальные DXF от AutoCAD приходят с TableFlags=22
+    ($02+$04+$10), где строки Title и Header фактически присутствуют
+    (см. cad_source/test/tablerazdel.dxf и комментарий к
+    GDBObjAcadTable.ComputeTopLabelRowCount). Из-за подмены зона повтора
+    верхних строк-меток обнулялась для любой таблицы, сохранённой с флагами
+    AutoCAD (issue #1409). }
+  CAcadTableTitleSuppressedFlag = $20;
+  CAcadTableHeaderSuppressedFlag = $40;
+
 function GetRowHeight(
   RowIndex: Integer;
   const ARowHeights: TZctnrVectorDouble): Double;
@@ -139,8 +152,10 @@ begin
   if (ARowCount <= 0) or (Length(ASegments) = 0) then
     Exit;
 
-  TitleSuppressed := (ATableFlags and 2) <> 0;
-  HeaderSuppressed := (ATableFlags and 4) <> 0;
+  TitleSuppressed :=
+    (ATableFlags and CAcadTableTitleSuppressedFlag) <> 0;
+  HeaderSuppressed :=
+    (ATableFlags and CAcadTableHeaderSuppressedFlag) <> 0;
 
   RepeatRowCount := 0;
   if ABreakRepeatTopLabels then

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -322,6 +322,10 @@ begin
   dxfPairOut(outstream, 5, inttohex(DictHandle, 0));
   dxfPairOut(outstream, 330, inttohex(StyleHandle, 0));
   dxfPairOut(outstream, 100, 'AcDbDictionary');
+  { 280|1 — жёсткое владение записями словаря. AutoCAD пишет этот флаг для
+    словаря-расширения стиля таблицы; без него CELLSTYLEMAP считается
+    «одолженным» объектом (issue #1409). }
+  dxfPairOut(outstream, 280, '1');
   dxfPairOut(outstream, 281, '1');
   dxfPairOut(outstream, 3, 'ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP');
   dxfPairOut(outstream, 360, inttohex(MapHandle, 0));

--- a/experiments/issue1409_roundtrip_audit.py
+++ b/experiments/issue1409_roundtrip_audit.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Audit the AcadTable round-trip structure of a DXF file (issue #1409).
+
+Usage::
+
+    python3 experiments/issue1409_roundtrip_audit.py file.dxf [file.dxf ...]
+
+For every file it reports the four markers that decide whether AutoCAD keeps
+the per-cell styles of an ACAD_TABLE entity:
+
+* does the ``ACAD_ROUNDTRIP_2008_TABLE_ENTITY`` XRECORD end with the hard
+  pointer ``361`` that terminates the record;
+* is the ``TABLEGEOMETRY`` object it points at actually present (and declared
+  in the CLASSES section);
+* what the AcDbTable ``90`` flag word and the per-cell ``172`` flag value are;
+* which style id each row and each cell carries inside TABLECONTENT.
+
+Run it on a ZCAD export and on an AutoCAD-resaved copy of the same drawing to
+see the difference.  Reference files live in ``cad_source/test/``.
+"""
+
+import sys
+from pathlib import Path
+
+
+def dxf_pairs(path):
+    lines = [line.strip() for line in
+             path.read_text(encoding="utf-8", errors="replace").splitlines()]
+    return list(zip(lines[0::2], lines[1::2]))
+
+
+def records(pairs, record_type):
+    out, current = [], None
+    for code, value in pairs:
+        if code == "0":
+            if current and current[0][1] == record_type:
+                out.append(current)
+            current = [(code, value)]
+        elif current is not None:
+            current.append((code, value))
+    if current and current[0][1] == record_type:
+        out.append(current)
+    return out
+
+
+def report_roundtrip(pairs):
+    geometry = {dict(r).get("5") for r in records(pairs, "TABLEGEOMETRY")}
+    xrecords = [r for r in records(pairs, "XRECORD")
+                if ("102", "ACAD_ROUNDTRIP_2008_TABLE_ENTITY") in r]
+    print(f"  TABLEGEOMETRY objects : {len(geometry)}")
+    classes = {dict(r).get("1") for r in records(pairs, "CLASS")}
+    print(f"  TABLEGEOMETRY class   : {'TABLEGEOMETRY' in classes}")
+    for record in xrecords:
+        code, value = record[-1]
+        ok = code == "361" and value in geometry
+        print(f"  xrecord tail          : {code}|{value}  "
+              f"{'OK' if ok else 'TRUNCATED - AutoCAD drops TABLECONTENT'}")
+    if not xrecords:
+        print("  xrecord tail          : no round-trip XRECORD at all")
+
+
+def report_entity(pairs):
+    for i, (code, value) in enumerate(pairs):
+        if code == "100" and value == "AcDbTable":
+            tail = pairs[i:]
+            end = next(j for j, (c, _) in enumerate(tail) if j and c == "0")
+            flags = next(v for c, v in tail if c == "90")
+            cells = sorted({v for c, v in tail[:end] if c == "172"})
+            print(f"  AcDbTable 90 (flags)  : {flags}")
+            print(f"  cell 172 values       : {cells}")
+            break
+
+
+def report_styles(pairs):
+    rows = [pairs[i + 1][1] for i, (_, v) in enumerate(pairs)
+            if v == "TABLEROW_BEGIN" and pairs[i + 1][0] == "90"]
+    cells = [pairs[i + 1][1] for i, (_, v) in enumerate(pairs)
+             if v == "TABLECELL_BEGIN" and pairs[i + 1][0] == "90"]
+    print(f"  row style ids         : {rows}")
+    print(f"  cell style ids        : {cells}")
+
+
+def main(argv):
+    if len(argv) < 2:
+        print(__doc__)
+        return 1
+    for name in argv[1:]:
+        path = Path(name)
+        print(path)
+        pairs = dxf_pairs(path)
+        report_roundtrip(pairs)
+        report_entity(pairs)
+        report_styles(pairs)
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/test_issue1409_acadtable_cell_styles.py
+++ b/test_issue1409_acadtable_cell_styles.py
@@ -45,14 +45,15 @@ def test_model_keeps_cell_styles_independent():
 
 
 def test_dxf_writes_style_for_each_cell():
-    # Group 172 is ZCAD's own round-trip channel only: in the DXF reference it
-    # is the "cell flag value", so AutoCAD ignores it. The style AutoCAD reads
-    # is written into the TABLECONTENT object - see
-    # test_issue1409_tablecontent_dxf.py.
+    # Group 172 of a cell is the "cell flag value", not the cell style, and
+    # AutoCAD writes 0 there (see cad_source/test/tablebugheader.dxf).  The
+    # style AutoCAD actually reads is written per cell into the TABLECONTENT
+    # object - see test_issue1409_tablecontent_dxf.py.
     source = read(ACADTABLE / "uzeacadtable_dxf_write.pas")
     assert "function CellStyleTypeAt(" in source
-    assert "StyleType := CellStyleTypeAt(APart, ARow, ACol);" in source
-    assert "dxfIntegerout(AOutStream, 172, StyleType);" in source
+    assert "dxfIntegerout(AOutStream, 172, CAcadCellFlagValue);" in source
+    assert "dxfIntegerout(AOutStream, 172, StyleType);" not in source
+    assert "AcadCellStyleId(CellStyleTypeAt(APart, RowIdx, ColIdx));" in source
     assert "AddAcadTableContentRecord(" in source
 
 

--- a/test_issue1409_tablegeometry_dxf.py
+++ b/test_issue1409_tablegeometry_dxf.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Contract for the round-trip terminator of an AcadTable (issue #1409).
+
+Symptom reported on the issue: whatever per-cell styles ZCAD writes into the
+round-trip TABLECONTENT object, AutoCAD keeps painting the table with its own
+positional rule (row 0 -> Title, row 1 -> Header, every other row -> Data).
+
+Root cause: the ``ACAD_ROUNDTRIP_2008_TABLE_ENTITY`` XRECORD written by ZCAD
+was truncated.  Every AutoCAD-authored reference in this repository ends that
+record with a hard pointer ``361`` to a ``TABLEGEOMETRY`` object:
+
+    XRECORD(ACAD_ROUNDTRIP_2008_TABLE_ENTITY)
+        360 -> TABLECONTENT      (per-cell styles live here)
+        ...
+        361 -> TABLEGEOMETRY     (cell geometry cache, terminates the record)
+
+Without the ``361`` terminator - and without the TABLEGEOMETRY object and its
+CLASS declaration - AutoCAD treats the round-trip record as incomplete and
+drops TABLECONTENT altogether, which is the only place a per-cell style can be
+stored (the legacy AcDbTable entity has no per-cell style at all: group 172 is
+the "cell flag value").
+
+This module pins the terminator, the geometry object, its class record and the
+two collateral AcDbTable fields that AutoCAD relies on while parsing.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+WRITER = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_dxf_write.pas"
+)
+DXFOUT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfout.pas"
+LAYOUT = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_layout.pas"
+)
+READER = (
+    ROOT
+    / "cad_source"
+    / "zcad"
+    / "velec"
+    / "acadtable"
+    / "uzeacadtable_dxf_read.pas"
+)
+REFERENCE_DXF = ROOT / "cad_source" / "test" / "tablebugheader.dxf"
+EMPTY_CELL_DXF = ROOT / "cad_source" / "test" / "tablerazdel.dxf"
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="replace")
+
+
+def emitted_pairs(source: str):
+    """Group code / literal value pairs emitted by the writer, in order."""
+    pattern = re.compile(
+        r"dxf(?:StringWithoutEncode|Integer|Double)[Oo]ut\("
+        r"\s*AOutStream\s*,\s*(\d+)\s*,\s*(.+?)\s*\)\s*;",
+        re.S,
+    )
+    return [
+        (int(c), " ".join(v.split()).strip("'"))
+        for c, v in pattern.findall(source)
+    ]
+
+
+def procedure_body(source: str, name: str) -> str:
+    match = re.search(r"^(?:procedure|function)\s+" + name + r"\b", source, re.M)
+    assert match, name
+    body = source[match.start() :]
+    end = re.search(r"\n(?:procedure|function)\s", body[20:])
+    assert end, name
+    return body[: 20 + end.start()]
+
+
+def dxf_pairs(path: Path):
+    lines = [line.strip() for line in read(path).splitlines()]
+    return list(zip(lines[0::2], lines[1::2]))
+
+
+def dxf_records(path: Path, record_type: str):
+    records = []
+    current = None
+    for code, value in dxf_pairs(path):
+        if code == "0":
+            if current and current[0][1] == record_type:
+                records.append(current)
+            current = [(code, value)]
+        elif current is not None:
+            current.append((code, value))
+    if current and current[0][1] == record_type:
+        records.append(current)
+    return records
+
+
+# --------------------------------------------------------------------------
+# Evidence: what AutoCAD itself writes.
+# --------------------------------------------------------------------------
+
+
+def test_reference_roundtrip_xrecord_ends_with_a_geometry_pointer():
+    handles = {
+        dict(record)["5"]: record[0][1]
+        for record in dxf_records(REFERENCE_DXF, "TABLEGEOMETRY")
+    }
+    assert handles, "reference file has no TABLEGEOMETRY object"
+
+    roundtrip = [
+        record
+        for record in dxf_records(REFERENCE_DXF, "XRECORD")
+        if ("102", "ACAD_ROUNDTRIP_2008_TABLE_ENTITY") in record
+    ]
+    assert roundtrip, "reference file has no table round-trip XRECORD"
+    for record in roundtrip:
+        code, value = record[-1]
+        assert code == "361", record[-3:]
+        assert handles.get(value) == "TABLEGEOMETRY", (value, record[-3:])
+
+
+def test_reference_declares_the_tablegeometry_class():
+    classes = {dict(r)["1"]: dict(r) for r in dxf_records(REFERENCE_DXF, "CLASS")}
+    record = classes["TABLEGEOMETRY"]
+    assert record["2"] == "AcDbTableGeometry"
+    assert record["3"] == "ObjectDBX Classes"
+    assert record["90"] == "1152"
+    assert record["280"] == "0"
+    assert record["281"] == "0"
+
+
+def test_reference_acdbtable_flags_and_cell_flag_value():
+    pairs = dxf_pairs(REFERENCE_DXF)
+    start = next(
+        i for i, (c, v) in enumerate(pairs) if c == "100" and v == "AcDbTable"
+    )
+    tail = pairs[start:]
+    # flag_for_table_value: 0x02|0x04 (has block) + 0x10 (direction down).
+    flag_value = next(v for c, v in tail if c == "90")
+    assert flag_value == "22", flag_value
+    # Group 172 of every cell is the cell flag value and AutoCAD writes 0.
+    end = next(i for i, (c, _) in enumerate(tail) if i and c == "0")
+    flags = [int(v) for c, v in tail[:end] if c == "172"]
+    assert flags, "no cell written in the reference table"
+    assert set(flags) == {0}, sorted(set(flags))
+
+
+def test_reference_encodes_an_uncached_cell_as_flag_seven_count_zero():
+    """AutoCAD's own encoding for a cell whose geometry is not cached."""
+    uncached = 0
+    for record in dxf_records(EMPTY_CELL_DXF, "TABLEGEOMETRY"):
+        codes = [c for c, _ in record]
+        for i, (code, value) in enumerate(record):
+            if code == "93":
+                assert value == "7", value
+            if code == "94" and value == "0":
+                uncached += 1
+        assert "94" in codes
+    assert uncached, "no uncached cell in the reference file"
+
+
+# --------------------------------------------------------------------------
+# Contract: what ZCAD must write.
+# --------------------------------------------------------------------------
+
+
+def test_writer_terminates_the_roundtrip_xrecord_with_361():
+    body = procedure_body(read(WRITER), "WriteAcadTableContentToDXF")
+    pairs = emitted_pairs(body)
+    start = next(
+        i
+        for i, (c, v) in enumerate(pairs)
+        if c == 102 and v == "ACAD_ROUNDTRIP_2008_TABLE_ENTITY"
+    )
+    tail = pairs[start:]
+    assert tail[1] == (360, "IntToHex(ARecord.ContentHandle, 0)"), tail[1]
+    assert tail[-1] == (361, "IntToHex(ARecord.GeometryHandle, 0)"), tail[-1]
+    assert tail[-2] == (90, "CAcadTableRoundTripTailValue"), tail[-2]
+    assert "WriteTableGeometryObject(AOutStream, ARecord);" in body
+
+
+def test_writer_emits_a_tablegeometry_object_owned_by_the_xrecord():
+    source = read(WRITER)
+    assert "GeometryHandle: TDWGHandle;" in source
+    assert "GeometryHandle := NextAnonymousHandle(AIODXFContext);" in source
+
+    body = procedure_body(source, "WriteTableGeometryObject")
+    pairs = emitted_pairs(body)
+    assert pairs[0] == (0, "TABLEGEOMETRY"), pairs[0]
+    assert pairs[1] == (5, "IntToHex(ARecord.GeometryHandle, 0)"), pairs[1]
+    assert pairs[2] == (330, "IntToHex(ARecord.XRecordHandle, 0)"), pairs[2]
+    assert pairs[3] == (100, "AcDbTableGeometry"), pairs[3]
+    assert [c for c, _ in pairs[4:7]] == [90, 91, 92]
+    # One geometry block per cell, written as "not cached" the way AutoCAD
+    # writes an empty cell.
+    assert [c for c, _ in pairs[7:12]] == [93, 40, 41, 330, 94]
+    assert pairs[7] == (93, "CAcadTableGeometryDataFlag"), pairs[7]
+    assert pairs[11] == (94, "CAcadTableGeometryNoCache"), pairs[11]
+    assert "CAcadTableGeometryDataFlag = 7;" in source
+    assert "CAcadTableGeometryNoCache = 0;" in source
+    assert "ARecord.RowCount * ARecord.ColCount - 1 do" in body
+
+
+def test_writer_declares_the_tablegeometry_class():
+    body = procedure_body(read(WRITER), "WriteAcadTableClassesToDXF")
+    assert re.search(
+        r"'TABLEGEOMETRY',\s*'AcDbTableGeometry',\s*1152,\s*"
+        r"AcadTableCount,\s*0",
+        body,
+    ), body
+
+
+def test_writer_uses_the_autocad_flag_set_for_acdbtable():
+    source = read(WRITER)
+    assert "CAcadTableHasBlockFlags = $02 or $04;" in source
+    assert "CAcadTableDirectionDownFlag = $10;" in source
+    assert re.search(
+        r"CAcadTableDefaultFlags\s*=\s*"
+        r"CAcadTableHasBlockFlags\s+or\s+CAcadTableDirectionDownFlag;",
+        source,
+    )
+    header = procedure_body(source, "WriteTableHeader")
+    assert (90, "TableFlagsForDXF(APart)") in emitted_pairs(header)
+    flags = procedure_body(source, "TableFlagsForDXF")
+    assert "Result := APart.TableFlags;" in flags
+    assert "Result := CAcadTableDefaultFlags;" in flags
+
+
+def test_header_suppression_does_not_read_the_has_block_bits():
+    """Saving the AutoCAD flag set must not suppress the repeated top rows.
+
+    ``BuildRenderSegments`` used to read 0x02/0x04 as "title/header
+    suppressed".  Those are the "table has a block" bits, so a table written
+    with the AutoCAD flag value (22 = 0x02|0x04|0x10) and read back would lose
+    its repeated Title/Header rows.  Suppression lives in 0x20/0x40.
+    """
+    layout = read(LAYOUT)
+    assert "CAcadTableTitleSuppressedFlag = $20;" in layout
+    assert "CAcadTableHeaderSuppressedFlag = $40;" in layout
+    body = layout[layout.index("\nimplementation") :]
+    assert "(ATableFlags and CAcadTableTitleSuppressedFlag) <> 0" in body
+    assert "(ATableFlags and CAcadTableHeaderSuppressedFlag) <> 0" in body
+    assert "(ATableFlags and 2) <> 0" not in body
+    assert "(ATableFlags and 4) <> 0" not in body
+
+    reader = read(READER)
+    assert "Ord((AData.TableFlags and 2) <> 0)" not in reader
+    assert "Ord((AData.TableFlags and 4) <> 0)" not in reader
+    assert "Ord((AData.TableFlags and $20) <> 0)" in reader
+    assert "Ord((AData.TableFlags and $40) <> 0)" in reader
+
+    # The value ZCAD now writes must not set any suppression bit.
+    assert (0x02 | 0x04 | 0x10) & (0x20 | 0x40) == 0
+
+
+def test_writer_keeps_cell_group_172_as_the_cell_flag_value():
+    source = read(WRITER)
+    assert "CAcadCellFlagValue = 0;" in source
+    body = procedure_body(source, "WriteCell")
+    pairs = emitted_pairs(body)
+    written = [v for c, v in pairs if c == 172]
+    assert written == ["CAcadCellFlagValue"], written
+    # The style type must not leak into the entity any more.
+    assert "CellStyleTypeAt" not in body
+
+
+def test_tablestyle_extension_dictionary_is_hard_owner():
+    body = procedure_body(read(DXFOUT), "WriteCellStyleMapObjectsToStream")
+    idx = body.index("'AcDbDictionary'")
+    window = body[idx : idx + 600]
+    assert re.search(r"dxfPairOut\(outstream,\s*280,\s*'1'\)", window), window
+    assert re.search(r"dxfPairOut\(outstream,\s*281,\s*'1'\)", window), window
+    assert "ACAD_ROUNDTRIP_2008_TABLESTYLE_CELLSTYLEMAP" in body
+
+
+def main():
+    failures = 0
+    for name, fn in sorted(globals().items()):
+        if name.startswith("test_") and callable(fn):
+            try:
+                fn()
+            except (AssertionError, KeyError, StopIteration, ValueError) as exc:
+                failures += 1
+                print(f"FAILED {name}: {exc!r}")
+            else:
+                print(f"ok {name}")
+    if failures:
+        raise SystemExit(f"{failures} test(s) failed")
+    print("ALL TESTS PASSED")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Закрывает #1409.

## Что было не так

Стили ячеек ZCAD писал правильно — в `TABLECONTENT` у каждой ячейки был свой
`TABLECELL_BEGIN|90` (1 = `_TITLE`, 2 = `_HEADER`, 3 = `_DATA`). Но AutoCAD этот
объект **не читал вообще** и раскрашивал таблицу по встроенному правилу строк:
строка 0 — Title, строка 1 — Header, остальные — Data. Ровно то, что видел
@veb86 на `test3.txt`, `test4.txt` и `test5.txt`.

Причина: запись `ACAD_ROUNDTRIP_2008_TABLE_ENTITY` писалась **незавершённой**.
Во всех эталонах AutoCAD — и в присланном `test3acad.txt`, и в семи файлах
самого репозитория (`cad_source/test/tablebugheader.dxf`, `tablerazdel.dxf`,
`acadtablerazdel2007_*.dxf`, `bugbreaktable.dxf`) — XRECORD всегда заканчивается
жёсткой ссылкой `361` на объект `TABLEGEOMETRY`. ZCAD эту ссылку не писал и сам
объект не создавал, поэтому AutoCAD считал round-trip запись неполной и
отбрасывал её вместе с `TABLECONTENT` — а это единственное место, где может
храниться стиль отдельной ячейки: в устаревшей сущности `AcDbTable` его нет,
группа 172 там — это «cell flag value», а не стиль.

Кстати, тот же терминатор `361` уже пишет собственный код ZCAD для round-trip
разрыва таблицы (`WriteRoundTripRecordToDXF`) — это независимое подтверждение
роли группы 361.

## Воспроизведение

`experiments/issue1409_roundtrip_audit.py` сравнивает экспорт ZCAD с эталоном
AutoCAD по маркерам, от которых зависит чтение стилей:

```
$ python3 experiments/issue1409_roundtrip_audit.py test5.dxf test3acad.dxf

test5.dxf                                  <- экспорт ZCAD (до исправления)
  TABLEGEOMETRY objects : 0
  TABLEGEOMETRY class   : False
  xrecord tail          : 90|5  TRUNCATED - AutoCAD drops TABLECONTENT
  AcDbTable 90 (flags)  : 0
  cell 172 values       : ['0', '1', '2']
  row style ids         : ['1', '2', '2', '3', '3', '3']
  cell style ids        : ['1','1','1','2','2','2','2','2','2','3',...]

test3acad.dxf                              <- тот же файл, пересохранённый AutoCAD
  TABLEGEOMETRY objects : 1
  TABLEGEOMETRY class   : True
  xrecord tail          : 361|100000102  OK
  AcDbTable 90 (flags)  : 22
  cell 172 values       : ['0']
  row style ids         : ['1', '2', '2', '3', '3']
  cell style ids        : ['1','1','1','2','2','2','2','2','2','3',...]
```

Стили ячеек у ZCAD уже совпадали с эталоном — расходились ровно те четыре
маркера, которые чинит этот PR.

## Что исправлено

| Файл | Изменение |
|---|---|
| `uzeacadtable_dxf_write.pas` | round-trip XRECORD завершается ссылкой `361` на новый объект `TABLEGEOMETRY` |
| `uzeacadtable_dxf_write.pas` | пишется сам объект `AcDbTableGeometry` (кэш геометрии ячеек) и его запись в секции `CLASSES` |
| `uzeacadtable_dxf_write.pas` | группа 172 ячейки пишется как cell flag value (`0`), а не как тип стиля |
| `uzeacadtable_dxf_write.pas` | группа 90 сущности пишется набором битов AutoCAD (`22` = `0x02+0x04+0x10`) вместо `0` |
| `uzeffdxfout.pas` | словарь-расширение стиля таблицы получает флаг жёсткого владения `280\|1` |
| `uzeacadtable_layout.pas`, `uzeacadtable_dxf_read.pas` | подавление Title/Header читается из битов `0x20`/`0x40`, а не из `0x02`/`0x04` |

Кэш геометрии пишется «пустым» (`93 = 7`, `94 = 0` — «геометрия не
закэширована»): именно так AutoCAD записывает пустые ячейки в
`cad_source/test/tablerazdel.dxf`. Реальные значения зависят от метрик шрифта
AutoCAD, а сам кэш AutoCAD перестраивает при регенерации таблицы.

### Почему тронуты биты подавления

Флаг `22` содержит биты `0x02`/`0x04`. `BuildRenderSegments` трактовал их как
«Title/Header подавлены», хотя это биты «таблица связана с блоком» — подавление
лежит в `0x20`/`0x40`. Без этой правки таблица, сохранённая с флагами AutoCAD и
загруженная обратно, теряла бы зону повтора верхних строк-меток при разрыве
(#1309, #1375). То, что биты `0x02`/`0x04` не означают подавление, уже было
зафиксировано в комментарии к `GDBObjAcadTable.ComputeTopLabelRowCount`.

## Тесты

Новый `test_issue1409_tablegeometry_dxf.py` сначала воспроизводит проблему — на
коде до исправления падают 6 проверок из 11 — и закрепляет контракт, сверяя его
с эталонными файлами AutoCAD из репозитория:

* round-trip XRECORD завершается `361`, и указывает он на существующий `TABLEGEOMETRY`;
* объект `AcDbTableGeometry` пишется и принадлежит XRECORD;
* класс `TABLEGEOMETRY` объявлен в `CLASSES` (`1152 / 0 / 0`);
* группа 172 ячейки — cell flag value;
* группа 90 сущности — набор битов AutoCAD;
* словарь стиля таблицы — жёсткий владелец (`280|1`);
* подавление заголовков не читается из битов «has block».

`test_issue1409_acadtable_cell_styles.py` обновлён: он закреплял старое
поведение (тип стиля в группе 172), хотя его же комментарий признавал, что
AutoCAD это значение игнорирует.

Все остальные `test_*.py` в корне проходят. `test_issue1387_acadtable_geometry_types.py`
падает и до, и после этих изменений (не связано с PR).

> Компилятор в окружении недоступен (`fpc`/`lazbuild` не установлены, прав на
> установку нет), поэтому сборка локально не проверялась.



Fixes veb86/zcadvelecAI#1409