### PR TITLE
AcadTable: материализовать формат ячейки при экспорте DXF (#1409)

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-30T10:32:57.099Z for PR creation at branch issue-1409-907f45e46ffe for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-30T10:32:57.099Z for PR creation at branch issue-1409-907f45e46ffe for issue https://github.com/veb86/zcadvelecAI/issues/1409

--- a/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
+++ b/cad_source/zcad/velec/acadtable/uzeacadtable_dxf_write.pas
@@ -1068,15 +1068,20 @@ begin
     IntToHex(ARecord.MainHandle, 0));
 end;
 
-// Нейтральный (без переопределений) блок CONTENTFORMAT: содержимое ячейки
-// полностью наследует свойства стиля ячейки.
-procedure WriteContentFormat(var AOutStream: TZctnrVectorBytes);
+// Блок CONTENTFORMAT. AutoCAD использует две разные пары type/flags:
+//   3/4   — формат непосредственно записанного содержимого ячейки;
+//   0/512 — наследуемый формат внутри CELLTABLEFORMAT.
+// Подмена первой пары второй делает TABLECONTENT внутренне противоречивым:
+// AutoCAD перестаёт применять индивидуальный стиль TABLECELL (issue #1409).
+procedure WriteContentFormat(
+  var AOutStream: TZctnrVectorBytes;
+  AContentType, AFlags: Integer);
 begin
   dxfStringWithoutEncodeOut(AOutStream, 300, 'CONTENTFORMAT');
   dxfStringWithoutEncodeOut(AOutStream, 1, 'CONTENTFORMAT_BEGIN');
-  dxfIntegerout(AOutStream, 90, 0);
+  dxfIntegerout(AOutStream, 90, AContentType);
   dxfIntegerout(AOutStream, 91, 0);
-  dxfIntegerout(AOutStream, 92, 512);
+  dxfIntegerout(AOutStream, 92, AFlags);
   dxfIntegerout(AOutStream, 93, 0);
   dxfStringWithoutEncodeOut(AOutStream, 300, '');
   dxfDoubleout(AOutStream, 40, 0);
@@ -1144,6 +1149,25 @@ begin
   dxfStringWithoutEncodeOut(AOutStream, 309, 'TABLEFORMAT_END');
 end;
 
+// Материализованный формат ячейки из файла, пересохранённого AutoCAD.
+// В отличие от пустого TABLEFORMAT с 170=0 этот блок активен (170=1) и
+// поэтому позволяет следующему TABLECELL_BEGIN/90 выбрать _TITLE, _HEADER
+// или _DATA. Остальные свойства наследуются из выбранного CELLSTYLE.
+procedure WriteCellTableFormat(var AOutStream: TZctnrVectorBytes);
+begin
+  dxfStringWithoutEncodeOut(AOutStream, 1, 'TABLEFORMAT_BEGIN');
+  dxfIntegerout(AOutStream, 90, 1);
+  dxfIntegerout(AOutStream, 170, 1);
+  dxfIntegerout(AOutStream, 91, 0);
+  dxfIntegerout(AOutStream, 92, 0);
+  dxfIntegerout(AOutStream, 62, 257);
+  dxfIntegerout(AOutStream, 93, 1);
+  WriteContentFormat(AOutStream, 0, 512);
+  dxfIntegerout(AOutStream, 171, 0);
+  dxfIntegerout(AOutStream, 94, 0);
+  dxfStringWithoutEncodeOut(AOutStream, 309, 'TABLEFORMAT_END');
+end;
+
 procedure WriteTableContentCell(
   var AOutStream: TZctnrVectorBytes;
   var AIODXFContext: TIODXFSaveContext;
@@ -1176,7 +1200,7 @@ begin
     dxfStringWithoutEncodeOut(AOutStream, 1,
       'FORMATTEDCELLCONTENT_BEGIN');
     dxfIntegerout(AOutStream, 170, 1);
-    WriteContentFormat(AOutStream);
+    WriteContentFormat(AOutStream, 3, 4);
     dxfStringWithoutEncodeOut(AOutStream, 309,
       'FORMATTEDCELLCONTENT_END');
   end
@@ -1187,7 +1211,7 @@ begin
   dxfStringWithoutEncodeOut(AOutStream, 1,
     'FORMATTEDTABLEDATACELL_BEGIN');
   dxfStringWithoutEncodeOut(AOutStream, 300, 'CELLTABLEFORMAT');
-  WriteEmptyTableFormat(AOutStream, 1);
+  WriteCellTableFormat(AOutStream);
   dxfStringWithoutEncodeOut(AOutStream, 309,
     'FORMATTEDTABLEDATACELL_END');
 

--- a/experiments/issue1409_tablecontent_compare.py
+++ b/experiments/issue1409_tablecontent_compare.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Compare the TABLECONTENT formatting blocks of AutoCAD table DXFs.
+
+Usage::
+
+    python3 experiments/issue1409_tablecontent_compare.py \
+        zcad-export.dxf autocad-resaved.dxf
+
+The regular issue #1409 audit checks the style identifiers and object
+references.  This companion experiment reports the TABLEFORMAT payload that
+activates those identifiers at cell and row level.  It is intentionally
+handle-agnostic so exports of the same table can be compared after AutoCAD
+renumbers the drawing.
+"""
+
+from collections import Counter
+from pathlib import Path
+import sys
+
+
+Pair = tuple[str, str]
+
+
+def dxf_pairs(path: Path) -> list[Pair]:
+    lines = [
+        line.strip()
+        for line in path.read_text(
+            encoding="utf-8", errors="replace"
+        ).splitlines()
+    ]
+    if len(lines) % 2:
+        raise ValueError(f"{path}: odd number of DXF lines")
+    return list(zip(lines[0::2], lines[1::2]))
+
+
+def records(pairs: list[Pair], record_type: str) -> list[list[Pair]]:
+    result: list[list[Pair]] = []
+    current: list[Pair] | None = None
+    for pair in pairs:
+        if pair[0] == "0":
+            if current and current[0] == ("0", record_type):
+                result.append(current)
+            current = [pair]
+        elif current is not None:
+            current.append(pair)
+    if current and current[0] == ("0", record_type):
+        result.append(current)
+    return result
+
+
+def marker_blocks(
+    record: list[Pair], begin_marker: str, end_marker: str
+) -> list[list[Pair]]:
+    result: list[list[Pair]] = []
+    start: int | None = None
+    for index, (_, value) in enumerate(record):
+        if value == begin_marker:
+            if start is not None:
+                raise ValueError(f"nested {begin_marker}")
+            start = index + 1
+        elif value == end_marker and start is not None:
+            result.append(record[start:index])
+            start = None
+    if start is not None:
+        raise ValueError(f"unterminated {begin_marker}")
+    return result
+
+
+def first_value(block: list[Pair], code: str, default: str = "-") -> str:
+    return next(
+        (value for item_code, value in block if item_code == code), default
+    )
+
+
+def compact(block: list[Pair]) -> str:
+    ignored_markers = {
+        "CELLTABLEFORMAT",
+        "ROWTABLEFORMAT",
+        "TABLEFORMAT_BEGIN",
+        "TABLEFORMAT_END",
+        "CONTENTFORMAT",
+        "CONTENTFORMAT_BEGIN",
+        "CONTENTFORMAT_END",
+        "MARGIN",
+        "CELLMARGIN_BEGIN",
+        "CELLMARGIN_END",
+        "GRIDFORMAT",
+        "GRIDFORMAT_BEGIN",
+        "GRIDFORMAT_END",
+    }
+    return " ".join(
+        f"{code}|{value or '<empty>'}"
+        for code, value in block
+        if value not in ignored_markers
+    )
+
+
+def summarize(path: Path) -> None:
+    pairs = dxf_pairs(path)
+    tablecontents = records(pairs, "TABLECONTENT")
+    if not tablecontents:
+        raise ValueError(f"{path}: no TABLECONTENT record")
+
+    print(path)
+    for record_index, record in enumerate(tablecontents, 1):
+        cell_formats = marker_blocks(
+            record,
+            "FORMATTEDTABLEDATACELL_BEGIN",
+            "FORMATTEDTABLEDATACELL_END",
+        )
+        table_cells = marker_blocks(record, "TABLECELL_BEGIN", "TABLECELL_END")
+        row_formats = marker_blocks(
+            record,
+            "FORMATTEDTABLEDATAROW_BEGIN",
+            "FORMATTEDTABLEDATAROW_END",
+        )
+        table_rows = marker_blocks(record, "TABLEROW_BEGIN", "TABLEROW_END")
+        content_formats = marker_blocks(
+            record,
+            "FORMATTEDCELLCONTENT_BEGIN",
+            "FORMATTEDCELLCONTENT_END",
+        )
+
+        if len(cell_formats) != len(table_cells):
+            raise ValueError(
+                f"{path}: {len(cell_formats)} cell formats but "
+                f"{len(table_cells)} TABLECELL blocks"
+            )
+        if len(row_formats) != len(table_rows):
+            raise ValueError(
+                f"{path}: {len(row_formats)} row formats but "
+                f"{len(table_rows)} TABLEROW blocks"
+            )
+
+        print(
+            f"  TABLECONTENT #{record_index}: "
+            f"{len(table_rows)} rows, {len(table_cells)} cells"
+        )
+        cell_signatures = Counter(compact(block) for block in cell_formats)
+        for count, signature in sorted(
+            (count, signature) for signature, count in cell_signatures.items()
+        ):
+            print(f"    cell format x{count}: {signature}")
+        print(
+            "    cell style ids: "
+            + " ".join(first_value(block, "90") for block in table_cells)
+        )
+        content_signatures = Counter(compact(block) for block in content_formats)
+        for count, signature in sorted(
+            (count, signature)
+            for signature, count in content_signatures.items()
+        ):
+            print(f"    content format x{count}: {signature}")
+
+        row_signatures = Counter(compact(block) for block in row_formats)
+        for count, signature in sorted(
+            (count, signature) for signature, count in row_signatures.items()
+        ):
+            print(f"    row format x{count}: {signature}")
+        print(
+            "    row style ids : "
+            + " ".join(first_value(block, "90") for block in table_rows)
+        )
+
+    for geometry_index, record in enumerate(
+        records(pairs, "TABLEGEOMETRY"), 1
+    ):
+        cache_counts = []
+        for index, pair in enumerate(record):
+            if pair[0] != "93":
+                continue
+            cache_counts.append(
+                next(
+                    (
+                        value
+                        for code, value in record[index + 1 :]
+                        if code == "94"
+                    ),
+                    "-",
+                )
+            )
+        print(
+            f"  TABLEGEOMETRY #{geometry_index} cache counts: "
+            + " ".join(cache_counts)
+        )
+    print()
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 1
+    for filename in argv[1:]:
+        summarize(Path(filename))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/test_issue1409_tablecontent_dxf.py
+++ b/test_issue1409_tablecontent_dxf.py
@@ -34,6 +34,11 @@ def read(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+def dxf_pairs(path: Path):
+    lines = [line.strip() for line in read(path).splitlines()]
+    return list(zip(lines[0::2], lines[1::2]))
+
+
 def emitted_pairs(source: str):
     """Group code / literal value pairs emitted by the writer, in order."""
     pattern = re.compile(
@@ -45,6 +50,12 @@ def emitted_pairs(source: str):
         (int(c), " ".join(v.split()).strip("'"))
         for c, v in pattern.findall(source)
     ]
+
+
+def procedure_source(source: str, name: str, next_name: str) -> str:
+    start = source.index(f"procedure {name}")
+    end = source.index(f"procedure {next_name}", start)
+    return source[start:end]
 
 
 def test_entity_references_extension_dictionary():
@@ -82,6 +93,41 @@ def test_each_cell_gets_its_own_style_id():
     assert "AcadCellStyleId(CellStyleTypeAt(APart, RowIdx, ColIdx));" in source
 
 
+def test_explicit_cell_style_uses_materialized_autocad_cell_format():
+    """The TABLEFORMAT containing a cell style id must be active.
+
+    AutoCAD's issue attachment ``test3acad.txt`` retains the requested
+    Title/Header/Data ids only when FORMATTEDTABLEDATACELL contains this
+    materialized payload.  ZCAD used to write only ``90=1, 170=0`` (an
+    inactive/inherited format) next to an explicit TABLECELL style id, so
+    AutoCAD discarded the id and fell back to row position.
+    """
+    source = read(WRITER)
+    formatter = procedure_source(
+        source, "WriteCellTableFormat", "WriteTableContentCell"
+    )
+    assert emitted_pairs(formatter) == [
+        (1, "TABLEFORMAT_BEGIN"),
+        (90, "1"),
+        (170, "1"),
+        (91, "0"),
+        (92, "0"),
+        (62, "257"),
+        (93, "1"),
+        (171, "0"),
+        (94, "0"),
+        (309, "TABLEFORMAT_END"),
+    ]
+    assert "WriteContentFormat(AOutStream, 0, 512);" in formatter
+
+    cell_writer = procedure_source(
+        source, "WriteTableContentCell", "WriteTableContentObject"
+    )
+    assert "WriteContentFormat(AOutStream, 3, 4);" in cell_writer
+    assert "WriteCellTableFormat(AOutStream);" in cell_writer
+    assert "WriteEmptyTableFormat(AOutStream, 1);" not in cell_writer
+
+
 def test_tablecontent_markers_are_balanced():
     source = read(WRITER)
     start = source.index("procedure WriteContentFormat")
@@ -99,8 +145,7 @@ def test_tablecontent_markers_are_balanced():
 
 def test_reference_autocad_file_uses_row_style_ids():
     """Evidence for the semantics asserted above, from a real AutoCAD file."""
-    lines = [line.strip() for line in read(REFERENCE_DXF).splitlines()]
-    pairs = [(lines[i], lines[i + 1]) for i in range(0, len(lines) - 1, 2)]
+    pairs = dxf_pairs(REFERENCE_DXF)
     styles = [
         int(pairs[i + 1][1])
         for i, (code, value) in enumerate(pairs)
@@ -110,10 +155,37 @@ def test_reference_autocad_file_uses_row_style_ids():
     assert styles == [1, 2, 2, 3, 3, 3], styles
 
 
+def test_reference_autocad_file_materializes_cell_formats():
+    """A checked-in AutoCAD file confirms the required active prefix."""
+    pairs = dxf_pairs(REFERENCE_DXF)
+    expected = [
+        ("1", "FORMATTEDTABLEDATACELL_BEGIN"),
+        ("300", "CELLTABLEFORMAT"),
+        ("1", "TABLEFORMAT_BEGIN"),
+        ("90", "1"),
+        ("170", "1"),
+        ("91", "0"),
+        ("92", "0"),
+        ("62", "257"),
+        ("93", "1"),
+        ("300", "CONTENTFORMAT"),
+        ("1", "CONTENTFORMAT_BEGIN"),
+        ("90", "0"),
+        ("91", "0"),
+        ("92", "512"),
+    ]
+    assert any(
+        pairs[index : index + len(expected)] == expected
+        for index in range(len(pairs) - len(expected) + 1)
+    )
+
+
 if __name__ == "__main__":
     test_entity_references_extension_dictionary()
     test_cell_style_id_mapping_is_title_header_data()
     test_each_cell_gets_its_own_style_id()
+    test_explicit_cell_style_uses_materialized_autocad_cell_format()
     test_tablecontent_markers_are_balanced()
     test_reference_autocad_file_uses_row_style_ids()
+    test_reference_autocad_file_materializes_cell_formats()
     print("ALL TESTS PASSED")


### PR DESCRIPTION
Fixes #1409.

## Причина

Последний приложенный к issue экспорт `test7.txt` уже содержит все исправления
предыдущих PR: `TABLECONTENT`, `CELLSTYLEMAP`, разрешимые ссылки на текстовый
стиль, `TABLEGEOMETRY`, корректный хвост XRECORD и индивидуальные идентификаторы
ячеек `1/2/3`. Тем не менее AutoCAD по-прежнему сбрасывает стили, которые не
совпадают со встроенным правилом положения строки.

Сравнение `test7.txt` с пересохранённым AutoCAD `test7acad.txt` и с правильным
эталоном `test3acad.txt` выявило оставшееся противоречие внутри `TABLECONTENT`:

| Блок | ZCAD до исправления | AutoCAD |
|---|---|---|
| `FORMATTEDTABLEDATACELL / TABLEFORMAT` | `90=1, 170=0` (формат не активен) | `90=1, 170=1, 91=0, 92=0, 62=257, 93=1, ...` |
| `FORMATTEDCELLCONTENT / CONTENTFORMAT` | `90=0, 92=512` | `90=3, 92=4` |
| `TABLECELL_BEGIN / 90` | корректные `1/2/3` | корректные `1/2/3` |

То есть ZCAD записывал явный идентификатор стиля рядом с пустым наследуемым
форматом ячейки (`170=0`). При открытии AutoCAD не применял такой идентификатор:
в `test7acad.txt` сохранились только позиционные Title/Header, а остальные
идентификаторы были сброшены в `0`.

## Исправление

- для каждой ячейки пишется материализованный `CELLTABLEFORMAT` с `170=1` и
  обязательным payload, совпадающим с правильным файлом AutoCAD;
- `CONTENTFORMAT` параметризован: содержимое ячейки получает AutoCAD-пару
  `3/4`, а вложенный наследуемый формат сохраняет пару `0/512`;
- форматы строк, столбцов и таблицы остаются наследуемыми — изменение ограничено
  тем уровнем, где записывается индивидуальный `TABLECELL` style id;
- добавлен эксперимент
  `experiments/issue1409_tablecontent_compare.py`, который сравнивает эти блоки
  DXF без привязки к перенумерованным хэндлам.

## Воспроизведение и регрессионный тест

1. Создать таблицу: строка 1 — Title, строки 2–3 — Header, строки 4–5 — Data.
2. Экспортировать её из ZCAD и открыть в AutoCAD.
3. До исправления AutoCAD показывал Header только у строки 2 и применял Data ко
   всем последующим строкам.
4. Новый тест сначала падал, потому что writer использовал
   `WriteEmptyTableFormat(..., 1)` и не умел формировать активный формат ячейки.
5. Теперь тест проверяет полный обязательный payload, разные пары
   `CONTENTFORMAT`, отсутствие старого пустого формата и подтверждает структуру
   по сохранённому в репозитории файлу AutoCAD `tablebugheader.dxf`.

Проверки:

- все 5 `test_issue1409_*.py` проходят;
- 33 применимых корневых contract-теста проходят;
- `python3 -m py_compile` для изменённого теста и нового эксперимента проходит;
- `git diff --check` проходит.

Единственный сбой полного набора —
`test_issue1387_acadtable_geometry_types.py`; он воспроизводится на неизменённых
файлах `upstream/master` и не связан с этим PR. Нативная сборка не запускалась:
в окружении отсутствуют `fpc` и `lazbuild`.
