### PR TITLE
AcadTable: сохранять ссылки на текстовые стили ячеек в DXF (#1409)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-30T06:27:56.414Z for PR creation at branch issue-1409-9b88755b57a1 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-30T06:27:56.414Z for PR creation at branch issue-1409-9b88755b57a1 for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zengine/fileformats/uzeffdxfout.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfout.pas
@@ -211,7 +211,8 @@ procedure WriteCellStyleMapEntryToStream(
   var outstream: TZctnrVectorBytes;
   const CS: TGDBDXFTableCellStyle;
   const AStyleId, AStyleType, AFlags92: Integer;
-  const AStyleName: string);
+  const AStyleName: string;
+  const ATextStyleHandle: string);
 var
   GridBit: Integer;
 begin
@@ -236,9 +237,10 @@ begin
   dxfPairOut(outstream, 140, '1.0');
   dxfPairOut(outstream, 94, IntToStr(CS.Alignment));
   dxfPairOut(outstream, 62, IntToStr(CS.TextColor));
-  { 340 = хэндл текстового стиля. 0 означает «стиль по умолчанию таблицы»;
-    имя текстового стиля уже записано в самом TABLESTYLE (группа 7). }
-  dxfPairOut(outstream, 340, '0');
+  { 340 = хэндл текстового стиля. AutoCAD пишет реальную ссылку STYLE в
+    каждом CONTENTFORMAT карты; 0 оставляет определение CELLSTYLE неполным,
+    после чего индивидуальные стили ячеек игнорируются (issue #1409). }
+  dxfPairOut(outstream, 340, ATextStyleHandle);
   dxfPairOut(outstream, 144, DXFFloatStr(CS.TextHeight));
   dxfPairOut(outstream, 309, 'CONTENTFORMAT_END');
 
@@ -290,13 +292,26 @@ end;
 procedure WriteCellStyleMapObjectsToStream(
   var outstream: TZctnrVectorBytes;
   Style: PTGDBDXFTableStyle;
-  const StyleHandle, DictHandle, MapHandle: TDWGHandle);
+  const StyleHandle, DictHandle, MapHandle: TDWGHandle;
+  TextStyleNameHandleMap: TString2StringDictionary);
 var
   CS: array[0..2] of TGDBDXFTableCellStyle;
+  TextStyleHandles: array[0..2] of string;
   PCellStyle: PTGDBDXFTableCellStyle;
   CellIdx: Integer;
   Iter: itrec;
   DefaultAlignments: array[0..2] of Integer;
+
+  function ResolveTextStyleHandle(const StyleName: string): string;
+  begin
+    Result := '0';
+    if (StyleName <> '')
+       and TextStyleNameHandleMap.MyGetValue(StyleName, Result) then
+      Exit;
+    { Старые/неполные TABLESTYLE могут не содержать группу 7. В таком случае
+      используем реальный хэндл Standard, как делает AutoCAD. }
+    TextStyleNameHandleMap.MyGetValue('Standard', Result);
+  end;
 begin
   { Порядок блоков ячеек в TABLESTYLE: 0=data, 1=title, 2=header }
   DefaultAlignments[0] := 2;
@@ -307,6 +322,8 @@ begin
     FillChar(CS[CellIdx], SizeOf(CS[CellIdx]), 0);
     CS[CellIdx].TextHeight := 2.5;
     CS[CellIdx].Alignment := DefaultAlignments[CellIdx];
+    TextStyleHandles[CellIdx] :=
+      ResolveTextStyleHandle(Style^.CellTextStyleName[CellIdx]);
   end;
   CellIdx := 0;
   PCellStyle := Style^.CellFormats.beginiterate(Iter);
@@ -339,9 +356,12 @@ begin
   dxfPairOut(outstream, 330, inttohex(DictHandle, 0));
   dxfPairOut(outstream, 100, 'AcDbCellStyleMap');
   dxfPairOut(outstream, 90, '3');
-  WriteCellStyleMapEntryToStream(outstream, CS[1], 1, 1, 32768, '_TITLE');
-  WriteCellStyleMapEntryToStream(outstream, CS[2], 2, 1, 0, '_HEADER');
-  WriteCellStyleMapEntryToStream(outstream, CS[0], 3, 2, 0, '_DATA');
+  WriteCellStyleMapEntryToStream(
+    outstream, CS[1], 1, 1, 32768, '_TITLE', TextStyleHandles[1]);
+  WriteCellStyleMapEntryToStream(
+    outstream, CS[2], 2, 1, 0, '_HEADER', TextStyleHandles[2]);
+  WriteCellStyleMapEntryToStream(
+    outstream, CS[0], 3, 2, 0, '_DATA', TextStyleHandles[0]);
 end;
 
 { Записывает один объект TABLESTYLE в выходной поток DXF.
@@ -354,6 +374,7 @@ procedure WriteTableStyleObjectToStream(
   Style: PTGDBDXFTableStyle;
   const StyleHandle: TDWGHandle;
   const OwnerHandle: TDWGHandle;
+  TextStyleNameHandleMap: TString2StringDictionary;
   const DictHandle: TDWGHandle = 0;
   const MapHandle: TDWGHandle = 0);
 var
@@ -445,7 +466,7 @@ begin
     ячеек в TABLECONTENT (issue #1409). }
   if (DictHandle > 0) and (MapHandle > 0) then
     WriteCellStyleMapObjectsToStream(outstream, Style,
-      StyleHandle, DictHandle, MapHandle);
+      StyleHandle, DictHandle, MapHandle, TextStyleNameHandleMap);
 
   programlog.LogOutFormatStr(
     'uzeffdxfout: записан TABLESTYLE "%s" handle=%s',
@@ -1429,6 +1450,10 @@ begin
 
                   p:=pcurrtextstyle;
                   IODXFContext.p2h.MyGetOrCreateValue(p,IODXFContext.handle,temphandle);
+                  if not IODXFContext.TextStyleNameHandleMap.MyContans(
+                    pcurrtextstyle^.Name) then
+                    IODXFContext.TextStyleNameHandleMap.Add(
+                      pcurrtextstyle^.Name, inttohex(temphandle,0));
                   outstream.TXTAddStringEOL(inttohex(temphandle,0));
 
                   outstream.TXTAddStringEOL(dxfGroupCode(330));
@@ -1607,6 +1632,7 @@ begin
               while (ptablestyle<>nil) and (i<tsCount) do begin
                 WriteTableStyleObjectToStream(
                   outstream,ptablestyle,tsHandles[i],tablestyledicthandle,
+                  IODXFContext.TextStyleNameHandleMap,
                   tsDictHandles[i],tsMapHandles[i]);
                 Inc(writtenstylecount);
                 Inc(i);
@@ -1658,6 +1684,7 @@ begin
             while (ptablestyle<>nil) and (i<tsCount) do begin
               WriteTableStyleObjectToStream(
                 outstream,ptablestyle,tsHandles[i],tablestyledicthandle,
+                  IODXFContext.TextStyleNameHandleMap,
                   tsDictHandles[i],tsMapHandles[i]);
               Inc(writtenstylecount);
               Inc(i);
@@ -1681,6 +1708,7 @@ begin
             while (ptablestyle<>nil) and (i<tsCount) do begin
               WriteTableStyleObjectToStream(
                 outstream,ptablestyle,tsHandles[i],tablestyledicthandle,
+                  IODXFContext.TextStyleNameHandleMap,
                   tsDictHandles[i],tsMapHandles[i]);
               Inc(writtenstylecount);
               Inc(i);

--- a/cad_source/zengine/fileformats/uzeffdxfsupport.pas
+++ b/cad_source/zengine/fileformats/uzeffdxfsupport.pas
@@ -112,10 +112,13 @@ type
       сущности на актуальные новые хэндлы:
         AcadTableOwnerHandle  — новый хэндл владельца (*Model_Space) для 330;
         BlockNameHandleMap    — имя блока -> новый хэндл BLOCK_RECORD для 343;
-        TableStyleNameHandleMap — имя стиля таблицы -> новый хэндл для 342. }
+        TableStyleNameHandleMap — имя стиля таблицы -> новый хэндл для 342;
+        TextStyleNameHandleMap  — имя текстового стиля -> новый хэндл STYLE
+          для ссылок 340 внутри CELLSTYLEMAP. }
     AcadTableOwnerHandle:TDWGHandle;
     BlockNameHandleMap:TString2StringDictionary;
     TableStyleNameHandleMap:TString2StringDictionary;
+    TextStyleNameHandleMap:TString2StringDictionary;
 
     procedure InitRec;
     procedure Done;
@@ -405,6 +408,7 @@ begin
   AcadTableOwnerHandle:=0;
   BlockNameHandleMap:=TString2StringDictionary.create;
   TableStyleNameHandleMap:=TString2StringDictionary.create;
+  TextStyleNameHandleMap:=TString2StringDictionary.create;
 
   Header.InitRec;
 end;
@@ -414,6 +418,7 @@ begin
   VarsDict.Free;
   BlockNameHandleMap.Free;
   TableStyleNameHandleMap.Free;
+  TextStyleNameHandleMap.Free;
 end;
 
 procedure TIODXFLoadContext.InitRec;

--- a/experiments/issue1409_roundtrip_audit.py
+++ b/experiments/issue1409_roundtrip_audit.py
@@ -5,7 +5,7 @@ Usage::
 
     python3 experiments/issue1409_roundtrip_audit.py file.dxf [file.dxf ...]
 
-For every file it reports the four markers that decide whether AutoCAD keeps
+For every file it reports the five markers that decide whether AutoCAD keeps
 the per-cell styles of an ACAD_TABLE entity:
 
 * does the ``ACAD_ROUNDTRIP_2008_TABLE_ENTITY`` XRECORD end with the hard
@@ -14,6 +14,7 @@ the per-cell styles of an ACAD_TABLE entity:
   in the CLASSES section);
 * what the AcDbTable ``90`` flag word and the per-cell ``172`` flag value are;
 * which style id each row and each cell carries inside TABLECONTENT.
+* whether each CELLSTYLE content format points to a real exported text STYLE.
 
 Run it on a ZCAD export and on an AutoCAD-resaved copy of the same drawing to
 see the difference.  Reference files live in ``cad_source/test/``.
@@ -80,6 +81,41 @@ def report_styles(pairs):
     print(f"  cell style ids        : {cells}")
 
 
+def report_cellstyle_text_refs(pairs):
+    text_styles = {
+        next((value for code, value in record if code == "5"), None):
+        next((value for code, value in record if code == "2"), None)
+        for record in records(pairs, "STYLE")
+    }
+    text_styles.pop(None, None)
+
+    refs = []
+    for record in records(pairs, "CELLSTYLEMAP"):
+        for index, pair in enumerate(record):
+            if pair != ("1", "CONTENTFORMAT_BEGIN"):
+                continue
+            content_format = record[index + 1:]
+            end = next(
+                (offset for offset, item in enumerate(content_format)
+                 if item == ("309", "CONTENTFORMAT_END")),
+                len(content_format),
+            )
+            refs.append(next(
+                (value for code, value in content_format[:end]
+                 if code == "340"),
+                None,
+            ))
+
+    resolved = [
+        f"{handle}->{text_styles[handle]}"
+        if handle in text_styles else f"{handle}->UNRESOLVED"
+        for handle in refs
+    ]
+    status = "OK" if refs and all(handle in text_styles for handle in refs) \
+        else "INVALID - AutoCAD cannot resolve CELLSTYLE content formats"
+    print(f"  CELLSTYLE text refs   : {resolved}  {status}")
+
+
 def main(argv):
     if len(argv) < 2:
         print(__doc__)
@@ -91,6 +127,7 @@ def main(argv):
         report_roundtrip(pairs)
         report_entity(pairs)
         report_styles(pairs)
+        report_cellstyle_text_refs(pairs)
         print()
     return 0
 

--- a/test_issue1409_cellstylemap_dxf.py
+++ b/test_issue1409_cellstylemap_dxf.py
@@ -29,6 +29,9 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent
 DXFOUT = ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfout.pas"
+DXFSUPPORT = (
+    ROOT / "cad_source" / "zengine" / "fileformats" / "uzeffdxfsupport.pas"
+)
 WRITER = (
     ROOT
     / "cad_source"
@@ -65,9 +68,17 @@ def test_tablestyle_gets_extension_dictionary_and_cellstylemap():
     assert "'CELLSTYLEMAP'" in source
     assert "'AcDbCellStyleMap'" in source
     # The map declares exactly three cell styles.
-    assert "WriteCellStyleMapEntryToStream(outstream, CS[1], 1, 1, 32768, '_TITLE')" in source
-    assert "WriteCellStyleMapEntryToStream(outstream, CS[2], 2, 1, 0, '_HEADER')" in source
-    assert "WriteCellStyleMapEntryToStream(outstream, CS[0], 3, 2, 0, '_DATA')" in source
+    for style, style_id, style_type, flags, name, text_index in (
+        ("CS[1]", 1, 1, 32768, "_TITLE", 1),
+        ("CS[2]", 2, 1, 0, "_HEADER", 2),
+        ("CS[0]", 3, 2, 0, "_DATA", 0),
+    ):
+        assert re.search(
+            rf"WriteCellStyleMapEntryToStream\(\s*outstream, "
+            rf"{re.escape(style)}, {style_id}, {style_type}, {flags}, "
+            rf"'{name}', TextStyleHandles\[{text_index}\]\)",
+            source,
+        )
 
 
 def test_dictionary_and_map_handles_are_preallocated():
@@ -115,6 +126,47 @@ def test_reference_file_documents_three_cell_styles():
     for name in ("_TITLE", "_HEADER", "_DATA"):
         assert name in text
     assert re.search(r"^90 3$", text, re.M)
+
+
+def test_cellstyle_content_formats_reference_real_text_styles():
+    """CONTENTFORMAT/340 must resolve to an exported STYLE, never handle 0.
+
+    The latest failing file (test6) matches the AutoCAD reference map except
+    for these three references: ZCAD writes 340|0, whereas AutoCAD writes the
+    handle of the applicable text STYLE.  A zero reference leaves the
+    CELLSTYLE definitions incomplete, so AutoCAD falls back to row position.
+    """
+    reference = read(REFERENCE)
+    content_formats = re.findall(
+        r"^1 CONTENTFORMAT_BEGIN$\n(.*?)^309 CONTENTFORMAT_END$",
+        reference,
+        re.M | re.S,
+    )
+    assert len(content_formats) == 3
+    reference_handles = [
+        re.search(r"^340 ([0-9A-F]+)$", block, re.M).group(1)
+        for block in content_formats
+    ]
+    assert all(handle != "0" for handle in reference_handles)
+
+    support = read(DXFSUPPORT)
+    source = read(DXFOUT)
+    entry = source[source.index("procedure WriteCellStyleMapEntryToStream"):]
+    entry = entry[: entry.index("\nprocedure WriteCellStyleMapObjectsToStream")]
+
+    # STYLE records are emitted before OBJECTS/CELLSTYLEMAP, so remember
+    # their fresh handles by name in the save context and use the handle
+    # selected for each Title/Header/Data text style in CONTENTFORMAT/340.
+    assert "TextStyleNameHandleMap:TString2StringDictionary;" in support
+    assert "TextStyleNameHandleMap:=TString2StringDictionary.create;" in support
+    assert "TextStyleNameHandleMap.Free;" in support
+    assert "IODXFContext.TextStyleNameHandleMap.Add(" in source
+    assert "const ATextStyleHandle: string" in entry
+    assert "dxfPairOut(outstream, 340, ATextStyleHandle);" in entry
+    assert "TextStyleNameHandleMap.MyGetValue('Standard', Result);" in source
+    assert "dxfPairOut(outstream, 340, '0');" not in entry.split(
+        "dxfPairOut(outstream, 144", 1
+    )[0]
 
 
 def test_entity_writes_owner_and_table_style_references():


### PR DESCRIPTION
## Причина

В присланном `test6.txt` уже присутствуют корректные идентификаторы строк и
ячеек (`1 = Title`, `2 = Header`, `3 = Data`), а round-trip XRECORD корректно
ссылается на `TABLEGEOMETRY`. Однако все три определения `CELLSTYLE` внутри
`CELLSTYLEMAP` содержат неразрешимую ссылку `CONTENTFORMAT / 340 = 0`.

В файле, пересохранённом AutoCAD, и в эталонах репозитория эта группа всегда
ссылается на реально записанный объект `STYLE` (например,
`340 = 14 -> Standard`). Поэтому AutoCAD не мог полностью разрешить
определения `_TITLE`, `_HEADER` и `_DATA` из экспорта ZCAD и возвращался к
стилям по положению строки.

## Исправление

- контекст сохранения теперь запоминает новые хэндлы текстовых стилей по имени
  при записи таблицы `STYLE`;
- каждый `CELLSTYLE / CONTENTFORMAT` получает хэндл своего текстового стиля;
- для старых или неполных `TABLESTYLE` предусмотрен fallback на реальный
  хэндл `Standard`, а не на `0`;
- round-trip аудит дополнен проверкой разрешимости ссылок
  `CELLSTYLE / CONTENTFORMAT / 340`.

## Воспроизведение

1. Создать таблицу, где первая строка имеет стиль Title, строки 2–3 — Header,
   строки 4–5 — Data.
2. Сохранить DXF в ZCAD и открыть его в AutoCAD.
3. До исправления аудит `test6.txt` показывает:
   `0->UNRESOLVED` для всех трёх `CELLSTYLE`; AutoCAD применяет Title только
   к первой строке, Header ко второй, Data ко всем остальным.
4. Эталон AutoCAD показывает разрешённые ссылки вида `14->Standard`; теперь
   ZCAD формирует такие же ссылки на актуальные хэндлы экспортированных
   текстовых стилей.

## Проверки

- `python3 test_issue1409_acadtable_cell_styles.py`
- `python3 test_issue1409_acadtable_classes_dxf.py`
- `python3 test_issue1409_cellstylemap_dxf.py`
- `python3 test_issue1409_tablecontent_dxf.py`
- `python3 test_issue1409_tablegeometry_dxf.py`
- аудит `cad_source/test/acadtablerazdel2007_1.dxf` и
  `cad_source/test/tablebugheader.dxf`: все ссылки `CELLSTYLE` разрешены
- 31 из 32 корневых contract-тестов проходят; единственный сбой
  `test_issue1387_acadtable_geometry_types.py` воспроизводится без изменений
  на `upstream/master`

Нативная сборка не запускалась: в окружении отсутствуют `fpc` и `lazbuild`.

Fixes #1409
